### PR TITLE
Quick notes, editor toolbar + images, meeting detection, Settings redesign, icon set

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,7 @@
     "@azure/msal-node": "^5.3.1",
     "@electron-toolkit/utils": "^4.0.0",
     "@repo/ai": "workspace:*",
+    "@tiptap/extension-image": "^3.27.2",
     "node-llama-cpp": "^3.19.0"
   },
   "devDependencies": {

--- a/apps/desktop/src/main/calendar-service.ts
+++ b/apps/desktop/src/main/calendar-service.ts
@@ -47,6 +47,7 @@ import {
   upcomingTrayEvents
 } from './calendar-events'
 import { eventsToPromptNow, pruneNotified } from './calendar-watcher'
+import type { PromptPanel } from './prompt-panel'
 
 /** Delegated Graph permissions; offline_access keeps the refresh token. */
 const SCOPES = ['User.Read', 'Calendars.Read', 'offline_access']
@@ -177,7 +178,9 @@ export class CalendarService {
     userDataDir: string,
     private readonly broadcast: CalendarBroadcast,
     /** Bring the app forward (or recreate the window) on notification click. */
-    private readonly focusWindow: () => void
+    private readonly focusWindow: () => void,
+    /** Floating always-on-top card for when the main window can't be seen. */
+    private readonly promptPanel?: PromptPanel
   ) {
     this.settingsPath = join(userDataDir, 'calendar-settings.json')
     this.tokenCachePath = join(userDataDir, 'calendar-token-cache')
@@ -714,47 +717,68 @@ export class CalendarService {
     for (const watchable of due) {
       this.notified[watchable.id] = new Date(nowMs).toISOString()
       const event = shown.find((e) => e.id === watchable.id)
-      const payload: CalendarStartMeetingEvent = {
+      this.deliverPrompt({
         action: 'prompt',
         eventId: watchable.id,
         subject: (event?.subject ?? '').trim() || 'Untitled meeting',
         startIso: watchable.startIso
-      }
-      // The banner broadcast is the guaranteed path; the OS notification and
-      // dock bounce are best-effort attention-getters on top.
-      this.broadcast(CALENDAR_START_MEETING_CHANNEL, payload)
-      this.showNotification(payload)
-      try {
-        app.dock?.bounce('informational')
-      } catch {
-        // Not on macOS, or no dock — the banner already covers it.
-      }
+      })
     }
     this.saveNotified()
+  }
+
+  /**
+   * Fan a "meeting is starting" prompt out to every attention channel: the
+   * in-app banner (guaranteed when the window is visible), the OS
+   * notification and dock bounce (best-effort), and — when the main window
+   * is closed or buried — the floating prompt panel. Also the entry point
+   * for ad-hoc mic-detected prompts (MicWatcher).
+   */
+  deliverPrompt(payload: CalendarStartMeetingEvent): void {
+    this.broadcast(CALENDAR_START_MEETING_CHANNEL, payload)
+    this.showNotification(payload)
+    try {
+      app.dock?.bounce('informational')
+    } catch {
+      // Not on macOS, or no dock — the banner already covers it.
+    }
+    const window = BrowserWindow.getAllWindows()[0]
+    const bannerVisible = window !== undefined && window.isVisible() && window.isFocused()
+    if (!bannerVisible) {
+      this.promptPanel?.show(payload, (action) => {
+        if (action === 'start') this.actOnPromptStart(payload)
+      })
+    }
+  }
+
+  /** One click anywhere = meeting created + recording (renderer handles it). */
+  private actOnPromptStart(prompt: CalendarStartMeetingEvent): void {
+    const payload = { ...prompt, action: 'start' as const }
+    const hadWindow = BrowserWindow.getAllWindows().length > 0
+    this.focusWindow()
+    if (hadWindow) {
+      this.broadcast(CALENDAR_START_MEETING_CHANNEL, payload)
+    } else {
+      // focusWindow just created the window — wait for the renderer to
+      // load (plus a beat for React to attach listeners) before sending.
+      const window = BrowserWindow.getAllWindows()[0]
+      window?.webContents.once('did-finish-load', () => {
+        setTimeout(() => this.broadcast(CALENDAR_START_MEETING_CHANNEL, payload), 400)
+      })
+    }
   }
 
   private showNotification(prompt: CalendarStartMeetingEvent): void {
     try {
       if (!Notification.isSupported()) return
       const notification = new Notification({
-        title: `${prompt.subject} is starting`,
+        title: prompt.adHoc
+          ? 'Looks like you’re in a meeting'
+          : `${prompt.subject} is starting`,
         body: 'Click to start taking notes'
       })
       notification.on('click', () => {
-        const payload = { ...prompt, action: 'start' as const }
-        const hadWindow = BrowserWindow.getAllWindows().length > 0
-        this.focusWindow()
-        if (hadWindow) {
-          // One click = meeting created + recording, handled by the renderer.
-          this.broadcast(CALENDAR_START_MEETING_CHANNEL, payload)
-        } else {
-          // focusWindow just created the window — wait for the renderer to
-          // load (plus a beat for React to attach listeners) before sending.
-          const window = BrowserWindow.getAllWindows()[0]
-          window?.webContents.once('did-finish-load', () => {
-            setTimeout(() => this.broadcast(CALENDAR_START_MEETING_CHANNEL, payload), 400)
-          })
-        }
+        this.actOnPromptStart(prompt)
       })
       notification.show()
     } catch (err) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, ipcMain } from 'electron'
+import { app, shell, BrowserWindow, ipcMain, protocol } from 'electron'
 import { spawn } from 'node:child_process'
 import { appendFileSync, cpSync, existsSync, statSync, writeFileSync } from 'node:fs'
 import path, { join } from 'node:path'
@@ -7,6 +7,7 @@ import icon from '../../resources/icon.png?asset'
 import { CalendarService } from './calendar-service'
 import { EngineProcess } from './engine-process'
 import { FoldersService } from './folders-service'
+import { MediaService } from './media-service'
 import { MeetingsService } from './meetings-service'
 import { NotesService } from './notes-service'
 import { SyncService } from './sync-service'
@@ -54,6 +55,12 @@ function migrateDevUserData(): void {
     console.error('[migrate] failed (continuing with fresh data):', err)
   }
 }
+
+// Must run before app ready: lets <img src="doodle-media://…"> load without
+// mixed-content blocking (the dev renderer is served over http).
+protocol.registerSchemesAsPrivileged([
+  { scheme: 'doodle-media', privileges: { secure: true, supportFetchAPI: true } }
+])
 
 const engine = new EngineProcess(resolveEngineBinary())
 let notesService: NotesService | null = null
@@ -199,6 +206,11 @@ app.whenReady().then(() => {
   const syncService = new SyncService(app.getPath('userData'), meetingsService, broadcast)
   syncService.registerIpc()
   meetingsService.onDidWrite = (change) => syncService.onMeetingsChanged(change.deletedId)
+
+  // Image attachments for the notes editor (doodle-media:// protocol).
+  const mediaService = new MediaService(join(app.getPath('userData'), 'attachments'))
+  mediaService.registerIpc()
+  mediaService.registerProtocol()
 
   // A fresh look at the app deserves fresh events (throttled inside).
   app.on('browser-window-focus', () => calendarService?.onWindowFocus())

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -9,8 +9,16 @@ import { EngineProcess } from './engine-process'
 import { FoldersService } from './folders-service'
 import { MediaService } from './media-service'
 import { MeetingsService } from './meetings-service'
+import { MicWatcher } from './mic-watcher'
 import { NotesService } from './notes-service'
+import { PromptPanel } from './prompt-panel'
 import { SyncService } from './sync-service'
+import {
+  DETECT_GET_STATE_CHANNEL,
+  DETECT_SET_PREFS_CHANNEL,
+  type DetectPrefsUpdate,
+  type DetectState
+} from '../shared/detect-api'
 import { TranscriptSession } from './transcript-session'
 import {
   ENGINE_EVENT_CHANNEL,
@@ -143,6 +151,18 @@ app.whenReady().then(() => {
     optimizer.watchWindowShortcuts(window)
   })
 
+  // Ad-hoc meeting detection: engine micmon watches for other apps holding
+  // the mic open (Zoom/Teams/Meet) and prompts even without a calendar event.
+  const micWatcher = new MicWatcher(resolveEngineBinary(), app.getPath('userData'), () => {
+    calendarService?.deliverPrompt({
+      action: 'prompt',
+      eventId: '',
+      subject: 'Meeting',
+      startIso: new Date().toISOString(),
+      adHoc: true
+    })
+  })
+
   const session = new TranscriptSession(
     broadcastEngineEvent,
     join(app.getPath('userData'), 'sessions')
@@ -177,11 +197,15 @@ app.whenReady().then(() => {
   })
 
   ipcMain.on(ENGINE_START_CHANNEL, (_event, request: EngineStartRequest) => {
+    // Our own capture holds the mic — the ad-hoc meeting detector must not
+    // mistake it for a Zoom call. Suppress BEFORE the engine opens the mic.
+    micWatcher.setSuppressed(true)
     engine.start(request.command, request.filePath, request.opts)
   })
 
   ipcMain.on(ENGINE_STOP_CHANNEL, () => {
     engine.stop()
+    micWatcher.setSuppressed(false)
   })
 
   // Meetings store first: NotesService reads it to gather cross-meeting
@@ -199,8 +223,38 @@ app.whenReady().then(() => {
   foldersService.registerIpc()
 
   // Microsoft 365 calendar: auth + Graph polling + the meeting-start watcher.
-  calendarService = new CalendarService(app.getPath('userData'), broadcast, focusMainWindow)
+  // The floating panel catches prompts when the main window can't be seen.
+  calendarService = new CalendarService(
+    app.getPath('userData'),
+    broadcast,
+    focusMainWindow,
+    new PromptPanel()
+  )
   calendarService.registerIpc()
+
+  // Meeting-detection settings: login item (OS-owned) + the mic watcher.
+  ipcMain.handle(DETECT_GET_STATE_CHANNEL, (): DetectState => {
+    return {
+      loginItem: app.getLoginItemSettings().openAtLogin,
+      micDetect: micWatcher.enabled,
+      micMonitorAlive: micWatcher.monitorAlive
+    }
+  })
+  ipcMain.handle(DETECT_SET_PREFS_CHANNEL, (_event, update: DetectPrefsUpdate): DetectState => {
+    if (typeof update?.loginItem === 'boolean') {
+      app.setLoginItemSettings({ openAtLogin: update.loginItem })
+    }
+    if (typeof update?.micDetect === 'boolean') {
+      micWatcher.setEnabled(update.micDetect)
+    }
+    return {
+      loginItem: app.getLoginItemSettings().openAtLogin,
+      micDetect: micWatcher.enabled,
+      micMonitorAlive: micWatcher.monitorAlive
+    }
+  })
+  micWatcher.start()
+  app.on('quit', () => micWatcher.stop())
 
   // Cloud sync: opt-in one-way push of meetings/notes to the web dashboard.
   const syncService = new SyncService(app.getPath('userData'), meetingsService, broadcast)

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -153,11 +153,12 @@ app.whenReady().then(() => {
 
   // Ad-hoc meeting detection: engine micmon watches for other apps holding
   // the mic open (Zoom/Teams/Meet) and prompts even without a calendar event.
-  const micWatcher = new MicWatcher(resolveEngineBinary(), app.getPath('userData'), () => {
+  const micWatcher = new MicWatcher(resolveEngineBinary(), app.getPath('userData'), (appLabel) => {
     calendarService?.deliverPrompt({
       action: 'prompt',
       eventId: '',
-      subject: 'Meeting',
+      // Pre-title from the detected app ("Zoom meeting"); generic otherwise.
+      subject: appLabel && appLabel !== 'browser' ? `${appLabel} meeting` : 'Meeting',
       startIso: new Date().toISOString(),
       adHoc: true
     })

--- a/apps/desktop/src/main/media-service.ts
+++ b/apps/desktop/src/main/media-service.ts
@@ -1,0 +1,64 @@
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { ipcMain, net, protocol } from 'electron'
+import {
+  MEDIA_ACCEPTED_MIME,
+  MEDIA_SAVE_CHANNEL,
+  type MediaSaveRequest,
+  type MediaSaveResult
+} from '../shared/media-api'
+
+/** Images pasted into notes; generous but bounded. */
+const MAX_BYTES = 15 * 1024 * 1024
+
+/** Served names are uuid.ext only — the protocol handler enforces this. */
+const SAFE_NAME = /^[a-z0-9-]+\.[a-z0-9]+$/
+
+/**
+ * Local image attachments for the notes editor. Files live in
+ * userData/attachments and are served to the renderer over the
+ * doodle-media:// protocol (works in dev where the renderer is http and
+ * file:// would be blocked, and in the packaged app alike).
+ */
+export class MediaService {
+  constructor(private readonly dir: string) {}
+
+  registerIpc(): void {
+    ipcMain.handle(MEDIA_SAVE_CHANNEL, (_event, request: unknown) =>
+      this.save(request as Partial<MediaSaveRequest>)
+    )
+  }
+
+  /** Call after app ready (protocol.handle requires it). */
+  registerProtocol(): void {
+    protocol.handle('doodle-media', (request) => {
+      // doodle-media://<uuid>.<ext> — the name parses as the URL host.
+      const name = new URL(request.url).host
+      if (!SAFE_NAME.test(name)) return new Response('bad name', { status: 400 })
+      return net.fetch(pathToFileURL(join(this.dir, name)).toString())
+    })
+  }
+
+  private save(request: Partial<MediaSaveRequest>): MediaSaveResult {
+    const mime = typeof request.mime === 'string' ? request.mime : ''
+    const ext = MEDIA_ACCEPTED_MIME[mime]
+    if (!ext) return { error: `Unsupported image type: ${mime || 'unknown'}` }
+    const bytes = request.bytes
+    if (!(bytes instanceof ArrayBuffer) || bytes.byteLength === 0) {
+      return { error: 'Empty image' }
+    }
+    if (bytes.byteLength > MAX_BYTES) {
+      return { error: 'Image is too large (15 MB max)' }
+    }
+    try {
+      mkdirSync(this.dir, { recursive: true })
+      const name = `${randomUUID()}.${ext}`
+      writeFileSync(join(this.dir, name), Buffer.from(bytes))
+      return { url: `doodle-media://${name}` }
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : 'Could not save image' }
+    }
+  }
+}

--- a/apps/desktop/src/main/meetings-service.ts
+++ b/apps/desktop/src/main/meetings-service.ts
@@ -49,6 +49,7 @@ export class MeetingsService {
       if (!record) continue
       summaries.push({
         id: record.id,
+        ...(record.kind === 'note' ? { kind: 'note' as const } : {}),
         title: record.title,
         createdAt: record.createdAt,
         ...(record.startedAt ? { startedAt: record.startedAt } : {}),
@@ -128,6 +129,8 @@ export class MeetingsService {
 function normalizeRecord(raw: MeetingUpsert): MeetingRecord {
   return {
     id: raw.id,
+    // Only "note" is stored; anything else normalizes to the meeting default.
+    ...(raw.kind === 'note' ? { kind: 'note' as const } : {}),
     title: typeof raw.title === 'string' ? raw.title : '',
     createdAt: typeof raw.createdAt === 'string' ? raw.createdAt : new Date().toISOString(),
     ...(typeof raw.startedAt === 'string' ? { startedAt: raw.startedAt } : {}),

--- a/apps/desktop/src/main/mic-watcher-logic.test.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  initialMicState,
+  markPrompted,
+  MIC_COOLDOWN_MS,
+  MIC_DEBOUNCE_MS,
+  onMicEvent,
+  setSuppressed,
+  shouldPrompt
+} from './mic-watcher-logic'
+
+const T0 = 1_000_000
+
+describe('mic-watcher-logic', () => {
+  it('prompts only after the debounce window', () => {
+    let s = onMicEvent(initialMicState(), true, T0)
+    assert.equal(shouldPrompt(s, T0 + MIC_DEBOUNCE_MS - 1), false)
+    assert.equal(shouldPrompt(s, T0 + MIC_DEBOUNCE_MS), true)
+  })
+
+  it('keeps the original busy start across repeated running=true events', () => {
+    let s = onMicEvent(initialMicState(), true, T0)
+    s = onMicEvent(s, true, T0 + 5_000)
+    assert.equal(shouldPrompt(s, T0 + MIC_DEBOUNCE_MS), true)
+  })
+
+  it('never prompts twice for one continuous busy stretch', () => {
+    let s = onMicEvent(initialMicState(), true, T0)
+    s = markPrompted(s, T0 + MIC_DEBOUNCE_MS)
+    assert.equal(shouldPrompt(s, T0 + MIC_DEBOUNCE_MS + 60_000), false)
+  })
+
+  it('idle resets the session but cooldown still applies', () => {
+    let s = onMicEvent(initialMicState(), true, T0)
+    s = markPrompted(s, T0 + MIC_DEBOUNCE_MS)
+    s = onMicEvent(s, false, T0 + 60_000) // hang up
+    s = onMicEvent(s, true, T0 + 70_000) // new call right away
+    assert.equal(shouldPrompt(s, T0 + 70_000 + MIC_DEBOUNCE_MS), false) // inside cooldown
+    const afterCooldown = T0 + MIC_DEBOUNCE_MS + MIC_COOLDOWN_MS
+    s = onMicEvent(s, false, afterCooldown - 20_000)
+    s = onMicEvent(s, true, afterCooldown - 10_000)
+    assert.equal(shouldPrompt(s, afterCooldown + 1), true)
+  })
+
+  it('short blips (Siri, dictation) never fire', () => {
+    let s = onMicEvent(initialMicState(), true, T0)
+    s = onMicEvent(s, false, T0 + 3_000)
+    assert.equal(shouldPrompt(s, T0 + MIC_DEBOUNCE_MS), false)
+  })
+
+  it('suppression swallows events and requires a fresh edge after lifting', () => {
+    let s = setSuppressed(initialMicState(), true)
+    s = onMicEvent(s, true, T0) // our own capture holding the mic
+    assert.equal(shouldPrompt(s, T0 + MIC_DEBOUNCE_MS), false)
+    // Capture ends but the meeting app STILL holds the mic — no busy edge yet.
+    s = setSuppressed(s, false)
+    assert.equal(shouldPrompt(s, T0 + 2 * MIC_DEBOUNCE_MS), false)
+    // Fresh idle→busy edge after unsuppression is trusted again.
+    s = onMicEvent(s, true, T0 + 60_000)
+    assert.equal(shouldPrompt(s, T0 + 60_000 + MIC_DEBOUNCE_MS), true)
+  })
+})

--- a/apps/desktop/src/main/mic-watcher-logic.test.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test'
 import {
   initialMicState,
   markPrompted,
+  meetingAppLabel,
   MIC_COOLDOWN_MS,
   MIC_DEBOUNCE_MS,
   onMicEvent,
@@ -47,6 +48,19 @@ describe('mic-watcher-logic', () => {
     let s = onMicEvent(initialMicState(), true, T0)
     s = onMicEvent(s, false, T0 + 3_000)
     assert.equal(shouldPrompt(s, T0 + MIC_DEBOUNCE_MS), false)
+  })
+
+  it('recognizes meeting apps by bundle id, ignores everything else', () => {
+    assert.equal(meetingAppLabel(['us.zoom.xos']), 'Zoom')
+    assert.equal(meetingAppLabel(['com.microsoft.teams2']), 'Teams')
+    assert.equal(meetingAppLabel(['com.google.Chrome.helper']), 'browser')
+    // Dictation tools hold the mic all day — never a meeting.
+    assert.equal(meetingAppLabel(['com.fluidvoice.app']), null)
+    assert.equal(meetingAppLabel(['com.apple.VoiceMemos']), null)
+    // No attribution (macOS < 14.4) stays conservative.
+    assert.equal(meetingAppLabel([]), null)
+    // A meeting app among others still wins.
+    assert.equal(meetingAppLabel(['com.fluidvoice.app', 'us.zoom.xos']), 'Zoom')
   })
 
   it('suppression swallows events and requires a fresh edge after lifting', () => {

--- a/apps/desktop/src/main/mic-watcher-logic.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.ts
@@ -9,6 +9,42 @@ export const MIC_DEBOUNCE_MS = 8_000
 /** After a prompt (or a dismissal), stay quiet this long. */
 export const MIC_COOLDOWN_MS = 5 * 60_000
 
+/**
+ * Only mic capture by an actual meeting app counts — dictation tools
+ * (FluidVoice et al.), voice memos, and everything else are ignored by
+ * bundle id. Browsers are included for Meet/Teams-web. Substring match,
+ * lowercase.
+ */
+const MEETING_BUNDLE_PATTERNS: ReadonlyArray<{ pattern: string; label: string }> = [
+  { pattern: 'us.zoom', label: 'Zoom' },
+  { pattern: 'com.microsoft.teams', label: 'Teams' },
+  { pattern: 'cisco', label: 'Webex' }, // Cisco-Systems.Spark
+  { pattern: 'com.tinyspeck.slackmacgap', label: 'Slack' },
+  { pattern: 'com.hnc.discord', label: 'Discord' },
+  { pattern: 'com.apple.facetime', label: 'FaceTime' },
+  { pattern: 'com.skype', label: 'Skype' },
+  { pattern: 'com.google.chrome', label: 'browser' },
+  { pattern: 'com.apple.safari', label: 'browser' },
+  { pattern: 'org.mozilla.firefox', label: 'browser' },
+  { pattern: 'com.microsoft.edgemac', label: 'browser' },
+  { pattern: 'company.thebrowser', label: 'browser' }, // Arc
+  { pattern: 'com.brave.browser', label: 'browser' }
+]
+
+/**
+ * The friendly name of the first meeting app among the capturing bundles,
+ * or null when none of them is meeting-shaped. Empty bundle info (macOS
+ * < 14.4 or attribution failure) is conservative: no prompt.
+ */
+export function meetingAppLabel(bundles: readonly string[]): string | null {
+  for (const bundle of bundles) {
+    const lower = bundle.toLowerCase()
+    const match = MEETING_BUNDLE_PATTERNS.find((m) => lower.includes(m.pattern))
+    if (match) return match.label
+  }
+  return null
+}
+
 export interface MicPromptState {
   /** Epoch ms when the mic went busy; null while idle. */
   busySinceMs: number | null

--- a/apps/desktop/src/main/mic-watcher-logic.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure "should the mic activity prompt fire?" logic, Electron-free so it can
+ * be unit-tested with node:test (see mic-watcher-logic.test.ts). MicWatcher
+ * feeds it micmon events and asks when the debounce timer lands.
+ */
+
+/** The mic must be held open this long before we call it a meeting. */
+export const MIC_DEBOUNCE_MS = 8_000
+/** After a prompt (or a dismissal), stay quiet this long. */
+export const MIC_COOLDOWN_MS = 5 * 60_000
+
+export interface MicPromptState {
+  /** Epoch ms when the mic went busy; null while idle. */
+  busySinceMs: number | null
+  /** We already prompted for this continuous busy stretch. */
+  promptedThisSession: boolean
+  /** Epoch ms of the last prompt, for the cooldown. */
+  lastPromptMs: number
+  /** Our own capture is running — everything is ignored until it isn't. */
+  suppressed: boolean
+}
+
+export function initialMicState(): MicPromptState {
+  return { busySinceMs: null, promptedThisSession: false, lastPromptMs: 0, suppressed: false }
+}
+
+/** Apply a micmon running=true/false transition. */
+export function onMicEvent(state: MicPromptState, running: boolean, nowMs: number): MicPromptState {
+  if (state.suppressed) return state
+  if (running) {
+    // Already tracking this busy stretch — keep its original start.
+    if (state.busySinceMs !== null) return state
+    return { ...state, busySinceMs: nowMs }
+  }
+  // Idle again: the next busy stretch may prompt anew (cooldown permitting).
+  return { ...state, busySinceMs: null, promptedThisSession: false }
+}
+
+/**
+ * While our own engine captures, the mic is busy because of US — ignore it,
+ * and when suppression lifts, require a fresh idle→busy edge before promoting
+ * any activity to a prompt (the meeting app's mic use may simply continue).
+ */
+export function setSuppressed(state: MicPromptState, suppressed: boolean): MicPromptState {
+  if (suppressed) return { ...state, suppressed: true, busySinceMs: null }
+  return { ...state, suppressed: false, busySinceMs: null, promptedThisSession: false }
+}
+
+/** True when the debounced busy stretch should fire the prompt at nowMs. */
+export function shouldPrompt(state: MicPromptState, nowMs: number): boolean {
+  if (state.suppressed || state.promptedThisSession) return false
+  if (state.busySinceMs === null) return false
+  if (nowMs - state.busySinceMs < MIC_DEBOUNCE_MS) return false
+  return nowMs - state.lastPromptMs >= MIC_COOLDOWN_MS
+}
+
+/** Record that the prompt fired. */
+export function markPrompted(state: MicPromptState, nowMs: number): MicPromptState {
+  return { ...state, promptedThisSession: true, lastPromptMs: nowMs }
+}

--- a/apps/desktop/src/main/mic-watcher.ts
+++ b/apps/desktop/src/main/mic-watcher.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import {
   initialMicState,
   markPrompted,
+  meetingAppLabel,
   MIC_DEBOUNCE_MS,
   onMicEvent,
   setSuppressed,
@@ -34,10 +35,13 @@ export class MicWatcher {
   private restartTimer: NodeJS.Timeout | null = null
   private stopping = false
 
+  /** Friendly name of the meeting app behind the current busy stretch. */
+  private currentAppLabel: string | null = null
+
   constructor(
     private readonly enginePath: string,
     userDataDir: string,
-    private readonly onMeetingDetected: () => void
+    private readonly onMeetingDetected: (appLabel: string | null) => void
   ) {
     this.configPath = join(userDataDir, 'mic-watch.json')
     this.config = this.readConfig()
@@ -103,9 +107,18 @@ export class MicWatcher {
         newline = buffer.indexOf('\n')
         if (line.length === 0) continue
         try {
-          const event = JSON.parse(line) as { event?: string; running?: boolean }
+          const event = JSON.parse(line) as {
+            event?: string
+            running?: boolean
+            bundles?: string[]
+          }
           if (event.event === 'micmon' && typeof event.running === 'boolean') {
-            this.handleMicEvent(event.running)
+            // Only capture by an actual meeting app counts as "busy" —
+            // dictation tools like FluidVoice must never prompt.
+            const bundles = Array.isArray(event.bundles) ? event.bundles.map(String) : []
+            const label = event.running ? meetingAppLabel(bundles) : null
+            this.currentAppLabel = label
+            this.handleMicEvent(event.running && label !== null)
           }
         } catch {
           // CoreML/CoreAudio noise on stdout — NDJSON hosts skip unparseable lines.
@@ -159,7 +172,7 @@ export class MicWatcher {
         const now = Date.now()
         if (shouldPrompt(this.state, now)) {
           this.state = markPrompted(this.state, now)
-          this.onMeetingDetected()
+          this.onMeetingDetected(this.currentAppLabel)
         }
       }, MIC_DEBOUNCE_MS)
       this.debounceTimer.unref?.()

--- a/apps/desktop/src/main/mic-watcher.ts
+++ b/apps/desktop/src/main/mic-watcher.ts
@@ -1,0 +1,194 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  initialMicState,
+  markPrompted,
+  MIC_DEBOUNCE_MS,
+  onMicEvent,
+  setSuppressed,
+  shouldPrompt,
+  type MicPromptState
+} from './mic-watcher-logic'
+
+/** Crashed child restarts after this (engine updates, transient failures). */
+const RESTART_DELAY_MS = 5_000
+
+interface MicWatcherConfig {
+  enabled: boolean
+}
+
+/**
+ * Ad-hoc meeting detection: runs the engine's `micmon` command (CoreAudio
+ * "device is running somewhere" listener) and prompts when some other app
+ * holds the microphone open past the debounce — a Zoom/Teams/Meet call that
+ * never made it onto the calendar. Decision logic is pure and tested
+ * (mic-watcher-logic.ts); this class owns the child process and timers.
+ */
+export class MicWatcher {
+  private config: MicWatcherConfig
+  private readonly configPath: string
+  private state: MicPromptState = initialMicState()
+  private child: ChildProcessWithoutNullStreams | null = null
+  private debounceTimer: NodeJS.Timeout | null = null
+  private restartTimer: NodeJS.Timeout | null = null
+  private stopping = false
+
+  constructor(
+    private readonly enginePath: string,
+    userDataDir: string,
+    private readonly onMeetingDetected: () => void
+  ) {
+    this.configPath = join(userDataDir, 'mic-watch.json')
+    this.config = this.readConfig()
+  }
+
+  get enabled(): boolean {
+    return this.config.enabled
+  }
+
+  get monitorAlive(): boolean {
+    return this.child !== null
+  }
+
+  start(): void {
+    if (this.config.enabled) this.spawnChild()
+  }
+
+  stop(): void {
+    this.stopping = true
+    this.killChild()
+  }
+
+  setEnabled(enabled: boolean): void {
+    if (this.config.enabled === enabled) return
+    this.config.enabled = enabled
+    this.writeConfig()
+    if (enabled) {
+      this.spawnChild()
+    } else {
+      this.killChild()
+      this.state = initialMicState()
+    }
+  }
+
+  /** True while DoodleNote's own capture holds the mic — don't self-prompt. */
+  setSuppressed(suppressed: boolean): void {
+    this.state = setSuppressed(this.state, suppressed)
+    if (suppressed) this.clearDebounce()
+  }
+
+  /* ---- child process ---- */
+
+  private spawnChild(): void {
+    if (this.child || this.stopping) return
+    let child: ChildProcessWithoutNullStreams
+    try {
+      // stdin stays open as the parent-death watchdog handle.
+      child = spawn(this.enginePath, ['micmon'], { stdio: ['pipe', 'pipe', 'pipe'] })
+    } catch (error) {
+      console.error('[micwatch] spawn failed:', error)
+      return
+    }
+    this.child = child
+
+    let buffer = ''
+    child.stdout.setEncoding('utf8')
+    child.stdout.on('data', (chunk: string) => {
+      buffer += chunk
+      let newline = buffer.indexOf('\n')
+      while (newline >= 0) {
+        const line = buffer.slice(0, newline).trim()
+        buffer = buffer.slice(newline + 1)
+        newline = buffer.indexOf('\n')
+        if (line.length === 0) continue
+        try {
+          const event = JSON.parse(line) as { event?: string; running?: boolean }
+          if (event.event === 'micmon' && typeof event.running === 'boolean') {
+            this.handleMicEvent(event.running)
+          }
+        } catch {
+          // CoreML/CoreAudio noise on stdout — NDJSON hosts skip unparseable lines.
+        }
+      }
+    })
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', () => {})
+    child.on('exit', () => {
+      this.child = null
+      this.clearDebounce()
+      if (!this.stopping && this.config.enabled) {
+        this.restartTimer = setTimeout(() => this.spawnChild(), RESTART_DELAY_MS)
+        this.restartTimer.unref?.()
+      }
+    })
+    child.on('error', (error) => {
+      console.error('[micwatch] child error:', error.message)
+    })
+  }
+
+  private killChild(): void {
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer)
+      this.restartTimer = null
+    }
+    this.clearDebounce()
+    if (this.child) {
+      // Closing stdin triggers the engine's own clean exit path.
+      try {
+        this.child.stdin.end()
+      } catch {
+        // already gone
+      }
+      const child = this.child
+      setTimeout(() => {
+        if (!child.killed) child.kill()
+      }, 2_000).unref()
+      this.child = null
+    }
+  }
+
+  /* ---- decision plumbing ---- */
+
+  private handleMicEvent(running: boolean): void {
+    this.state = onMicEvent(this.state, running, Date.now())
+    this.clearDebounce()
+    if (running && this.state.busySinceMs !== null) {
+      this.debounceTimer = setTimeout(() => {
+        this.debounceTimer = null
+        const now = Date.now()
+        if (shouldPrompt(this.state, now)) {
+          this.state = markPrompted(this.state, now)
+          this.onMeetingDetected()
+        }
+      }, MIC_DEBOUNCE_MS)
+      this.debounceTimer.unref?.()
+    }
+  }
+
+  private clearDebounce(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer)
+      this.debounceTimer = null
+    }
+  }
+
+  /* ---- config ---- */
+
+  private readConfig(): MicWatcherConfig {
+    try {
+      const raw = JSON.parse(readFileSync(this.configPath, 'utf8')) as Partial<MicWatcherConfig>
+      return { enabled: raw.enabled !== false } // default ON
+    } catch {
+      return { enabled: true }
+    }
+  }
+
+  private writeConfig(): void {
+    try {
+      writeFileSync(this.configPath, JSON.stringify(this.config, null, 2))
+    } catch (error) {
+      console.error('[micwatch] could not persist config:', error)
+    }
+  }
+}

--- a/apps/desktop/src/main/prompt-panel.ts
+++ b/apps/desktop/src/main/prompt-panel.ts
@@ -1,0 +1,125 @@
+import { BrowserWindow, screen } from 'electron'
+import type { CalendarStartMeetingEvent } from '../shared/calendar-api'
+
+/** The panel dismisses itself if the user ignores it this long. */
+const PANEL_TTL_MS = 4 * 60_000
+
+const PANEL_WIDTH = 340
+const PANEL_HEIGHT = 108
+
+/**
+ * A small always-on-top "meeting is starting" card for when the main window
+ * is closed or buried — the in-app banner can't be seen then, and macOS
+ * notifications are best-effort on unsigned builds. Frameless, click-through
+ * free, top-right of the active display.
+ *
+ * Zero-preload design: the page is a data: URL and the buttons navigate to
+ * doodle-panel://<action>, which will-navigate intercepts. No IPC surface.
+ */
+export class PromptPanel {
+  private window: BrowserWindow | null = null
+  private closeTimer: NodeJS.Timeout | null = null
+
+  show(prompt: CalendarStartMeetingEvent, onAction: (action: 'start' | 'dismiss') => void): void {
+    this.close() // one panel at a time; a newer prompt replaces an older one
+
+    const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint())
+    const { x, y, width } = display.workArea
+    const panel = new BrowserWindow({
+      width: PANEL_WIDTH,
+      height: PANEL_HEIGHT,
+      x: x + width - PANEL_WIDTH - 16,
+      y: y + 16,
+      frame: false,
+      resizable: false,
+      movable: true,
+      minimizable: false,
+      maximizable: false,
+      closable: true,
+      alwaysOnTop: true,
+      skipTaskbar: true,
+      focusable: true,
+      show: false,
+      transparent: true,
+      hasShadow: true
+    })
+    this.window = panel
+    panel.setAlwaysOnTop(true, 'floating')
+    panel.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
+
+    panel.webContents.on('will-navigate', (event, url) => {
+      event.preventDefault()
+      if (url.startsWith('doodle-panel://start')) {
+        this.close()
+        onAction('start')
+      } else if (url.startsWith('doodle-panel://dismiss')) {
+        this.close()
+        onAction('dismiss')
+      }
+    })
+
+    void panel.loadURL(panelDataUrl(prompt))
+    panel.once('ready-to-show', () => {
+      // Never steal focus — the user may be mid-sentence in another app.
+      panel.showInactive()
+    })
+    panel.on('closed', () => {
+      if (this.window === panel) this.window = null
+    })
+
+    this.closeTimer = setTimeout(() => this.close(), PANEL_TTL_MS)
+    this.closeTimer.unref?.()
+  }
+
+  close(): void {
+    if (this.closeTimer) {
+      clearTimeout(this.closeTimer)
+      this.closeTimer = null
+    }
+    if (this.window && !this.window.isDestroyed()) this.window.close()
+    this.window = null
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function panelDataUrl(prompt: CalendarStartMeetingEvent): string {
+  const heading = prompt.adHoc
+    ? 'Looks like you’re in a meeting'
+    : `${escapeHtml(prompt.subject)} is starting`
+  const sub = prompt.adHoc
+    ? 'Your microphone is live — want notes?'
+    : 'Want DoodleNote to take notes?'
+  const html = `<!doctype html><html><head><meta charset="utf-8"><style>
+  * { margin: 0; box-sizing: border-box; -webkit-user-select: none; cursor: default; }
+  body { font: 13px/1.4 -apple-system, BlinkMacSystemFont, sans-serif; background: transparent; padding: 2px; }
+  .card { background: #fdfcf8; border: 1px solid #e7e3d8; border-radius: 14px;
+    box-shadow: 0 10px 30px rgba(38,40,31,.22); padding: 12px 14px; height: ${PANEL_HEIGHT - 4}px;
+    display: flex; flex-direction: column; gap: 9px; -webkit-app-region: drag; }
+  .head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+  h1 { font-size: 13.5px; font-weight: 600; color: #26281f; overflow: hidden;
+    text-overflow: ellipsis; white-space: nowrap; }
+  p { color: #8a8d7f; font-size: 12px; }
+  .row { display: flex; gap: 8px; -webkit-app-region: no-drag; }
+  a { text-decoration: none; border-radius: 8px; padding: 6px 12px; font-size: 12.5px; font-weight: 600; }
+  .go { background: #7c9769; color: #fff; flex: 1; text-align: center; }
+  .go:hover { background: #5f7a4e; }
+  .no { color: #8a8d7f; padding: 6px 8px; }
+  .no:hover { color: #26281f; }
+  </style></head><body><div class="card">
+  <div class="head"><h1>${heading}</h1></div>
+  <p>${sub}</p>
+  <div class="row">
+    <a class="go" href="doodle-panel://start">✎ Take notes</a>
+    <a class="no" href="doodle-panel://dismiss">Dismiss</a>
+  </div>
+  </div></body></html>`
+  return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`
+}

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1,6 +1,7 @@
 import type { CalendarApi } from '../shared/calendar-api'
 import type { EngineApi } from '../shared/engine-events'
 import type { FoldersApi } from '../shared/folders-api'
+import type { MediaApi } from '../shared/media-api'
 import type { MeetingsApi } from '../shared/meetings-api'
 import type { NotesApi } from '../shared/notes-api'
 import type { SyncApi } from '../shared/sync-api'
@@ -13,6 +14,7 @@ declare global {
     folders: FoldersApi
     calendar: CalendarApi
     sync: SyncApi
+    media: MediaApi
   }
 }
 

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1,4 +1,5 @@
 import type { CalendarApi } from '../shared/calendar-api'
+import type { DetectApi } from '../shared/detect-api'
 import type { EngineApi } from '../shared/engine-events'
 import type { FoldersApi } from '../shared/folders-api'
 import type { MediaApi } from '../shared/media-api'
@@ -15,6 +16,7 @@ declare global {
     calendar: CalendarApi
     sync: SyncApi
     media: MediaApi
+    detect: DetectApi
   }
 }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -59,6 +59,13 @@ import {
   type FoldersApi
 } from '../shared/folders-api'
 import {
+  DETECT_GET_STATE_CHANNEL,
+  DETECT_SET_PREFS_CHANNEL,
+  type DetectApi,
+  type DetectPrefsUpdate,
+  type DetectState
+} from '../shared/detect-api'
+import {
   MEDIA_SAVE_CHANNEL,
   type MediaApi,
   type MediaSaveRequest,
@@ -277,6 +284,16 @@ const mediaApi: MediaApi = {
   }
 }
 
+const detectApi: DetectApi = {
+  getState(): Promise<DetectState> {
+    return ipcRenderer.invoke(DETECT_GET_STATE_CHANNEL) as Promise<DetectState>
+  },
+
+  setPrefs(update: DetectPrefsUpdate): Promise<DetectState> {
+    return ipcRenderer.invoke(DETECT_SET_PREFS_CHANNEL, update) as Promise<DetectState>
+  }
+}
+
 if (process.contextIsolated) {
   try {
     contextBridge.exposeInMainWorld('engine', engineApi)
@@ -286,6 +303,7 @@ if (process.contextIsolated) {
     contextBridge.exposeInMainWorld('calendar', calendarApi)
     contextBridge.exposeInMainWorld('sync', syncApi)
     contextBridge.exposeInMainWorld('media', mediaApi)
+    contextBridge.exposeInMainWorld('detect', detectApi)
   } catch (error) {
     console.error(error)
   }
@@ -304,4 +322,6 @@ if (process.contextIsolated) {
   window.sync = syncApi
   // @ts-ignore (defined in index.d.ts)
   window.media = mediaApi
+  // @ts-ignore (defined in index.d.ts)
+  window.detect = detectApi
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -59,6 +59,12 @@ import {
   type FoldersApi
 } from '../shared/folders-api'
 import {
+  MEDIA_SAVE_CHANNEL,
+  type MediaApi,
+  type MediaSaveRequest,
+  type MediaSaveResult
+} from '../shared/media-api'
+import {
   SYNC_CONNECT_CHANNEL,
   SYNC_DISCONNECT_CHANNEL,
   SYNC_GET_STATUS_CHANNEL,
@@ -265,6 +271,12 @@ const syncApi: SyncApi = {
   }
 }
 
+const mediaApi: MediaApi = {
+  save(request: MediaSaveRequest): Promise<MediaSaveResult> {
+    return ipcRenderer.invoke(MEDIA_SAVE_CHANNEL, request) as Promise<MediaSaveResult>
+  }
+}
+
 if (process.contextIsolated) {
   try {
     contextBridge.exposeInMainWorld('engine', engineApi)
@@ -273,6 +285,7 @@ if (process.contextIsolated) {
     contextBridge.exposeInMainWorld('folders', foldersApi)
     contextBridge.exposeInMainWorld('calendar', calendarApi)
     contextBridge.exposeInMainWorld('sync', syncApi)
+    contextBridge.exposeInMainWorld('media', mediaApi)
   } catch (error) {
     console.error(error)
   }
@@ -289,4 +302,6 @@ if (process.contextIsolated) {
   window.calendar = calendarApi
   // @ts-ignore (defined in index.d.ts)
   window.sync = syncApi
+  // @ts-ignore (defined in index.d.ts)
+  window.media = mediaApi
 }

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: doodle-media:"
     />
   </head>
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -531,10 +531,16 @@ function App(): React.JSX.Element {
       {banner !== null && (
         <div className="meeting-banner no-drag" role="status">
           <span className="mb-emoji" aria-hidden="true">
-            📅
+            {banner.adHoc ? '🎙' : '📅'}
           </span>
           <span className="mb-text">
-            <strong>{banner.subject}</strong> is starting
+            {banner.adHoc ? (
+              <>Looks like you&rsquo;re in a meeting</>
+            ) : (
+              <>
+                <strong>{banner.subject}</strong> is starting
+              </>
+            )}
           </span>
           <button
             type="button"

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -76,13 +76,18 @@ function App(): React.JSX.Element {
   }, [])
 
   const newMeeting = useCallback(
-    async (prefill?: { title?: string; calendarEventId?: string }): Promise<void> => {
+    async (prefill?: {
+      title?: string
+      calendarEventId?: string
+      kind?: 'note'
+    }): Promise<void> => {
       const id =
         typeof crypto.randomUUID === 'function'
           ? crypto.randomUUID()
           : `m-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
       await window.meetings.upsert({
         id,
+        ...(prefill?.kind === 'note' ? { kind: 'note' as const } : {}),
         title: prefill?.title ?? '',
         createdAt: new Date().toISOString(),
         rawNotesMarkdown: '',
@@ -91,8 +96,9 @@ function App(): React.JSX.Element {
         ...(prefill?.calendarEventId ? { calendarEventId: prefill.calendarEventId } : {})
       })
       // Fresh meetings start recording immediately; opening an existing
-      // meeting from the list never does.
-      setAutoRecordId(id)
+      // meeting from the list never does. Quick notes never auto-record —
+      // typing is their default, the rec pill is there when wanted.
+      if (prefill?.kind !== 'note') setAutoRecordId(id)
       openMeeting(id)
     },
     [openMeeting]
@@ -492,6 +498,7 @@ function App(): React.JSX.Element {
               onStartCalendarMeeting={startFromCalendarEvent}
               onOpenMeeting={openMeeting}
               onNewMeeting={() => void newMeeting()}
+              onNewNote={() => void newMeeting({ kind: 'note' })}
               onChanged={refreshHome}
               onOpenSettings={() => setView('settings')}
             />

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -11,6 +11,16 @@ import HomeView, { type HomeFilter } from './HomeView'
 import MeetingView from './MeetingView'
 import ModelsView from './ModelsView'
 import mascotUrl from './assets/mascot-square.png'
+import {
+  CalendarIcon,
+  FolderIcon,
+  GearIcon,
+  HomeIcon,
+  LockIcon,
+  MicIcon,
+  PencilIcon,
+  TrashIcon
+} from './icons'
 
 type ViewId = 'home' | 'editor' | 'settings' | 'dev'
 
@@ -315,7 +325,10 @@ function App(): React.JSX.Element {
               className={onHome && filter.kind === 'all' ? 'nav-item on' : 'nav-item'}
               onClick={() => selectFilter({ kind: 'all' })}
             >
-              <span className="nav-icon">⌂</span> Home
+              <span className="nav-icon">
+                <HomeIcon size={14} />
+              </span>{' '}
+              Home
             </button>
           </nav>
 
@@ -336,7 +349,9 @@ function App(): React.JSX.Element {
                 }
               }}
             >
-              <span className="nav-icon">✎</span>
+              <span className="nav-icon">
+                <PencilIcon size={13} />
+              </span>
               <span className="nav-label">My notes</span>
               <button
                 type="button"
@@ -384,7 +399,9 @@ function App(): React.JSX.Element {
                     }
                   }}
                 >
-                  <span className="nav-icon">📁</span>
+                  <span className="nav-icon">
+                    <FolderIcon size={13} />
+                  </span>
                   <span className="nav-label">{f.name}</span>
                   <span className="nav-count">{folderCounts.get(f.id) ?? 0}</span>
                   <button
@@ -417,14 +434,14 @@ function App(): React.JSX.Element {
                           setRenamingFolder({ id: f.id, name: f.name })
                         }}
                       >
-                        ✎ Rename
+                        <PencilIcon size={12} /> Rename
                       </button>
                       <button
                         type="button"
                         className="danger"
                         onClick={() => void deleteFolder(f.id)}
                       >
-                        🗑 Delete folder
+                        <TrashIcon size={12} /> Delete folder
                       </button>
                     </div>
                   )}
@@ -464,7 +481,9 @@ function App(): React.JSX.Element {
               className={onHome && filter.kind === 'trash' ? 'nav-item on' : 'nav-item'}
               onClick={() => selectFilter({ kind: 'trash' })}
             >
-              <span className="nav-icon">🗑</span>
+              <span className="nav-icon">
+                <TrashIcon size={13} />
+              </span>
               <span className="nav-label">Trash</span>
               {trashCount > 0 && <span className="nav-count">{trashCount}</span>}
             </button>
@@ -473,13 +492,18 @@ function App(): React.JSX.Element {
           <div className="sidebar-spacer" />
 
           <div className="sidebar-bottom">
-            <div className="privacy-badge">🔒 Local &amp; private</div>
+            <div className="privacy-badge">
+              <LockIcon size={12} /> Local &amp; private
+            </div>
             <button
               type="button"
               className={view === 'settings' ? 'nav-item on' : 'nav-item'}
               onClick={() => setView('settings')}
             >
-              <span className="nav-icon">⚙</span> Settings
+              <span className="nav-icon">
+                <GearIcon size={14} />
+              </span>{' '}
+              Settings
             </button>
             <button type="button" className="dev-link" onClick={() => setView('dev')}>
               Developer
@@ -531,7 +555,7 @@ function App(): React.JSX.Element {
       {banner !== null && (
         <div className="meeting-banner no-drag" role="status">
           <span className="mb-emoji" aria-hidden="true">
-            {banner.adHoc ? '🎙' : '📅'}
+            {banner.adHoc ? <MicIcon size={15} /> : <CalendarIcon size={15} />}
           </span>
           <span className="mb-text">
             {banner.adHoc ? (

--- a/apps/desktop/src/renderer/src/FolderPicker.tsx
+++ b/apps/desktop/src/renderer/src/FolderPicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { FolderRecord } from '../../shared/folders-api'
 import type { MeetingSummary } from '../../shared/meetings-api'
+import { FolderIcon, LockIcon } from './icons'
 
 /**
  * Granola-style "Add to folder" popover: search field, "My notes" + folder
@@ -111,7 +112,9 @@ export default function FolderPicker({
       <div className="fp-list">
         {showMyNotes && (
           <button type="button" className="fp-row" onClick={() => onAssign(null)}>
-            <span className="fp-icon">🔒</span>
+            <span className="fp-icon">
+              <LockIcon size={13} />
+            </span>
             <span className="fp-name">My notes</span>
             {currentFolderId === null ? (
               <span className="fp-check">✓</span>
@@ -122,7 +125,9 @@ export default function FolderPicker({
         )}
         {shownFolders.map((f) => (
           <button key={f.id} type="button" className="fp-row" onClick={() => onAssign(f.id)}>
-            <span className="fp-icon">📁</span>
+            <span className="fp-icon">
+              <FolderIcon size={13} />
+            </span>
             <span className="fp-name">{f.name}</span>
             {currentFolderId === f.id ? (
               <span className="fp-check">✓</span>

--- a/apps/desktop/src/renderer/src/FormatToolbar.tsx
+++ b/apps/desktop/src/renderer/src/FormatToolbar.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useReducer } from 'react'
 import type { Editor } from '@tiptap/react'
+import { CheckSquareIcon, ImageIcon } from './icons'
 
 interface ToolButton {
-  label: string
+  label: React.ReactNode
   title: string
   isOn: (editor: Editor) => boolean
   run: (editor: Editor) => void
@@ -52,7 +53,7 @@ const TOOLS: ToolButton[] = [
     run: (e) => e.chain().focus().toggleOrderedList().run()
   },
   {
-    label: '☑',
+    label: <CheckSquareIcon size={13} />,
     title: 'To-do list',
     isOn: (e) => e.isActive('taskList'),
     run: (e) => e.chain().focus().toggleTaskList().run()
@@ -116,7 +117,7 @@ export default function FormatToolbar({
         onMouseDown={(e) => e.preventDefault()}
         onClick={onPickImage}
       >
-        🖼
+        <ImageIcon size={13} />
       </button>
     </div>
   )

--- a/apps/desktop/src/renderer/src/FormatToolbar.tsx
+++ b/apps/desktop/src/renderer/src/FormatToolbar.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useReducer } from 'react'
+import type { Editor } from '@tiptap/react'
+
+interface ToolButton {
+  label: string
+  title: string
+  isOn: (editor: Editor) => boolean
+  run: (editor: Editor) => void
+}
+
+const TOOLS: ToolButton[] = [
+  {
+    label: 'B',
+    title: 'Bold (⌘B)',
+    isOn: (e) => e.isActive('bold'),
+    run: (e) => e.chain().focus().toggleBold().run()
+  },
+  {
+    label: 'I',
+    title: 'Italic (⌘I)',
+    isOn: (e) => e.isActive('italic'),
+    run: (e) => e.chain().focus().toggleItalic().run()
+  },
+  {
+    label: 'S',
+    title: 'Strikethrough',
+    isOn: (e) => e.isActive('strike'),
+    run: (e) => e.chain().focus().toggleStrike().run()
+  },
+  {
+    label: 'H1',
+    title: 'Heading',
+    isOn: (e) => e.isActive('heading', { level: 1 }),
+    run: (e) => e.chain().focus().toggleHeading({ level: 1 }).run()
+  },
+  {
+    label: 'H2',
+    title: 'Subheading',
+    isOn: (e) => e.isActive('heading', { level: 2 }),
+    run: (e) => e.chain().focus().toggleHeading({ level: 2 }).run()
+  },
+  {
+    label: '•',
+    title: 'Bullet list',
+    isOn: (e) => e.isActive('bulletList'),
+    run: (e) => e.chain().focus().toggleBulletList().run()
+  },
+  {
+    label: '1.',
+    title: 'Numbered list',
+    isOn: (e) => e.isActive('orderedList'),
+    run: (e) => e.chain().focus().toggleOrderedList().run()
+  },
+  {
+    label: '☑',
+    title: 'To-do list',
+    isOn: (e) => e.isActive('taskList'),
+    run: (e) => e.chain().focus().toggleTaskList().run()
+  },
+  {
+    label: '❝',
+    title: 'Quote',
+    isOn: (e) => e.isActive('blockquote'),
+    run: (e) => e.chain().focus().toggleBlockquote().run()
+  },
+  {
+    label: '</>',
+    title: 'Code block',
+    isOn: (e) => e.isActive('codeBlock'),
+    run: (e) => e.chain().focus().toggleCodeBlock().run()
+  }
+]
+
+/** Slim formatting bar above the notes editor; also hosts the image picker. */
+export default function FormatToolbar({
+  editor,
+  onPickImage
+}: {
+  editor: Editor | null
+  onPickImage: () => void
+}): React.JSX.Element | null {
+  // Active states live inside the editor; re-render on every transaction.
+  const [, bump] = useReducer((n: number) => n + 1, 0)
+  useEffect(() => {
+    if (!editor) return
+    editor.on('transaction', bump)
+    return () => {
+      editor.off('transaction', bump)
+    }
+  }, [editor])
+
+  if (!editor) return null
+
+  return (
+    <div className="fmt-toolbar" role="toolbar" aria-label="Text formatting">
+      {TOOLS.map((tool) => (
+        <button
+          key={tool.title}
+          type="button"
+          className={tool.isOn(editor) ? 'fmt-btn on' : 'fmt-btn'}
+          title={tool.title}
+          aria-label={tool.title}
+          aria-pressed={tool.isOn(editor)}
+          onMouseDown={(e) => e.preventDefault() /* keep editor selection */}
+          onClick={() => tool.run(editor)}
+        >
+          {tool.label}
+        </button>
+      ))}
+      <span className="fmt-sep" aria-hidden="true" />
+      <button
+        type="button"
+        className="fmt-btn"
+        title="Insert image (or paste / drag one in)"
+        aria-label="Insert image"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={onPickImage}
+      >
+        🖼
+      </button>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/HomeView.tsx
+++ b/apps/desktop/src/renderer/src/HomeView.tsx
@@ -8,6 +8,7 @@ import type {
   NotesSettingsView
 } from '../../shared/notes-api'
 import FolderPicker from './FolderPicker'
+import { CheckSquareIcon, DocIcon, FolderIcon, PencilIcon, TrashIcon } from './icons'
 import { markdownToHtml } from './lib/markdown'
 import logoUrl from './assets/doodlenote-logo.png'
 
@@ -606,8 +607,16 @@ export default function HomeView({
               onOpenSettings={onOpenSettings}
             />
           )}
-          {filter.kind === 'folder' && <h2 className="home-heading">📁 {folderName}</h2>}
-          {inTrash && <h2 className="home-heading">🗑 Trash</h2>}
+          {filter.kind === 'folder' && (
+            <h2 className="home-heading">
+              <FolderIcon size={17} /> {folderName}
+            </h2>
+          )}
+          {inTrash && (
+            <h2 className="home-heading">
+              <TrashIcon size={17} /> Trash
+            </h2>
+          )}
 
           <div className={filter.kind === 'all' ? 'meetings-list' : 'meetings-list flush'}>
             {noneInView && filter.kind === 'all' && (
@@ -646,7 +655,9 @@ export default function HomeView({
                         }
                       }}
                     >
-                      <span className="row-icon">{m.kind === 'note' ? '✎' : '☰'}</span>
+                      <span className="row-icon">
+                        {m.kind === 'note' ? <PencilIcon size={14} /> : <DocIcon size={14} />}
+                      </span>
                       <span className="row-main">
                         <span className="row-title">
                           {m.title.trim() || (m.kind === 'note' ? 'New note' : 'New meeting')}
@@ -863,7 +874,7 @@ export default function HomeView({
               onClick={() => void submitAsk(RECENT_TODOS_QUESTION)}
               title="List outstanding action items from your recent meetings"
             >
-              ☑ List recent todos
+              <CheckSquareIcon size={13} /> List recent todos
             </button>
           )}
         </form>

--- a/apps/desktop/src/renderer/src/HomeView.tsx
+++ b/apps/desktop/src/renderer/src/HomeView.tsx
@@ -39,10 +39,10 @@ function timeLabel(iso: string): string {
 /** Events starting within this window (or in progress) get a Take notes button. */
 const TAKE_NOTES_LEAD_MS = 10 * 60_000
 
-/** The chevrons page the day window a week at a time… */
-const DAYS_PER_PAGE = 7
-/** …across the service's 14-day fetch: page 0 = days 0–6, page 1 = days 7–13. */
-const LAST_PAGE = 1
+/** The card shows two days at a time (today + tomorrow); chevrons page by two… */
+const DAYS_PER_PAGE = 2
+/** …across the service's 14-day fetch: page 0 = days 0–1 … page 6 = days 12–13. */
+const LAST_PAGE = 6
 
 const DAY_MS = 86_400_000
 
@@ -343,6 +343,7 @@ export default function HomeView({
   onStartCalendarMeeting,
   onOpenMeeting,
   onNewMeeting,
+  onNewNote,
   onChanged,
   onOpenSettings
 }: {
@@ -354,6 +355,7 @@ export default function HomeView({
   onStartCalendarMeeting: (event: CalendarEvent) => void
   onOpenMeeting: (id: string) => void
   onNewMeeting: () => void
+  onNewNote: () => void
   onChanged: () => void
   onOpenSettings: () => void
 }): React.JSX.Element {
@@ -580,6 +582,14 @@ export default function HomeView({
             Empty trash
           </button>
         )}
+        <button
+          type="button"
+          className="pill-btn new-note no-drag"
+          title="A blank note — type freely, or hit record to mind-dump and generate notes"
+          onClick={onNewNote}
+        >
+          + New note
+        </button>
         <button type="button" className="pill-btn new-meeting no-drag" onClick={onNewMeeting}>
           + New meeting
         </button>
@@ -636,11 +646,14 @@ export default function HomeView({
                         }
                       }}
                     >
-                      <span className="row-icon">☰</span>
+                      <span className="row-icon">{m.kind === 'note' ? '✎' : '☰'}</span>
                       <span className="row-main">
-                        <span className="row-title">{m.title.trim() || 'New meeting'}</span>
+                        <span className="row-title">
+                          {m.title.trim() || (m.kind === 'note' ? 'New note' : 'New meeting')}
+                        </span>
                         <span className="row-sub">
-                          Me{m.durationMin !== undefined ? ` · ${m.durationMin} min` : ''}
+                          {m.kind === 'note' ? 'Note' : 'Me'}
+                          {m.durationMin !== undefined ? ` · ${m.durationMin} min` : ''}
                         </span>
                       </span>
                       <span className="row-time">{timeLabel(m.createdAt)}</span>

--- a/apps/desktop/src/renderer/src/MeetingView.tsx
+++ b/apps/desktop/src/renderer/src/MeetingView.tsx
@@ -698,7 +698,7 @@ export default function MeetingView({
             className="doc-title"
             type="text"
             spellCheck={false}
-            placeholder="New meeting"
+            placeholder={meeting?.kind === 'note' ? 'New note' : 'New meeting'}
             value={title}
             onChange={(e) => {
               setTitle(e.target.value)
@@ -709,7 +709,7 @@ export default function MeetingView({
 
           <div className="chips-row">
             <span className="chip">📅 {dateChip}</span>
-            <span className="chip">👥 Me</span>
+            <span className="chip">{meeting?.kind === 'note' ? '✎ Note' : '👥 Me'}</span>
             <span className="chip-folder-anchor">
               <button
                 type="button"

--- a/apps/desktop/src/renderer/src/MeetingView.tsx
+++ b/apps/desktop/src/renderer/src/MeetingView.tsx
@@ -10,6 +10,15 @@ import type { MeetingChatEntry, MeetingRecord } from '../../shared/meetings-api'
 import type { NotesModelsResponse, NotesSettingsView } from '../../shared/notes-api'
 import FolderPicker from './FolderPicker'
 import FormatToolbar from './FormatToolbar'
+import {
+  CalendarIcon,
+  FolderIcon,
+  HomeIcon,
+  MailIcon,
+  PencilIcon,
+  SparkleIcon,
+  UsersIcon
+} from './icons'
 import { docToMarkdown, markdownToHtml } from './lib/markdown'
 
 type Phase = 'idle' | 'starting' | 'recording' | 'finishing' | 'ended'
@@ -712,7 +721,7 @@ export default function MeetingView({
     <div className="editor-page">
       <div className="editor-topbar drag">
         <button type="button" className="back-pill no-drag" onClick={goBack} title="Back to home">
-          ‹ ⌂
+          ‹ <HomeIcon size={13} />
         </button>
       </div>
 
@@ -754,8 +763,20 @@ export default function MeetingView({
           />
 
           <div className="chips-row">
-            <span className="chip">📅 {dateChip}</span>
-            <span className="chip">{meeting?.kind === 'note' ? '✎ Note' : '👥 Me'}</span>
+            <span className="chip">
+              <CalendarIcon size={12} /> {dateChip}
+            </span>
+            <span className="chip">
+              {meeting?.kind === 'note' ? (
+                <>
+                  <PencilIcon size={12} /> Note
+                </>
+              ) : (
+                <>
+                  <UsersIcon size={12} /> Me
+                </>
+              )}
+            </span>
             <span className="chip-folder-anchor">
               <button
                 type="button"
@@ -763,7 +784,7 @@ export default function MeetingView({
                 title={folderName !== null ? 'Move to another folder' : 'Add to folder'}
                 onClick={() => setFolderPickerOpen((open) => !open)}
               >
-                📁 {folderName ?? 'Add to folder'}
+                <FolderIcon size={12} /> {folderName ?? 'Add to folder'}
               </button>
               {folderPickerOpen && (
                 <FolderPicker
@@ -1003,7 +1024,9 @@ export default function MeetingView({
               {streamedWords > 0 ? `Writing… ${streamedWords} words` : 'Generating…'}
             </>
           ) : (
-            <>✨ Generate notes</>
+            <>
+              <SparkleIcon size={14} /> Generate notes
+            </>
           )}
         </button>
       )}
@@ -1097,7 +1120,7 @@ export default function MeetingView({
               onClick={() => void submitAsk(FOLLOW_UP_EMAIL_QUESTION)}
               title="Draft a ready-to-send follow-up email from this meeting"
             >
-              ✉ Write follow up email
+              <MailIcon size={12} /> Write follow up email
             </button>
           )}
         </form>

--- a/apps/desktop/src/renderer/src/MeetingView.tsx
+++ b/apps/desktop/src/renderer/src/MeetingView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
+import Image from '@tiptap/extension-image'
 import { TaskItem, TaskList } from '@tiptap/extension-list'
 import { Placeholder } from '@tiptap/extensions'
 import type { EngineChannel, EngineEvent, TranscriptSegment } from '../../shared/engine-events'
@@ -8,6 +9,7 @@ import type { FolderRecord } from '../../shared/folders-api'
 import type { MeetingChatEntry, MeetingRecord } from '../../shared/meetings-api'
 import type { NotesModelsResponse, NotesSettingsView } from '../../shared/notes-api'
 import FolderPicker from './FolderPicker'
+import FormatToolbar from './FormatToolbar'
 import { docToMarkdown, markdownToHtml } from './lib/markdown'
 
 type Phase = 'idle' | 'starting' | 'recording' | 'finishing' | 'ended'
@@ -134,6 +136,11 @@ function BarsIcon({ animated }: { animated: boolean }): React.JSX.Element {
   )
 }
 
+/** The image files in a paste/drop/pick payload (other file types ignored). */
+function imageFilesFrom(list: FileList | null | undefined): File[] {
+  return Array.from(list ?? []).filter((f) => f.type.startsWith('image/'))
+}
+
 /** The Granola-shaped note editor: title, chips, page-wide TipTap doc,
  *  floating record/enhance bar and the transcript flyout. */
 export default function MeetingView({
@@ -227,19 +234,58 @@ export default function MeetingView({
     persist({ title: titleValueRef.current, rawNotesMarkdown: roughMarkdownRef.current })
   }, [persist])
 
+  /** Pasted/dropped image files route through here (set once editor exists). */
+  const insertImagesRef = useRef<(files: File[]) => void>(() => {})
+
   const editor = useEditor({
     extensions: [
       StarterKit,
       TaskList,
       TaskItem.configure({ nested: true }),
+      Image,
       Placeholder.configure({ placeholder: 'Write notes…' })
     ],
+    editorProps: {
+      // Pasted and dragged-in images persist to the local attachments store.
+      handlePaste: (_view, event) => {
+        const files = imageFilesFrom(event.clipboardData?.files)
+        if (files.length === 0) return false
+        insertImagesRef.current(files)
+        return true
+      },
+      handleDrop: (_view, event, _slice, moved) => {
+        if (moved) return false
+        const files = imageFilesFrom(event.dataTransfer?.files)
+        if (files.length === 0) return false
+        insertImagesRef.current(files)
+        return true
+      }
+    },
     onUpdate: ({ editor: ed }) => {
       if (applyingRef.current || docViewRef.current !== 'notes') return
       roughMarkdownRef.current = docToMarkdown(ed.getJSON())
       scheduleNotesSave()
     }
   })
+
+  useEffect(() => {
+    insertImagesRef.current = (files: File[]): void => {
+      if (!editor) return
+      void (async () => {
+        for (const file of files) {
+          const bytes = await file.arrayBuffer()
+          const result = await window.media.save({ bytes, mime: file.type })
+          if ('url' in result) {
+            editor.chain().focus().setImage({ src: result.url }).run()
+          } else {
+            console.error('[media] image save failed:', result.error)
+          }
+        }
+      })()
+    }
+  }, [editor])
+
+  const imageInputRef = useRef<HTMLInputElement>(null)
 
   const setEditorMarkdown = useCallback(
     (markdown: string, editable: boolean): void => {
@@ -764,6 +810,21 @@ export default function MeetingView({
             )}
           </div>
 
+          {docView === 'notes' && (
+            <FormatToolbar editor={editor} onPickImage={() => imageInputRef.current?.click()} />
+          )}
+          <input
+            ref={imageInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/gif,image/webp"
+            multiple
+            style={{ display: 'none' }}
+            onChange={(e) => {
+              const files = imageFilesFrom(e.target.files)
+              if (files.length > 0) insertImagesRef.current(files)
+              e.target.value = ''
+            }}
+          />
           <EditorContent editor={editor} className="doc-editor" />
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { CalendarPrefsUpdate, CalendarState } from '../../shared/calendar-api'
+import type { DetectState } from '../../shared/detect-api'
 import type { SyncStatus } from '../../shared/sync-api'
 import type {
   CloudProvider,
@@ -145,6 +146,9 @@ export default function ModelsView({ active }: { active: boolean }): React.JSX.E
   const [syncStatus, setSyncStatus] = useState<SyncStatus | null>(null)
   const [linkPending, setLinkPending] = useState(false)
 
+  /* ---- meeting detection ---- */
+  const [detect, setDetect] = useState<DetectState | null>(null)
+
   /* ---- calendar (Microsoft 365) ---- */
   const [calState, setCalState] = useState<CalendarState | null>(null)
   const [clientId, setClientId] = useState('')
@@ -187,6 +191,15 @@ export default function ModelsView({ active }: { active: boolean }): React.JSX.E
   }, [active])
 
   useEffect(() => window.sync.onStatus(setSyncStatus), [])
+
+  useEffect(() => {
+    if (active) {
+      void window.detect
+        .getState()
+        .then(setDetect)
+        .catch(() => setDetect(null))
+    }
+  }, [active])
 
   const connectSync = async (): Promise<void> => {
     if (linkPending) return
@@ -581,6 +594,51 @@ export default function ModelsView({ active }: { active: boolean }): React.JSX.E
                   )
                 })
               )}
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section className="keys-section calendar-section">
+        <h3>Meeting detection</h3>
+        <p className="models-sub">
+          DoodleNote already nudges you when a calendar meeting starts. These make sure it never
+          misses one.
+        </p>
+        {detect === null ? (
+          <span className="calendar-note">loading detection settings…</span>
+        ) : (
+          <div className="cal-subcard">
+            <div className="cal-row">
+              <span className="cal-row-main">
+                <span className="cal-row-label">Start DoodleNote at login</span>
+                <span className="cal-row-sub">
+                  Keeps meeting prompts working without remembering to open the app
+                </span>
+              </span>
+              <Toggle
+                checked={detect.loginItem}
+                label="Start DoodleNote at login"
+                onChange={() => {
+                  void window.detect.setPrefs({ loginItem: !detect.loginItem }).then(setDetect)
+                }}
+              />
+            </div>
+            <div className="cal-row">
+              <span className="cal-row-main">
+                <span className="cal-row-label">Detect meetings from mic activity</span>
+                <span className="cal-row-sub">
+                  Prompts to take notes when Zoom, Teams, or Meet holds your microphone open —
+                  even for meetings that aren&rsquo;t on your calendar
+                </span>
+              </span>
+              <Toggle
+                checked={detect.micDetect}
+                label="Detect meetings from mic activity"
+                onChange={() => {
+                  void window.detect.setPrefs({ micDetect: !detect.micDetect }).then(setDetect)
+                }}
+              />
             </div>
           </div>
         )}

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -130,7 +130,17 @@ function Toggle({
   )
 }
 
+type SettingsSection = 'general' | 'calendar' | 'sync' | 'model'
+
+const SETTINGS_NAV: Array<{ key: SettingsSection; icon: string; label: string }> = [
+  { key: 'general', icon: '⚙️', label: 'General' },
+  { key: 'calendar', icon: '📅', label: 'Calendar' },
+  { key: 'sync', icon: '☁️', label: 'Cloud sync' },
+  { key: 'model', icon: '✨', label: 'Notes model' }
+]
+
 export default function ModelsView({ active }: { active: boolean }): React.JSX.Element {
+  const [section, setSection] = useState<SettingsSection>('general')
   const [data, setData] = useState<NotesModelsResponse | null>(null)
   const [settings, setSettings] = useState<NotesSettingsView | null>(null)
   const [downloading, setDownloading] = useState<{ id: string; progress: number } | null>(null)
@@ -378,18 +388,43 @@ export default function ModelsView({ active }: { active: boolean }): React.JSX.E
       <header className="models-header">
         <img className="settings-logo" src={logoUrl} alt="DoodleNote" />
         <div>
-          <h2>Notes model</h2>
+          <h2>Settings</h2>
           <p className="models-sub">
-            DoodleNote polishes your meeting notes with a model that runs entirely on this Mac
-            {data ? ` (${data.ramGB} GB RAM)` : ''}. Download one once — nothing leaves your
-            machine.
+            Local-first by default — nothing leaves this Mac unless you turn it on.
           </p>
         </div>
       </header>
 
-      {error && <div className="models-error">{error}</div>}
+      <div className="settings-shell">
+        <nav className="settings-nav" aria-label="Settings sections">
+          {SETTINGS_NAV.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              className={section === item.key ? 'settings-nav-btn on' : 'settings-nav-btn'}
+              onClick={() => setSection(item.key)}
+            >
+              <span className="settings-nav-icon" aria-hidden="true">
+                {item.icon}
+              </span>
+              {item.label}
+            </button>
+          ))}
+        </nav>
 
-      <div className="model-cards">
+        <div className="settings-content">
+          {section === 'model' && (
+            <section className="keys-section">
+              <h3>On-device model</h3>
+              <p className="models-sub">
+                DoodleNote polishes your meeting notes with a model that runs entirely on this Mac
+                {data ? ` (${data.ramGB} GB RAM)` : ''}. Download one once — nothing leaves your
+                machine.
+              </p>
+
+              {error && <div className="models-error">{error}</div>}
+
+              <div className="model-cards">
         {data === null && <span className="placeholder">loading models…</span>}
         {data?.models.map((m) => (
           <div
@@ -408,7 +443,10 @@ export default function ModelsView({ active }: { active: boolean }): React.JSX.E
           </div>
         ))}
       </div>
+            </section>
+          )}
 
+          {section === 'calendar' && (
       <section className="keys-section calendar-section">
         <h3>Calendar</h3>
         <p className="models-sub">
@@ -598,7 +636,9 @@ export default function ModelsView({ active }: { active: boolean }): React.JSX.E
           </div>
         )}
       </section>
+          )}
 
+          {section === 'general' && (
       <section className="keys-section calendar-section">
         <h3>Meeting detection</h3>
         <p className="models-sub">
@@ -643,7 +683,9 @@ export default function ModelsView({ active }: { active: boolean }): React.JSX.E
           </div>
         )}
       </section>
+          )}
 
+          {section === 'sync' && (
       <section className="keys-section calendar-section">
         <h3>Sync with cloud</h3>
         <p className="models-sub">
@@ -734,7 +776,9 @@ export default function ModelsView({ active }: { active: boolean }): React.JSX.E
           </div>
         )}
       </section>
+          )}
 
+          {section === 'model' && (
       <section className="keys-section">
         <h3>AI keys (optional)</h3>
         <p className="models-sub">
@@ -790,6 +834,9 @@ export default function ModelsView({ active }: { active: boolean }): React.JSX.E
           {(keySaved || settings?.cloud?.hasKey) && <span className="key-saved">key saved ✓</span>}
         </div>
       </section>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { CalendarPrefsUpdate, CalendarState } from '../../shared/calendar-api'
 import type { DetectState } from '../../shared/detect-api'
 import type { SyncStatus } from '../../shared/sync-api'
+import { CalendarIcon, CloudIcon, GearIcon, SparkleIcon } from './icons'
 import type {
   CloudProvider,
   EngineChoice,
@@ -132,11 +133,11 @@ function Toggle({
 
 type SettingsSection = 'general' | 'calendar' | 'sync' | 'model'
 
-const SETTINGS_NAV: Array<{ key: SettingsSection; icon: string; label: string }> = [
-  { key: 'general', icon: '⚙️', label: 'General' },
-  { key: 'calendar', icon: '📅', label: 'Calendar' },
-  { key: 'sync', icon: '☁️', label: 'Cloud sync' },
-  { key: 'model', icon: '✨', label: 'Notes model' }
+const SETTINGS_NAV: Array<{ key: SettingsSection; icon: React.JSX.Element; label: string }> = [
+  { key: 'general', icon: <GearIcon size={15} />, label: 'General' },
+  { key: 'calendar', icon: <CalendarIcon size={15} />, label: 'Calendar' },
+  { key: 'sync', icon: <CloudIcon size={15} />, label: 'Cloud sync' },
+  { key: 'model', icon: <SparkleIcon size={15} />, label: 'Notes model' }
 ]
 
 export default function ModelsView({ active }: { active: boolean }): React.JSX.Element {

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -668,8 +668,9 @@ export default function ModelsView({ active }: { active: boolean }): React.JSX.E
               <span className="cal-row-main">
                 <span className="cal-row-label">Detect meetings from mic activity</span>
                 <span className="cal-row-sub">
-                  Prompts to take notes when Zoom, Teams, or Meet holds your microphone open —
-                  even for meetings that aren&rsquo;t on your calendar
+                  Prompts when a meeting app — Zoom, Teams, Webex, Slack, FaceTime, or a browser
+                  — holds your microphone, even without a calendar event. Dictation tools are
+                  ignored.
                 </span>
               </span>
               <Toggle

--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -62,6 +62,13 @@ textarea {
   font-family: inherit;
 }
 
+/* Shared SVG icons (icons.tsx): sit on the text baseline when inline; flex
+   containers (nav rows, chips with align-items) center them naturally. */
+.ico {
+  vertical-align: -2.5px;
+  flex-shrink: 0;
+}
+
 /* macOS window chrome helpers */
 .drag {
   -webkit-app-region: drag;

--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -1161,9 +1161,64 @@ button.fp-row:hover {
   color: var(--accent-deep);
 }
 
+/* slim formatting bar above the doc */
+.fmt-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin: 10px 0 2px;
+  padding: 3px;
+  width: fit-content;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+
+.fmt-btn {
+  min-width: 26px;
+  height: 24px;
+  padding: 0 7px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.fmt-btn:hover {
+  background: var(--card-soft);
+  color: var(--ink);
+}
+
+.fmt-btn.on {
+  background: var(--sage-fill);
+  color: var(--accent-deep);
+}
+
+.fmt-sep {
+  width: 1px;
+  height: 16px;
+  margin: 0 3px;
+  background: var(--border);
+}
+
 /* the TipTap doc IS the page — no box */
 .doc-editor {
   user-select: text;
+}
+
+.doc-editor .tiptap img {
+  display: block;
+  max-width: min(100%, 560px);
+  border-radius: 10px;
+  border: 1px solid var(--border);
+}
+
+.doc-editor .tiptap img.ProseMirror-selectednode {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .doc-editor .tiptap {

--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -1934,7 +1934,7 @@ button.fp-row:hover {
 
 .models {
   height: 100%;
-  max-width: 660px;
+  max-width: 780px;
   margin: 0 auto;
   padding: 28px 28px 32px;
   display: flex;
@@ -2123,6 +2123,73 @@ button.fp-row:hover {
   flex-direction: column;
   gap: 10px;
   padding-bottom: 8px;
+}
+
+/* ---- settings shell: nav rail + one visible section ---- */
+
+.settings-shell {
+  display: flex;
+  align-items: flex-start;
+  gap: 22px;
+  min-height: 0;
+}
+
+.settings-nav {
+  position: sticky;
+  top: 0;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 148px;
+  padding: 6px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.settings-nav-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--body);
+  text-align: left;
+}
+
+.settings-nav-btn:hover {
+  background: var(--card-soft);
+  color: var(--ink);
+}
+
+.settings-nav-btn.on {
+  background: var(--sage-fill);
+  color: var(--accent-deep);
+  font-weight: 600;
+}
+
+.settings-nav-icon {
+  width: 18px;
+  text-align: center;
+}
+
+.settings-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+/* the visible section starts flush — no orphan divider under the header */
+.settings-content > .keys-section:first-child {
+  border-top: none;
+  padding-top: 0;
 }
 
 .engine-choice {

--- a/apps/desktop/src/renderer/src/icons.tsx
+++ b/apps/desktop/src/renderer/src/icons.tsx
@@ -1,0 +1,167 @@
+/**
+ * Shared UI icon set — hand-inlined stroke icons (lucide-style geometry,
+ * 24×24 viewBox, currentColor) so nothing in the product chrome renders as
+ * an emoji. Sized via the `size` prop; `.ico` handles inline baseline
+ * alignment (see main.css).
+ */
+
+function Icon({
+  children,
+  size = 16
+}: {
+  children: React.ReactNode
+  size?: number
+}): React.JSX.Element {
+  return (
+    <svg
+      className="ico"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  )
+}
+
+export function GearIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+      <circle cx="12" cy="12" r="3" />
+    </Icon>
+  )
+}
+
+export function CalendarIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <rect x="3" y="4" width="18" height="18" rx="2" />
+      <path d="M16 2v4M8 2v4M3 10h18" />
+    </Icon>
+  )
+}
+
+export function CloudIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z" />
+    </Icon>
+  )
+}
+
+export function SparkleIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <path d="m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3L12 3Z" />
+      <path d="M19 3v4M21 5h-4" />
+    </Icon>
+  )
+}
+
+export function HomeIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <path d="M3 10.2a2 2 0 0 1 .7-1.5l7-6a2 2 0 0 1 2.6 0l7 6a2 2 0 0 1 .7 1.5V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+      <path d="M9 21v-6a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v6" />
+    </Icon>
+  )
+}
+
+export function PencilIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <path d="M17 3a2.8 2.8 0 0 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+      <path d="m15 5 4 4" />
+    </Icon>
+  )
+}
+
+export function FolderIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <path d="M3 7a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.7.9l.8 1.2a2 2 0 0 0 1.7.9H19a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+    </Icon>
+  )
+}
+
+export function TrashIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+      <path d="m19 6-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+      <path d="M10 11v6M14 11v6" />
+    </Icon>
+  )
+}
+
+export function DocIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <path d="M14 2v6h6M8 13h8M8 17h5" />
+    </Icon>
+  )
+}
+
+export function MicIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <rect x="9" y="2" width="6" height="12" rx="3" />
+      <path d="M19 10a7 7 0 0 1-14 0M12 17v4" />
+    </Icon>
+  )
+}
+
+export function UsersIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+    </Icon>
+  )
+}
+
+export function MailIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <rect x="2" y="4" width="20" height="16" rx="2" />
+      <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+    </Icon>
+  )
+}
+
+export function ImageIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <circle cx="9" cy="9" r="2" />
+      <path d="m21 15-3.1-3.1a2 2 0 0 0-2.8 0L6 21" />
+    </Icon>
+  )
+}
+
+export function LockIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <rect x="4" y="11" width="16" height="10" rx="2" />
+      <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+    </Icon>
+  )
+}
+
+export function CheckSquareIcon({ size }: { size?: number }): React.JSX.Element {
+  return (
+    <Icon {...(size !== undefined ? { size } : {})}>
+      <path d="m9 11 3 3L22 4" />
+      <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+    </Icon>
+  )
+}

--- a/apps/desktop/src/renderer/src/lib/markdown.ts
+++ b/apps/desktop/src/renderer/src/lib/markdown.ts
@@ -89,6 +89,12 @@ function blockToMarkdown(node: JSONContent, indent: string): string | null {
     }
     case 'horizontalRule':
       return indent + '---'
+    case 'image': {
+      const src = typeof node.attrs?.['src'] === 'string' ? node.attrs['src'] : ''
+      if (!src) return null
+      const alt = typeof node.attrs?.['alt'] === 'string' ? node.attrs['alt'] : ''
+      return `${indent}![${alt.replace(/[[\]]/g, '')}](${src})`
+    }
     default: {
       const text = inlineChildren(node)
       return text.trim().length > 0 ? indent + text : null
@@ -108,6 +114,12 @@ export function docToMarkdown(doc: JSONContent | null | undefined): string {
 }
 
 /* ---- tiny markdown → HTML for displaying enhanced notes ---- */
+
+/**
+ * Only local attachments render as images — the src whitelist keeps
+ * javascript:/http: URLs (e.g. from a pasted markdown doc) inert.
+ */
+const IMAGE_LINE = /^!\[([^\]]*)\]\((doodle-media:\/\/[a-z0-9.-]+)\)$/
 
 function escapeHtml(s: string): string {
   return s
@@ -171,6 +183,12 @@ export function markdownToHtml(md: string): string {
       continue
     }
 
+    const image = IMAGE_LINE.exec(line.trim())
+    if (image) {
+      closeList()
+      out.push(`<img src="${image[2]}" alt="${escapeHtml(image[1] ?? '')}">`)
+      continue
+    }
     const heading = /^(#{1,6})\s+(.*)$/.exec(line)
     if (heading) {
       closeList()

--- a/apps/desktop/src/shared/calendar-api.ts
+++ b/apps/desktop/src/shared/calendar-api.ts
@@ -116,9 +116,12 @@ export interface CalendarStartMeetingEvent {
    *            the OS notification).
    */
   action: 'prompt' | 'start'
+  /** Empty for ad-hoc (mic-detected) meetings — no calendar event to link. */
   eventId: string
   subject: string
   startIso: string
+  /** True when detected from mic activity rather than the calendar. */
+  adHoc?: boolean
 }
 
 /** API surface exposed on `window.calendar` by the preload script. */

--- a/apps/desktop/src/shared/detect-api.ts
+++ b/apps/desktop/src/shared/detect-api.ts
@@ -1,0 +1,21 @@
+export const DETECT_GET_STATE_CHANNEL = 'detect:get-state'
+export const DETECT_SET_PREFS_CHANNEL = 'detect:set-prefs'
+
+export interface DetectState {
+  /** DoodleNote starts when you log in to your Mac (OS is source of truth). */
+  loginItem: boolean
+  /** Prompt when another app holds the microphone open (ad-hoc meetings). */
+  micDetect: boolean
+  /** The engine micmon child is currently alive (diagnostic). */
+  micMonitorAlive: boolean
+}
+
+export interface DetectPrefsUpdate {
+  loginItem?: boolean
+  micDetect?: boolean
+}
+
+export interface DetectApi {
+  getState(): Promise<DetectState>
+  setPrefs(update: DetectPrefsUpdate): Promise<DetectState>
+}

--- a/apps/desktop/src/shared/media-api.ts
+++ b/apps/desktop/src/shared/media-api.ts
@@ -1,0 +1,22 @@
+export const MEDIA_SAVE_CHANNEL = 'media:save'
+
+/** Mime types the editor accepts; anything else is rejected on save. */
+export const MEDIA_ACCEPTED_MIME: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp'
+}
+
+export interface MediaSaveRequest {
+  /** Raw file bytes (structured-clone transfers ArrayBuffer over IPC). */
+  bytes: ArrayBuffer
+  mime: string
+}
+
+export type MediaSaveResult = { url: string } | { error: string }
+
+export interface MediaApi {
+  /** Persist an image to the local attachments store; returns a doodle-media:// URL. */
+  save(request: MediaSaveRequest): Promise<MediaSaveResult>
+}

--- a/apps/desktop/src/shared/meetings-api.ts
+++ b/apps/desktop/src/shared/meetings-api.ts
@@ -25,6 +25,12 @@ export interface MeetingChatEntry {
 /** Full meeting document as stored on disk. */
 export interface MeetingRecord {
   id: string
+  /**
+   * What this document is: a meeting (default when absent) or a standalone
+   * quick note ("+ New note" — same editor and optional recording, but
+   * created without a meeting context and never auto-recorded).
+   */
+  kind?: 'meeting' | 'note'
   title: string
   /** ISO timestamp of creation ("+ New meeting"). */
   createdAt: string
@@ -55,6 +61,8 @@ export interface MeetingRecord {
 /** Lightweight row for the Home list, sorted newest-first. */
 export interface MeetingSummary {
   id: string
+  /** "note" marks standalone quick notes; absent = meeting. */
+  kind?: 'meeting' | 'note'
   title: string
   createdAt: string
   startedAt?: string

--- a/engine/Sources/engine/EngineMain.swift
+++ b/engine/Sources/engine/EngineMain.swift
@@ -22,6 +22,8 @@ struct EngineMain {
                 try await LiveCommand.run(options)
             case "preflight":
                 await PreflightCommand.run()
+            case "micmon":
+                MicMonitorCommand.run()
             case "info":
                 Commands.info()
             default:

--- a/engine/Sources/engine/MicMonitorCommand.swift
+++ b/engine/Sources/engine/MicMonitorCommand.swift
@@ -1,0 +1,92 @@
+import CoreAudio
+import Foundation
+
+/// Emits `{"event":"micmon","running":<bool>}` whenever any process starts or
+/// stops capturing from the default input device (CoreAudio's
+/// DeviceIsRunningSomewhere). The app uses this to detect "you're in a
+/// meeting" moments — Zoom/Teams/Meet hold the mic open for the whole call.
+/// Runs until stdin closes (it only ever exists as a child of the app).
+enum MicMonitorCommand {
+    private static var deviceId = AudioObjectID(kAudioObjectUnknown)
+    private static var lastRunning: Bool?
+    private static let queue = DispatchQueue(label: "micmon")
+
+    private static var runningAddress = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    private static var defaultDeviceAddress = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDefaultInputDevice,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+
+    static func run() {
+        // Parent-death watchdog: the host spawns us with a live stdin pipe;
+        // EOF means it is gone and we must not linger.
+        Thread {
+            while true {
+                let data = FileHandle.standardInput.availableData
+                if data.isEmpty { break }
+            }
+            exit(0)
+        }.start()
+
+        // Re-arm when the default input device changes (AirPods in/out etc.).
+        AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject), &defaultDeviceAddress, queue
+        ) { _, _ in
+            armDeviceListener()
+            emitIfChanged()
+        }
+
+        armDeviceListener()
+        emitCurrent()
+        RunLoop.main.run()
+    }
+
+    private static func armDeviceListener() {
+        let next = currentDefaultInputDevice()
+        guard next != deviceId else { return }
+        if deviceId != AudioObjectID(kAudioObjectUnknown) {
+            AudioObjectRemovePropertyListenerBlock(deviceId, &runningAddress, queue, runningChanged)
+        }
+        deviceId = next
+        guard deviceId != AudioObjectID(kAudioObjectUnknown) else { return }
+        AudioObjectAddPropertyListenerBlock(deviceId, &runningAddress, queue, runningChanged)
+    }
+
+    private static let runningChanged: AudioObjectPropertyListenerBlock = { _, _ in
+        emitIfChanged()
+    }
+
+    private static func currentDefaultInputDevice() -> AudioObjectID {
+        var id = AudioObjectID(kAudioObjectUnknown)
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &defaultDeviceAddress, 0, nil, &size, &id
+        )
+        return status == noErr ? id : AudioObjectID(kAudioObjectUnknown)
+    }
+
+    private static func isRunningSomewhere() -> Bool {
+        guard deviceId != AudioObjectID(kAudioObjectUnknown) else { return false }
+        var running: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        let status = AudioObjectGetPropertyData(deviceId, &runningAddress, 0, nil, &size, &running)
+        return status == noErr && running != 0
+    }
+
+    private static func emitCurrent() {
+        lastRunning = isRunningSomewhere()
+        Events.emit(["event": "micmon", "running": lastRunning ?? false])
+    }
+
+    private static func emitIfChanged() {
+        let running = isRunningSomewhere()
+        guard running != lastRunning else { return }
+        lastRunning = running
+        Events.emit(["event": "micmon", "running": running])
+    }
+}

--- a/engine/Sources/engine/MicMonitorCommand.swift
+++ b/engine/Sources/engine/MicMonitorCommand.swift
@@ -1,15 +1,18 @@
 import CoreAudio
 import Foundation
 
-/// Emits `{"event":"micmon","running":<bool>}` whenever any process starts or
-/// stops capturing from the default input device (CoreAudio's
-/// DeviceIsRunningSomewhere). The app uses this to detect "you're in a
-/// meeting" moments — Zoom/Teams/Meet hold the mic open for the whole call.
-/// Runs until stdin closes (it only ever exists as a child of the app).
+/// Emits `{"event":"micmon","running":<bool>,"bundles":[<bundle ids>]}`
+/// whenever the set of processes capturing from the microphone changes.
+/// On macOS 14.4+ the bundle ids identify WHO holds the mic, so the app can
+/// prompt for Zoom/Teams/Meet but ignore dictation tools; on older systems
+/// bundles is empty and the host stays conservative. Runs until stdin closes
+/// (it only ever exists as a child of the app).
 enum MicMonitorCommand {
     private static var deviceId = AudioObjectID(kAudioObjectUnknown)
     private static var lastRunning: Bool?
+    private static var lastBundles: Set<String> = []
     private static let queue = DispatchQueue(label: "micmon")
+    private static var timer: DispatchSourceTimer?
 
     private static var runningAddress = AudioObjectPropertyAddress(
         mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
@@ -42,6 +45,16 @@ enum MicMonitorCommand {
         }
 
         armDeviceListener()
+
+        // The capturing-process SET can change without the device-level
+        // running flag flipping (a Zoom call joining mid-dictation) — a slow
+        // poll catches those transitions; the listeners catch sharp edges.
+        let poll = DispatchSource.makeTimerSource(queue: queue)
+        poll.schedule(deadline: .now() + 5, repeating: 5)
+        poll.setEventHandler { emitIfChanged() }
+        poll.resume()
+        timer = poll
+
         emitCurrent()
         RunLoop.main.run()
     }
@@ -78,15 +91,76 @@ enum MicMonitorCommand {
         return status == noErr && running != 0
     }
 
+    /// Bundle ids of every process currently capturing audio input.
+    private static func capturingBundles() -> Set<String> {
+        guard #available(macOS 14.4, *) else { return [] }
+        var listAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyProcessObjectList,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let system = AudioObjectID(kAudioObjectSystemObject)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(system, &listAddress, 0, nil, &size) == noErr,
+            size > 0
+        else { return [] }
+        var processes = [AudioObjectID](
+            repeating: 0, count: Int(size) / MemoryLayout<AudioObjectID>.size)
+        guard AudioObjectGetPropertyData(system, &listAddress, 0, nil, &size, &processes) == noErr
+        else { return [] }
+
+        var bundles: Set<String> = []
+        for process in processes {
+            var inputAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioProcessPropertyIsRunningInput,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            var running: UInt32 = 0
+            var runningSize = UInt32(MemoryLayout<UInt32>.size)
+            guard
+                AudioObjectGetPropertyData(
+                    process, &inputAddress, 0, nil, &runningSize, &running) == noErr,
+                running != 0
+            else { continue }
+
+            var bundleAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioProcessPropertyBundleID,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            var bundle: CFString? = nil
+            var bundleSize = UInt32(MemoryLayout<CFString?>.size)
+            let status = withUnsafeMutablePointer(to: &bundle) { pointer in
+                AudioObjectGetPropertyData(process, &bundleAddress, 0, nil, &bundleSize, pointer)
+            }
+            if status == noErr, let bundle = bundle as String?, !bundle.isEmpty {
+                bundles.insert(bundle)
+            }
+        }
+        return bundles
+    }
+
     private static func emitCurrent() {
         lastRunning = isRunningSomewhere()
-        Events.emit(["event": "micmon", "running": lastRunning ?? false])
+        lastBundles = capturingBundles()
+        emit()
     }
 
     private static func emitIfChanged() {
         let running = isRunningSomewhere()
-        guard running != lastRunning else { return }
+        let bundles = capturingBundles()
+        guard running != lastRunning || bundles != lastBundles else { return }
         lastRunning = running
-        Events.emit(["event": "micmon", "running": running])
+        lastBundles = bundles
+        emit()
+    }
+
+    private static func emit() {
+        Events.emit([
+            "event": "micmon",
+            "running": lastRunning ?? false,
+            "bundles": lastBundles.sorted()
+        ])
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@repo/ai':
         specifier: workspace:*
         version: link:../../packages/ai
+      '@tiptap/extension-image':
+        specifier: ^3.27.2
+        version: 3.27.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
       node-llama-cpp:
         specifier: ^3.19.0
         version: 3.19.0(typescript@5.9.3)
@@ -138,7 +141,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.10
-        version: 16.2.10(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.10(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.3.2
@@ -1805,6 +1808,11 @@ packages:
     peerDependencies:
       '@tiptap/core': 3.27.1
       '@tiptap/pm': 3.27.1
+
+  '@tiptap/extension-image@3.27.2':
+    resolution: {integrity: sha512-xnDCj+9oNwr4Zh9B+HHi+9lXyUVYv2KmCF3QuCdGxhZA4FDNlJT3gISwYnH4LNtKSD1XHh/gSCMTpZF+8oqe3g==}
+    peerDependencies:
+      '@tiptap/core': 3.27.2
 
   '@tiptap/extension-italic@3.27.1':
     resolution: {integrity: sha512-jGGeyn9uRUnNjSTHpbqhiGsp6KaYTSbV09jDXPJI9cDwfV9hpugLvpaCZd0BMBbhU1B1W6kOfX0BE15qX/HQfA==}
@@ -6203,6 +6211,10 @@ snapshots:
       '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
       '@tiptap/pm': 3.27.1
 
+  '@tiptap/extension-image@3.27.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+
   '@tiptap/extension-italic@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
     dependencies:
       '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
@@ -7469,13 +7481,13 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.2.10(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  eslint-config-next@16.2.10(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.10
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -7501,7 +7513,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7512,22 +7524,21 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7538,7 +7549,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -7549,8 +7560,6 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
Re-created from #5, which GitHub auto-closed when its stacked base branch (#4) merged and was deleted.

Everything from today's desktop feature run:
- **Coming up** shows today + tomorrow (chevrons page by two days)
- **Quick notes**: `+ New note` — same editor + optional recording/transcript/Generate, never auto-records
- **Formatting toolbar + images**: paste/drag/pick, stored locally, served over `doodle-media://`, markdown round-trip with src whitelist
- **Meeting detection**: floating always-on-top prompt panel when the window is buried, launch-at-login toggle, mic-activity detection via engine `micmon` — bundle-attributed (macOS 14.4+) so only real meeting apps prompt; dictation tools like FluidVoice are ignored
- **Settings redesign**: nav rail (General / Calendar / Cloud sync / Notes model), one section at a time
- **Production icon set**: shared SVG stroke icons replace every emoji icon app-wide

Gates: desktop typecheck/build/test (35/35), engine builds, web typecheck/build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)