### PR TITLE
Note templates, auto-generate on meeting end, share links

### DIFF
--- a/apps/desktop/src/main/meetings-service.ts
+++ b/apps/desktop/src/main/meetings-service.ts
@@ -138,6 +138,9 @@ function normalizeRecord(raw: MeetingUpsert): MeetingRecord {
     rawNotesMarkdown: typeof raw.rawNotesMarkdown === 'string' ? raw.rawNotesMarkdown : '',
     ...(typeof raw.enhancedMarkdown === 'string' ? { enhancedMarkdown: raw.enhancedMarkdown } : {}),
     ...(typeof raw.engine === 'string' ? { engine: raw.engine } : {}),
+    ...(typeof raw.templateId === 'string' && raw.templateId.length > 0
+      ? { templateId: raw.templateId }
+      : {}),
     segments: Array.isArray(raw.segments) ? (raw.segments as TranscriptSegment[]) : [],
     echoSuppressed: typeof raw.echoSuppressed === 'number' ? raw.echoSuppressed : 0,
     ...(Array.isArray(raw.chat) ? { chat: raw.chat.filter(isChatEntry) } : {}),

--- a/apps/desktop/src/main/notes-service.ts
+++ b/apps/desktop/src/main/notes-service.ts
@@ -19,6 +19,7 @@ import {
   NOTES_ASK_TOKEN_CHANNEL,
   NOTES_DOWNLOAD_PROGRESS_CHANNEL,
   NOTES_ENHANCE_CHANNEL,
+  NOTES_TEMPLATES_CHANNEL,
   NOTES_ENHANCE_TOKEN_CHANNEL,
   NOTES_GET_SETTINGS_CHANNEL,
   NOTES_GLOBAL_CHAT_CLEAR_CHANNEL,
@@ -112,6 +113,10 @@ export class NotesService {
     ipcMain.handle(NOTES_SET_SETTINGS_CHANNEL, (_event, update: unknown) =>
       this.applySettings((update ?? {}) as NotesSettingsUpdate)
     )
+    ipcMain.handle(NOTES_TEMPLATES_CHANNEL, async () => {
+      const { NOTE_TEMPLATES } = await import('@repo/ai')
+      return NOTE_TEMPLATES.map((t) => ({ id: t.id, label: t.label, description: t.description }))
+    })
     ipcMain.handle(NOTES_ENHANCE_CHANNEL, (_event, request: unknown) =>
       this.enhance((request ?? {}) as EnhanceRequest)
     )
@@ -262,7 +267,8 @@ export class NotesService {
         rawNotesMarkdown:
           typeof request.rawNotesMarkdown === 'string' ? request.rawNotesMarkdown : '',
         segments: kept.map((s) => ({ speaker: s.speaker, text: s.text, startMs: s.startMs })),
-        ...(kept.length > 0 ? { durationMs: Math.max(...kept.map((s) => s.endMs)) } : {})
+        ...(kept.length > 0 ? { durationMs: Math.max(...kept.map((s) => s.endMs)) } : {}),
+        ...(typeof request.templateId === 'string' ? { templateId: request.templateId } : {})
       }
       const engine = this.pickEngine()
       const result = await engine.generateNotes(input, (token) => {

--- a/apps/desktop/src/main/sync-service.ts
+++ b/apps/desktop/src/main/sync-service.ts
@@ -7,11 +7,13 @@ import { ipcMain, safeStorage, shell } from 'electron'
 import type { MeetingRecord } from '../shared/meetings-api'
 import {
   SYNC_CONNECT_CHANNEL,
+  SYNC_SHARE_CHANNEL,
   SYNC_DISCONNECT_CHANNEL,
   SYNC_GET_STATUS_CHANNEL,
   SYNC_NOW_CHANNEL,
   SYNC_SET_ENABLED_CHANNEL,
   SYNC_STATUS_EVENT_CHANNEL,
+  type ShareResult,
   type SyncStatus
 } from '../shared/sync-api'
 import type { MeetingsService } from './meetings-service'
@@ -69,6 +71,9 @@ export class SyncService {
       this.setEnabled(Boolean(enabled))
     )
     ipcMain.handle(SYNC_NOW_CHANNEL, () => this.syncNow())
+    ipcMain.handle(SYNC_SHARE_CHANNEL, (_event, meetingId: unknown) =>
+      this.share(String(meetingId))
+    )
 
     setInterval(() => {
       if (this.config.enabled && this.token()) void this.pushAll()
@@ -206,6 +211,48 @@ export class SyncService {
     if (this.config.enabled) void this.pushAll()
     this.emitStatus()
     return this.status()
+  }
+
+  /**
+   * Push the meeting fresh (the shared page must show current content),
+   * then mint or fetch its public share link.
+   */
+  async share(meetingId: string): Promise<ShareResult> {
+    const token = this.token()
+    if (!token) return { error: 'Connect cloud sync in Settings first' }
+    const record = this.meetings
+      .readAll()
+      .find((r) => r.id === meetingId && !r.trashedAt)
+    if (!record) return { error: 'Meeting not found' }
+
+    try {
+      const pushResponse = await fetch(`${this.baseUrl}/api/sync/push`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ meetings: [toPushMeeting(record)] })
+      })
+      if (!pushResponse.ok) {
+        return { error: `Could not sync the meeting (HTTP ${pushResponse.status})` }
+      }
+      this.config.pushed[record.id] = contentHash(record)
+      this.writeConfig()
+
+      const shareResponse = await fetch(`${this.baseUrl}/api/sync/share`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ meetingId, enable: true })
+      })
+      const body = (await shareResponse.json().catch(() => ({}))) as {
+        url?: string
+        error?: string
+      }
+      if (!shareResponse.ok || typeof body.url !== 'string') {
+        return { error: body.error ?? `Share failed (HTTP ${shareResponse.status})` }
+      }
+      return { url: body.url }
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : 'Share failed' }
+    }
   }
 
   async syncNow(): Promise<SyncStatus> {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -23,6 +23,7 @@ import {
   NOTES_GLOBAL_CHAT_GET_CHANNEL,
   NOTES_MODELS_CHANNEL,
   NOTES_SET_SETTINGS_CHANNEL,
+  NOTES_TEMPLATES_CHANNEL,
   type ActivateModelResult,
   type AskRequest,
   type AskResult,
@@ -38,7 +39,8 @@ import {
   type NotesApi,
   type NotesModelsResponse,
   type NotesSettingsUpdate,
-  type NotesSettingsView
+  type NotesSettingsView,
+  type NotesTemplateInfo
 } from '../shared/notes-api'
 import {
   MEETINGS_DELETE_CHANNEL,
@@ -82,8 +84,10 @@ import {
   SYNC_DISCONNECT_CHANNEL,
   SYNC_GET_STATUS_CHANNEL,
   SYNC_NOW_CHANNEL,
+  SYNC_SHARE_CHANNEL,
   SYNC_SET_ENABLED_CHANNEL,
   SYNC_STATUS_EVENT_CHANNEL,
+  type ShareResult,
   type SyncApi,
   type SyncStatus
 } from '../shared/sync-api'
@@ -135,6 +139,10 @@ function subscribe<T>(channel: string, cb: (payload: T) => void): () => void {
 }
 
 const notesApi: NotesApi = {
+  templates(): Promise<NotesTemplateInfo[]> {
+    return ipcRenderer.invoke(NOTES_TEMPLATES_CHANNEL) as Promise<NotesTemplateInfo[]>
+  },
+
   models(): Promise<NotesModelsResponse> {
     return ipcRenderer.invoke(NOTES_MODELS_CHANNEL) as Promise<NotesModelsResponse>
   },
@@ -259,6 +267,10 @@ const calendarApi: CalendarApi = {
 }
 
 const syncApi: SyncApi = {
+  share(meetingId: string): Promise<ShareResult> {
+    return ipcRenderer.invoke(SYNC_SHARE_CHANNEL, meetingId) as Promise<ShareResult>
+  },
+
   getStatus(): Promise<SyncStatus> {
     return ipcRenderer.invoke(SYNC_GET_STATUS_CHANNEL) as Promise<SyncStatus>
   },

--- a/apps/desktop/src/renderer/src/HomeView.tsx
+++ b/apps/desktop/src/renderer/src/HomeView.tsx
@@ -363,6 +363,30 @@ export default function HomeView({
   /** Meeting id whose ⋯ menu is open, and whose folder picker is open. */
   const [menuFor, setMenuFor] = useState<string | null>(null)
   const [pickerFor, setPickerFor] = useState<string | null>(null)
+  /** Transient share feedback: message shown as a toast under the topbar. */
+  const [shareNotice, setShareNotice] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (shareNotice === null) return
+    const timer = setTimeout(() => setShareNotice(null), 6000)
+    return () => clearTimeout(timer)
+  }, [shareNotice])
+
+  const copyShareLink = async (id: string): Promise<void> => {
+    setMenuFor(null)
+    setShareNotice('Creating share link…')
+    const result = await window.sync.share(id)
+    if ('url' in result) {
+      try {
+        await navigator.clipboard.writeText(result.url)
+        setShareNotice('Share link copied to clipboard ✓')
+      } catch {
+        setShareNotice(result.url) // clipboard blocked — at least show it
+      }
+    } else {
+      setShareNotice(result.error)
+    }
+  }
 
   /* ---- cross-meeting "ask anything" (thread persisted by main) ---- */
   const [chatOpen, setChatOpen] = useState(false)
@@ -596,6 +620,12 @@ export default function HomeView({
         </button>
       </div>
 
+      {shareNotice !== null && (
+        <div className="share-notice" role="status">
+          {shareNotice}
+        </div>
+      )}
+
       <div className="home-scroll">
         <div className="home-col">
           {filter.kind === 'all' && (
@@ -711,11 +741,12 @@ export default function HomeView({
                       )}
                       {menuOpen && (
                         <div className="row-menu" onClick={(e) => e.stopPropagation()}>
-                          <button type="button" disabled title="Coming with cloud sync">
-                            Copy link
-                          </button>
-                          <button type="button" disabled title="Coming with cloud sync">
-                            Share
+                          <button
+                            type="button"
+                            title="Copy a public link to this meeting's notes"
+                            onClick={() => void copyShareLink(m.id)}
+                          >
+                            Copy share link
                           </button>
                           <button
                             type="button"

--- a/apps/desktop/src/renderer/src/MeetingView.tsx
+++ b/apps/desktop/src/renderer/src/MeetingView.tsx
@@ -7,7 +7,11 @@ import { Placeholder } from '@tiptap/extensions'
 import type { EngineChannel, EngineEvent, TranscriptSegment } from '../../shared/engine-events'
 import type { FolderRecord } from '../../shared/folders-api'
 import type { MeetingChatEntry, MeetingRecord } from '../../shared/meetings-api'
-import type { NotesModelsResponse, NotesSettingsView } from '../../shared/notes-api'
+import type {
+  NotesModelsResponse,
+  NotesSettingsView,
+  NotesTemplateInfo
+} from '../../shared/notes-api'
 import FolderPicker from './FolderPicker'
 import FormatToolbar from './FormatToolbar'
 import {
@@ -320,6 +324,8 @@ export default function MeetingView({
       setSavedSegments(record.segments.filter((s) => !s.echo))
       setSavedEcho(record.echoSuppressed)
       startedAtRef.current = record.startedAt ?? null
+      setTemplateId(record.templateId ?? 'general')
+      templateIdRef.current = record.templateId ?? 'general'
       setFolderId(record.folderId ?? null)
       if (record.enhancedMarkdown) setEnhancedMarkdown(record.enhancedMarkdown)
       if (Array.isArray(record.chat) && record.chat.length > 0) {
@@ -435,17 +441,54 @@ export default function MeetingView({
   const phase = state.phase
   const capturing = ACTIVE_PHASES.includes(phase)
 
+  /* ---- note templates ---- */
+
+  const [templates, setTemplates] = useState<NotesTemplateInfo[]>([])
+  const [templateId, setTemplateId] = useState('general')
+  const templateIdRef = useRef('general')
+  const [tplMenuOpen, setTplMenuOpen] = useState(false)
+
+  useEffect(() => {
+    void window.notes
+      .templates()
+      .then(setTemplates)
+      .catch(() => setTemplates([]))
+  }, [])
+
+  // Close the template menu on outside click or Escape.
+  useEffect(() => {
+    if (!tplMenuOpen) return
+    const onDown = (e: MouseEvent): void => {
+      const target = e.target as HTMLElement | null
+      if (target?.closest('.tpl-menu') || target?.closest('.tpl-anchor')) return
+      setTplMenuOpen(false)
+    }
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setTplMenuOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [tplMenuOpen])
+
   /* ---- auto-stop when the meeting app hangs up (Granola-style) ---- */
 
   const [autoStopped, setAutoStopped] = useState(false)
   const capturingRef = useRef(false)
   capturingRef.current = capturing
 
+  /** Meeting ended → after the capture settles, generate notes on their own. */
+  const pendingAutoGenRef = useRef(false)
+
   useEffect(() => {
     return window.detect.onMeetingEnded(() => {
       if (!capturingRef.current) return
       window.engine.stop()
       setAutoStopped(true)
+      pendingAutoGenRef.current = true
     })
   }, [])
 
@@ -575,7 +618,8 @@ export default function MeetingView({
     const result = await window.notes.enhance({
       title: titleValueRef.current.trim() || 'New meeting',
       rawNotesMarkdown: roughMarkdownRef.current,
-      segments: allSegments
+      segments: allSegments,
+      templateId: templateIdRef.current
     })
     if (result.error !== undefined || result.markdown === undefined) {
       setEnhanceStatus('error')
@@ -592,6 +636,44 @@ export default function MeetingView({
     docViewRef.current = 'enhanced'
     setEditorMarkdown(result.markdown, false)
   }
+
+  /** Pick a template: remember it on the meeting and (re)generate with it. */
+  const chooseTemplate = (id: string): void => {
+    setTemplateId(id)
+    templateIdRef.current = id
+    setTplMenuOpen(false)
+    persist({ templateId: id })
+    void runEnhance()
+  }
+
+  const templateMenu = (
+    <div className="tpl-menu" role="menu" aria-label="Note templates">
+      {templates.map((t) => (
+        <button
+          key={t.id}
+          type="button"
+          role="menuitemradio"
+          aria-checked={t.id === templateId}
+          className={t.id === templateId ? 'tpl-item on' : 'tpl-item'}
+          onClick={() => chooseTemplate(t.id)}
+        >
+          <span className="tpl-item-label">{t.label}</span>
+          <span className="tpl-item-desc">{t.description}</span>
+        </button>
+      ))}
+    </div>
+  )
+
+  // Granola-style: notes appear on their own after the meeting ends. Waits
+  // for the stop to settle (capturing false, segments folded) and the model
+  // to be ready; skips silently when there is nothing to write from.
+  useEffect(() => {
+    if (!pendingAutoGenRef.current || capturing) return
+    if (enhanceStatus === 'running') return
+    if (allSegments.length === 0 || !modelReady) return
+    pendingAutoGenRef.current = false
+    void runEnhance()
+  })
 
   const showNotesDoc = (): void => {
     if (docView === 'notes') return
@@ -853,6 +935,21 @@ export default function MeetingView({
                 {enhanceStatus === 'running' ? <span className="spinner" aria-hidden="true" /> : '↻'}
               </button>
             )}
+            {enhancedMarkdown !== null && !capturing && (
+              <span className="chip-template-anchor tpl-anchor">
+                <button
+                  type="button"
+                  className="chip"
+                  disabled={!canEnhance}
+                  title="Regenerate with a different template"
+                  aria-expanded={tplMenuOpen}
+                  onClick={() => setTplMenuOpen((o) => !o)}
+                >
+                  {templates.find((t) => t.id === templateId)?.label ?? 'Template'} ▾
+                </button>
+                {tplMenuOpen && templateMenu}
+              </span>
+            )}
             {enhancedMarkdown !== null && enhanceStatus === 'running' && (
               <span className="chip-regen-status">
                 {streamedWords > 0 ? `Writing… ${streamedWords} words` : 'Generating…'}
@@ -1040,24 +1137,38 @@ export default function MeetingView({
       )}
 
       {!capturing && allSegments.length > 0 && enhancedMarkdown === null && (
-        <button
-          type="button"
-          className="generate-cta"
-          disabled={!canEnhance}
-          title={!modelReady ? 'Activate a notes model in Settings first' : 'Generate notes'}
-          onClick={() => void runEnhance()}
-        >
-          {enhanceStatus === 'running' ? (
-            <>
-              <span className="spinner" aria-hidden="true" />
-              {streamedWords > 0 ? `Writing… ${streamedWords} words` : 'Generating…'}
-            </>
-          ) : (
-            <>
-              <SparkleIcon size={14} /> Generate notes
-            </>
-          )}
-        </button>
+        <div className="generate-cta-wrap tpl-anchor">
+          <button
+            type="button"
+            className="generate-cta"
+            disabled={!canEnhance}
+            title={!modelReady ? 'Activate a notes model in Settings first' : 'Generate notes'}
+            onClick={() => void runEnhance()}
+          >
+            {enhanceStatus === 'running' ? (
+              <>
+                <span className="spinner" aria-hidden="true" />
+                {streamedWords > 0 ? `Writing… ${streamedWords} words` : 'Generating…'}
+              </>
+            ) : (
+              <>
+                <SparkleIcon size={14} /> Generate notes
+              </>
+            )}
+          </button>
+          <button
+            type="button"
+            className="generate-cta generate-cta-arrow"
+            disabled={!canEnhance}
+            title="Choose a note template"
+            aria-label="Choose a note template"
+            aria-expanded={tplMenuOpen}
+            onClick={() => setTplMenuOpen((o) => !o)}
+          >
+            ▾
+          </button>
+          {tplMenuOpen && templateMenu}
+        </div>
       )}
 
       <div className="bottom-bar">

--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -2854,21 +2854,113 @@ button.fp-row:hover {
 }
 
 /* generate-notes CTA (Granola-style centered button above the pill bar) */
-.generate-cta {
+.generate-cta-wrap {
   position: absolute;
   left: 50%;
   bottom: 96px;
   transform: translateX(-50%);
+  display: flex;
+  gap: 2px;
+  z-index: 5;
+}
+
+.generate-cta {
   background: #5f7247;
   border: none;
   color: #fdfcf8;
   font-size: 13.5px;
   font-weight: 600;
   padding: 10px 22px;
-  border-radius: 999px;
+  border-radius: 999px 0 0 999px;
   box-shadow: 0 6px 20px rgba(38, 40, 31, 0.18);
   cursor: pointer;
-  z-index: 5;
+}
+
+.generate-cta-arrow {
+  padding: 10px 14px;
+  border-radius: 0 999px 999px 0;
+  font-size: 11px;
+}
+
+/* share-link toast on Home */
+.share-notice {
+  position: absolute;
+  top: 56px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 40;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: var(--shadow-pill);
+  padding: 7px 16px;
+  font-size: 12.5px;
+  color: var(--ink);
+  max-width: 70%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* template picker (shared by the CTA and the regenerate chip) */
+.tpl-anchor {
+  position: relative;
+}
+
+.tpl-menu {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 280px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 5px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow-panel);
+  z-index: 30;
+}
+
+.chip-template-anchor .tpl-menu {
+  bottom: auto;
+  top: calc(100% + 8px);
+  left: 0;
+  transform: none;
+}
+
+.tpl-item {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  width: 100%;
+  text-align: left;
+  padding: 7px 10px;
+  border-radius: 8px;
+}
+
+.tpl-item:hover {
+  background: var(--card-soft);
+}
+
+.tpl-item.on {
+  background: var(--sage-fill);
+}
+
+.tpl-item-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.tpl-item.on .tpl-item-label {
+  color: var(--accent-deep);
+}
+
+.tpl-item-desc {
+  font-size: 11.5px;
+  color: var(--muted);
 }
 
 .generate-cta:hover:not(:disabled) {

--- a/apps/desktop/src/shared/meetings-api.ts
+++ b/apps/desktop/src/shared/meetings-api.ts
@@ -44,6 +44,8 @@ export interface MeetingRecord {
   enhancedMarkdown?: string
   /** Which notes engine produced enhancedMarkdown (e.g. "local:…"). */
   engine?: string
+  /** Note template used for Generate notes; absent = "general". */
+  templateId?: string
   /** Interleaved You/Them transcript segments (echo-flagged ones excluded). */
   segments: TranscriptSegment[]
   /** How many echo segments were suppressed across the session(s). */

--- a/apps/desktop/src/shared/notes-api.ts
+++ b/apps/desktop/src/shared/notes-api.ts
@@ -10,6 +10,7 @@
 import type { TranscriptSegment } from './engine-events'
 
 export const NOTES_MODELS_CHANNEL = 'notes:models'
+export const NOTES_TEMPLATES_CHANNEL = 'notes:templates'
 export const NOTES_ACTIVATE_MODEL_CHANNEL = 'notes:activate-model'
 export const NOTES_GET_SETTINGS_CHANNEL = 'notes:get-settings'
 export const NOTES_SET_SETTINGS_CHANNEL = 'notes:set-settings'
@@ -87,6 +88,15 @@ export interface EnhanceRequest {
   title: string
   rawNotesMarkdown: string
   segments: TranscriptSegment[]
+  /** Note template shaping the output; default "general". */
+  templateId?: string
+}
+
+/** Template list for the Generate-notes picker (catalog lives in @repo/ai). */
+export interface NotesTemplateInfo {
+  id: string
+  label: string
+  description: string
 }
 
 /** Errors come back as a value, never as a rejected promise. */
@@ -167,6 +177,7 @@ export interface GlobalAskTokenEvent {
 
 /** API surface exposed on `window.notes` by the preload script. */
 export interface NotesApi {
+  templates(): Promise<NotesTemplateInfo[]>
   models(): Promise<NotesModelsResponse>
   activateModel(modelId: string): Promise<ActivateModelResult>
   getSettings(): Promise<NotesSettingsView>

--- a/apps/desktop/src/shared/sync-api.ts
+++ b/apps/desktop/src/shared/sync-api.ts
@@ -3,6 +3,7 @@ export const SYNC_CONNECT_CHANNEL = 'sync:connect'
 export const SYNC_DISCONNECT_CHANNEL = 'sync:disconnect'
 export const SYNC_SET_ENABLED_CHANNEL = 'sync:set-enabled'
 export const SYNC_NOW_CHANNEL = 'sync:now'
+export const SYNC_SHARE_CHANNEL = 'sync:share'
 export const SYNC_STATUS_EVENT_CHANNEL = 'sync:status-event'
 
 export interface SyncStatus {
@@ -26,7 +27,11 @@ export interface SyncStatus {
   linking: boolean
 }
 
+export type ShareResult = { url: string } | { error: string }
+
 export interface SyncApi {
+  /** Push the meeting (fresh) and mint/fetch its public share link. */
+  share(meetingId: string): Promise<ShareResult>
   getStatus(): Promise<SyncStatus>
   /** Opens the browser link flow; resolves when linked, failed, or timed out. */
   connect(): Promise<SyncStatus>

--- a/apps/web/app/api/sync/share/route.ts
+++ b/apps/web/app/api/sync/share/route.ts
@@ -1,0 +1,70 @@
+import { randomBytes } from "node:crypto";
+
+import { NextResponse } from "next/server";
+import { and, eq, getDb, meetings } from "@repo/db";
+
+import { authenticateSyncRequest } from "@/lib/sync-auth";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Canonical public origin for share URLs. */
+function shareOrigin(request: Request): string {
+  return process.env.BETTER_AUTH_URL ?? new URL(request.url).origin;
+}
+
+/**
+ * Enable/disable the public share link for a meeting. Bearer-authenticated
+ * (desktop sync token); the meeting must belong to the token's workspace.
+ */
+export async function POST(request: Request) {
+  const device = await authenticateSyncRequest(request);
+  if (!device) {
+    return NextResponse.json({ error: "Invalid sync token" }, { status: 401 });
+  }
+
+  let body: { meetingId?: unknown; enable?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const meetingId = String(body.meetingId ?? "");
+  if (!UUID_RE.test(meetingId)) {
+    return NextResponse.json({ error: "meetingId must be a UUID" }, { status: 400 });
+  }
+  const enable = body.enable !== false;
+
+  const db = getDb();
+  const rows = await db
+    .select({ id: meetings.id, shareToken: meetings.shareToken })
+    .from(meetings)
+    .where(
+      and(eq(meetings.id, meetingId), eq(meetings.organizationId, device.organizationId)),
+    )
+    .limit(1);
+  const meeting = rows[0];
+  if (!meeting) {
+    return NextResponse.json(
+      { error: "Meeting not synced yet — sync it first" },
+      { status: 404 },
+    );
+  }
+
+  if (!enable) {
+    await db
+      .update(meetings)
+      .set({ shareToken: null })
+      .where(eq(meetings.id, meetingId));
+    return NextResponse.json({ ok: true, url: null });
+  }
+
+  const token = meeting.shareToken ?? randomBytes(16).toString("hex");
+  if (!meeting.shareToken) {
+    await db
+      .update(meetings)
+      .set({ shareToken: token })
+      .where(eq(meetings.id, meetingId));
+  }
+  return NextResponse.json({ ok: true, url: `${shareOrigin(request)}/share/${token}` });
+}

--- a/apps/web/app/share/[token]/page.tsx
+++ b/apps/web/app/share/[token]/page.tsx
@@ -1,0 +1,138 @@
+import Image from "next/image";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import ReactMarkdown from "react-markdown";
+import { asc, eq, getDb, meetings, notes, transcriptSegments } from "@repo/db";
+
+export const metadata = { title: "Shared meeting — DoodleNote" };
+
+const TOKEN_RE = /^[0-9a-f]{32}$/;
+
+function markdownOf(content: unknown): string | null {
+  if (
+    content &&
+    typeof content === "object" &&
+    "markdown" in content &&
+    typeof (content as { markdown: unknown }).markdown === "string"
+  ) {
+    return (content as { markdown: string }).markdown;
+  }
+  return null;
+}
+
+function timestamp(ms: number): string {
+  const total = Math.max(0, Math.round(ms / 1000));
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, "0")}`;
+}
+
+/** Public, read-only view of a shared meeting. No auth — the token is the key. */
+export default async function SharePage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  if (!TOKEN_RE.test(token)) notFound();
+
+  const db = getDb();
+  const meetingRows = await db
+    .select()
+    .from(meetings)
+    .where(eq(meetings.shareToken, token))
+    .limit(1);
+  const meeting = meetingRows[0];
+  if (!meeting) notFound();
+
+  const noteRows = await db
+    .select()
+    .from(notes)
+    .where(eq(notes.meetingId, meeting.id))
+    .limit(1);
+  const enhanced = markdownOf(noteRows[0]?.enhancedContent);
+  const raw = markdownOf(noteRows[0]?.rawContent);
+
+  const segments = await db
+    .select()
+    .from(transcriptSegments)
+    .where(eq(transcriptSegments.meetingId, meeting.id))
+    .orderBy(asc(transcriptSegments.startMs))
+    .limit(5000);
+
+  const when = meeting.startedAt ?? meeting.createdAt;
+
+  return (
+    <div className="flex flex-1 flex-col bg-cream text-bark">
+      <header className="border-b border-sand bg-card-soft">
+        <div className="mx-auto flex w-full max-w-3xl items-center justify-between px-6 py-3">
+          <Link href="/" className="flex items-center gap-2">
+            <Image src="/mascot.png" alt="" width={26} height={26} className="rounded-md" />
+            <span className="text-sm font-bold tracking-tight">
+              <span className="text-ink">Doodle</span>
+              <span className="text-sage">Note</span>
+            </span>
+          </Link>
+          <span className="text-xs text-stone">Shared meeting notes</span>
+        </div>
+      </header>
+
+      <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-6 py-8">
+        <h1 className="text-2xl font-semibold tracking-tight text-ink">
+          {meeting.title || "Untitled meeting"}
+        </h1>
+        {when && (
+          <p className="mt-1 text-sm text-stone">
+            {when.toLocaleDateString("en-US", {
+              weekday: "long",
+              month: "long",
+              day: "numeric",
+              year: "numeric",
+            })}
+          </p>
+        )}
+
+        {(enhanced ?? raw) ? (
+          <section className="prose-notes mt-6 rounded-xl border border-sand bg-white p-6">
+            <ReactMarkdown>{enhanced ?? raw ?? ""}</ReactMarkdown>
+          </section>
+        ) : (
+          <p className="mt-6 rounded-xl border border-sand bg-card-soft p-6 text-sm text-stone">
+            No notes on this meeting yet.
+          </p>
+        )}
+
+        {segments.length > 0 && (
+          <section className="mt-6">
+            <h2 className="text-base font-semibold text-ink">Transcript</h2>
+            <div className="mt-3 space-y-3 rounded-xl border border-sand bg-card-soft p-5">
+              {segments.map((segment) => (
+                <p key={segment.id} className="text-sm leading-relaxed">
+                  <span
+                    className={
+                      segment.speaker === "You"
+                        ? "font-semibold text-sage-deep"
+                        : "font-semibold text-ink"
+                    }
+                  >
+                    {segment.speaker}
+                  </span>
+                  <span className="ml-2 text-xs text-stone">{timestamp(segment.startMs)}</span>
+                  <span className="mt-0.5 block text-bark">{segment.text}</span>
+                </p>
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+
+      <footer className="border-t border-sand">
+        <div className="mx-auto w-full max-w-3xl px-6 py-5 text-sm text-stone">
+          Notes taken with{" "}
+          <Link href="/" className="font-semibold text-sage-deep hover:underline">
+            DoodleNote
+          </Link>{" "}
+          — AI meeting notes without the bot.
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/packages/ai/src/cloud-engine.ts
+++ b/packages/ai/src/cloud-engine.ts
@@ -3,7 +3,7 @@ import { createOpenAI } from '@ai-sdk/openai'
 import { generateText } from 'ai'
 import { ASK_SYSTEM_PROMPT, buildAskUserMessage } from './ask-prompt'
 import { buildGlobalAskUserMessage, GLOBAL_ASK_SYSTEM_PROMPT, type GlobalAskInput } from './global-ask-prompt'
-import { buildMergeUserMessage, MERGE_SYSTEM_PROMPT } from './prompt'
+import { buildMergeSystemPrompt, buildMergeUserMessage } from './prompt'
 import type { AskAnswer, AskInput, MergeInput, MergedNotes, NotesEngine } from './types'
 
 /**
@@ -29,7 +29,7 @@ export class CloudNotesEngine implements NotesEngine {
   }
 
   async generateNotes(input: MergeInput, onToken?: (text: string) => void): Promise<MergedNotes> {
-    return this.runPrompt(MERGE_SYSTEM_PROMPT, buildMergeUserMessage(input), onToken)
+    return this.runPrompt(buildMergeSystemPrompt(input.templateId), buildMergeUserMessage(input), onToken)
   }
 
   async askQuestion(input: AskInput, onToken?: (text: string) => void): Promise<AskAnswer> {

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -17,3 +17,4 @@ export type {
   MergeSegment,
   NotesEngine
 } from './types'
+export { NOTE_TEMPLATES, templateById, type NoteTemplate } from './templates'

--- a/packages/ai/src/local-engine.ts
+++ b/packages/ai/src/local-engine.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import type { Llama, LlamaModel } from 'node-llama-cpp'
 import { ASK_SYSTEM_PROMPT, buildAskUserMessage } from './ask-prompt'
 import { buildGlobalAskUserMessage, GLOBAL_ASK_SYSTEM_PROMPT, type GlobalAskInput } from './global-ask-prompt'
-import { buildMergeUserMessage, MERGE_SYSTEM_PROMPT } from './prompt'
+import { buildMergeSystemPrompt, buildMergeUserMessage } from './prompt'
 import type { AskAnswer, AskInput, MergeInput, MergedNotes, NotesEngine } from './types'
 
 /**
@@ -69,7 +69,7 @@ export class LocalNotesEngine implements NotesEngine {
   }
 
   async generateNotes(input: MergeInput, onToken?: (text: string) => void): Promise<MergedNotes> {
-    return this.runPrompt(MERGE_SYSTEM_PROMPT, buildMergeUserMessage(input), onToken)
+    return this.runPrompt(buildMergeSystemPrompt(input.templateId), buildMergeUserMessage(input), onToken)
   }
 
   async askQuestion(input: AskInput, onToken?: (text: string) => void): Promise<AskAnswer> {

--- a/packages/ai/src/prompt.ts
+++ b/packages/ai/src/prompt.ts
@@ -1,3 +1,4 @@
+import { templateById } from './templates'
 import type { MergeInput, MergeSegment } from './types'
 
 /**
@@ -12,7 +13,7 @@ import type { MergeInput, MergeSegment } from './types'
  * - Markdown out, no preamble, so the result can be dropped straight into
  *   the editor.
  */
-export const MERGE_SYSTEM_PROMPT = `You are the note-writing engine inside Doodle Note, an AI meeting notepad. You turn a meeting transcript plus the user's rough notes into polished meeting notes.
+const MERGE_RULES = `You are the note-writing engine inside Doodle Note, an AI meeting notepad. You turn a meeting transcript plus the user's rough notes into polished meeting notes.
 
 Rules:
 - Use ONLY information present in the transcript or the rough notes. Never invent names, numbers, dates, or commitments.
@@ -21,20 +22,17 @@ Rules:
 - "You" is the note-taker; "Them" is everyone else on the call.
 - Attribute every action item and decision to whoever actually committed to it in the transcript. Use "You" as an owner ONLY when a [You] line contains that commitment; if a [Them] line says "I will…", the owner is the person speaking (use their name if known, otherwise "Them").
 - Write in tight, plain English. No filler, no corporate fluff.
+- A section heading with nothing real to put under it is omitted entirely.
 
-Output format (markdown, nothing before or after it):
-# <meeting title>
+`
 
-<1-2 sentence summary of what the meeting was about and its outcome>
+/** Shared rules + the selected template's output format. */
+export function buildMergeSystemPrompt(templateId?: string): string {
+  return MERGE_RULES + templateById(templateId).outputFormat
+}
 
-## Notes
-<the substance, grouped under short bold topic lines following the meeting's flow; bullets, not paragraphs>
-
-## Decisions
-<bullet list of decisions actually made; omit the section if none>
-
-## Action items
-<markdown checkboxes: - [ ] Owner — task (deadline if stated); omit the section if none>`
+/** The default (general-template) prompt — kept for compatibility. */
+export const MERGE_SYSTEM_PROMPT = buildMergeSystemPrompt('general')
 
 function formatTimestamp(ms: number): string {
   const totalSec = Math.floor(ms / 1000)

--- a/packages/ai/src/templates.ts
+++ b/packages/ai/src/templates.ts
@@ -1,0 +1,197 @@
+/**
+ * Note templates — each swaps the OUTPUT FORMAT block of the merge prompt so
+ * generated notes come out shaped for the meeting type. The rules block
+ * (never invent facts, attribution, tone) is shared and lives in prompt.ts.
+ */
+
+export interface NoteTemplate {
+  id: string
+  label: string
+  /** One line shown under the label in the template picker. */
+  description: string
+  /** The "Output format" block appended to the merge system prompt. */
+  outputFormat: string
+}
+
+const OMIT = 'omit the section if none'
+
+export const NOTE_TEMPLATES: NoteTemplate[] = [
+  {
+    id: 'general',
+    label: 'General meeting',
+    description: 'Summary, notes by topic, decisions, action items',
+    outputFormat: `Output format (markdown, nothing before or after it):
+# <meeting title>
+
+<1-2 sentence summary of what the meeting was about and its outcome>
+
+## Notes
+<the substance, grouped under short bold topic lines following the meeting's flow; bullets, not paragraphs>
+
+## Decisions
+<bullet list of decisions actually made; ${OMIT}>
+
+## Action items
+<markdown checkboxes: - [ ] Owner — task (deadline if stated); ${OMIT}>`
+  },
+  {
+    id: 'customer-discovery',
+    label: 'Customer discovery',
+    description: 'Pain points, current setup, requirements, next steps',
+    outputFormat: `Output format (markdown, nothing before or after it):
+# <meeting title>
+
+<1-2 sentence summary: who the customer is and what they need>
+
+## Company & contacts
+<who was on the call, company, roles; only what the transcript supports>
+
+## Situation & pain points
+<what hurts today, in their words where possible>
+
+## Current setup
+<tools, vendors, environment they described; ${OMIT}>
+
+## Requirements & success criteria
+<what a solution must do for them>
+
+## Budget & timeline
+<anything said about money or dates; ${OMIT}>
+
+## Risks & objections
+<hesitations, blockers, competitors mentioned; ${OMIT}>
+
+## Next steps
+<markdown checkboxes: - [ ] Owner — task (deadline if stated)>`
+  },
+  {
+    id: 'site-survey',
+    label: 'Site survey / scoping',
+    description: 'Site details, existing infra, constraints, open questions, quote items',
+    outputFormat: `Output format (markdown, nothing before or after it):
+# <meeting title>
+
+<1-2 sentence summary: the site and what the project is>
+
+## Site & scope
+<location, areas covered, what the client wants done>
+
+## Existing infrastructure
+<equipment, wiring, closets, networks found on site; ${OMIT}>
+
+## Constraints & measurements
+<physical constraints, distances, access issues, anything measured; ${OMIT}>
+
+## Open questions for the client
+<bullet list of everything that must be answered before quoting>
+
+## Quote considerations
+<materials, labor, or line items discussed for the estimate; ${OMIT}>
+
+## Next steps
+<markdown checkboxes: - [ ] Owner — task (deadline if stated)>`
+  },
+  {
+    id: 'troubleshooting',
+    label: 'Troubleshooting',
+    description: 'Issue, symptoms, diagnostics, root cause, resolution',
+    outputFormat: `Output format (markdown, nothing before or after it):
+# <meeting title>
+
+<1-2 sentence summary: the issue and where it stands>
+
+## Issue
+<what is broken, who reported it, impact>
+
+## Environment & symptoms
+<systems involved and observed behavior>
+
+## Diagnostics performed
+<what was checked and what each check showed>
+
+## Root cause
+<the identified cause; ${OMIT} or write "Not yet identified" if discussed but unresolved>
+
+## Resolution / workaround
+<what fixed or mitigated it; ${OMIT}>
+
+## Follow-up actions
+<markdown checkboxes: - [ ] Owner — task (deadline if stated)>`
+  },
+  {
+    id: 'one-on-one',
+    label: '1:1',
+    description: 'Wins, challenges, feedback, growth, action items',
+    outputFormat: `Output format (markdown, nothing before or after it):
+# <meeting title>
+
+<1-2 sentence summary of the conversation>
+
+## Wins
+<what went well since last time; ${OMIT}>
+
+## Challenges & blockers
+<what is hard or stuck; ${OMIT}>
+
+## Feedback
+<feedback exchanged in either direction; ${OMIT}>
+
+## Growth & goals
+<career, skills, or goal discussion; ${OMIT}>
+
+## Action items
+<markdown checkboxes: - [ ] Owner — task (deadline if stated)>`
+  },
+  {
+    id: 'standup',
+    label: 'Team standup',
+    description: 'Per-person updates, blockers, cross-team topics',
+    outputFormat: `Output format (markdown, nothing before or after it):
+# <meeting title>
+
+<1 sentence summary>
+
+## Updates
+<one bold line per person or workstream with their done / doing / blocked bullets underneath>
+
+## Blockers
+<bullet list of blockers and who owns unblocking them; ${OMIT}>
+
+## Discussion
+<anything beyond status updates; ${OMIT}>
+
+## Action items
+<markdown checkboxes: - [ ] Owner — task (deadline if stated)>`
+  },
+  {
+    id: 'interview',
+    label: 'Interview',
+    description: 'Background, assessment, strengths, concerns, recommendation',
+    outputFormat: `Output format (markdown, nothing before or after it):
+# <meeting title>
+
+<1-2 sentence summary: candidate, role, overall impression as stated by the interviewer>
+
+## Background highlights
+<relevant experience and skills they described>
+
+## Assessment
+<how they handled the questions; specifics over generalities>
+
+## Strengths
+<bullet list>
+
+## Concerns
+<bullet list; ${OMIT}>
+
+## Their questions
+<what the candidate asked; ${OMIT}>
+
+## Next steps
+<markdown checkboxes: - [ ] Owner — task (deadline if stated)>`
+  }
+]
+
+export function templateById(id: string | undefined): NoteTemplate {
+  return NOTE_TEMPLATES.find((t) => t.id === id) ?? NOTE_TEMPLATES[0]!
+}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -12,6 +12,8 @@ export interface MergeInput {
   rawNotesMarkdown: string
   segments: MergeSegment[]
   durationMs?: number
+  /** Note template shaping the output (see templates.ts); default "general". */
+  templateId?: string
 }
 
 export interface MergedNotes {

--- a/packages/db/drizzle/0003_slow_anthem.sql
+++ b/packages/db/drizzle/0003_slow_anthem.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "meetings" ADD COLUMN "share_token" text;--> statement-breakpoint
+ALTER TABLE "meetings" ADD CONSTRAINT "meetings_share_token_unique" UNIQUE("share_token");

--- a/packages/db/drizzle/meta/0003_snapshot.json
+++ b/packages/db/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1066 @@
+{
+  "id": "ff14d15d-1309-4ea8-a39c-3e122cc16e4f",
+  "prevId": "3b7b01e2-28ac-4f92-8585-5554c3e91f9a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.meetings": {
+      "name": "meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled meeting'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetings_organization_id_idx": {
+          "name": "meetings_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetings_organization_id_organization_id_fk": {
+          "name": "meetings_organization_id_organization_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meetings_share_token_unique": {
+          "name": "meetings_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notes": {
+      "name": "notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_content": {
+          "name": "raw_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enhanced_content": {
+          "name": "enhanced_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notes_meeting_id_meetings_id_fk": {
+          "name": "notes_meeting_id_meetings_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notes_meeting_id_unique": {
+          "name": "notes_meeting_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meeting_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_devices": {
+      "name": "sync_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Desktop'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_devices_user_id_idx": {
+          "name": "sync_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_devices_user_id_user_id_fk": {
+          "name": "sync_devices_user_id_user_id_fk",
+          "tableFrom": "sync_devices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_devices_organization_id_organization_id_fk": {
+          "name": "sync_devices_organization_id_organization_id_fk",
+          "tableFrom": "sync_devices",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sync_devices_token_hash_unique": {
+          "name": "sync_devices_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcript_segments": {
+      "name": "transcript_segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker": {
+          "name": "speaker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcript_segments_meeting_id_idx": {
+          "name": "transcript_segments_meeting_id_idx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transcript_segments_meeting_id_meetings_id_fk": {
+          "name": "transcript_segments_meeting_id_meetings_id_fk",
+          "tableFrom": "transcript_segments",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1783352942989,
       "tag": "0002_far_mimic",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1783370735905,
+      "tag": "0003_slow_anthem",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -24,6 +24,8 @@ export const meetings = pgTable(
       .notNull()
       .default("complete"),
     calendarEventId: text("calendar_event_id"),
+    /** Public share-link token; null = not shared. */
+    shareToken: text("share_token").unique(),
     startedAt: timestamp("started_at", { withTimezone: true }),
     endedAt: timestamp("ended_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),


### PR DESCRIPTION
The three top Granola-parity gaps, per Sean's go-ahead:

1. **Note templates** — 7 built-ins (general, customer discovery, site survey/scoping, troubleshooting, 1:1, standup, interview). Split-button picker on Generate notes; template chip next to Regenerate; choice remembered per meeting. Each template reshapes the merge prompt's output format; the never-invent-facts rules are shared.
2. **Auto-generate on meeting end** — after the mic-detected auto-stop, notes generate on their own once the capture settles. Hang up → notes appear.
3. **Share links** — `share_token` on meetings (migration 0003), `POST /api/sync/share` (bearer), public read-only `/share/[token]` page with DoodleNote branding. Desktop row menu's disabled placeholders replaced by a working **Copy share link** (pushes fresh, mints link, clipboard + toast).

## Verification
- Share flow e2e locally: push → mint → public page renders unauthenticated → revoke → 404
- Template prompt builder smoke (sections + fallback)
- Gates: desktop typecheck/build/test (40/40), web typecheck/build/auth-smoke, db smoke

## Deploy notes
- Requires migration 0003 on Neon before merge-deploy
- Desktop share hits production; repackage after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)