### PR TITLE
Prompt on incoming calls — ring detection

### DIFF
--- a/apps/desktop/src/main/calendar-service.ts
+++ b/apps/desktop/src/main/calendar-service.ts
@@ -773,7 +773,7 @@ export class CalendarService {
       if (!Notification.isSupported()) return
       const notification = new Notification({
         title: prompt.adHoc
-          ? 'Looks like you’re in a meeting'
+          ? 'Looks like you’re on a call'
           : `${prompt.subject} is starting`,
         body: 'Click to start taking notes'
       })

--- a/apps/desktop/src/main/mic-watcher-logic.test.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.test.ts
@@ -7,6 +7,7 @@ import {
   markPrompted,
   MEETING_END_DEBOUNCE_MS,
   meetingAppLabel,
+  meetingRingLabel,
   MIC_COOLDOWN_MS,
   MIC_DEBOUNCE_MS,
   onCaptureMicEvent,
@@ -116,5 +117,15 @@ describe('meeting-end watch', () => {
     s = onCaptureMicEvent(s, false, T0 + 10_000)
     s = markEnded(s)
     assert.equal(shouldAutoStop(s, T0 + 10 * 60_000), false)
+  })
+})
+
+describe('meetingRingLabel', () => {
+  it('rings only for native meeting apps, never browsers', () => {
+    assert.equal(meetingRingLabel(['us.zoom.xos']), 'Zoom')
+    assert.equal(meetingRingLabel(['com.apple.FaceTime']), 'FaceTime')
+    assert.equal(meetingRingLabel(['com.google.Chrome']), null) // YouTube ≠ meeting
+    assert.equal(meetingRingLabel(['com.spotify.client']), null)
+    assert.equal(meetingRingLabel([]), null)
   })
 })

--- a/apps/desktop/src/main/mic-watcher-logic.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.ts
@@ -45,6 +45,17 @@ export function meetingAppLabel(bundles: readonly string[]): string | null {
   return null
 }
 
+/**
+ * Ring detection works on audio OUTPUT — an incoming call rings long before
+ * the mic engages. Browsers are excluded here (any tab playing audio would
+ * read as a meeting); only native meeting apps count, and the debounce
+ * filters their short notification dings.
+ */
+export function meetingRingLabel(bundles: readonly string[]): string | null {
+  const label = meetingAppLabel(bundles)
+  return label === 'browser' ? null : label
+}
+
 export interface MicPromptState {
   /** Epoch ms when the mic went busy; null while idle. */
   busySinceMs: number | null

--- a/apps/desktop/src/main/mic-watcher.ts
+++ b/apps/desktop/src/main/mic-watcher.ts
@@ -8,6 +8,7 @@ import {
   markPrompted,
   MEETING_END_DEBOUNCE_MS,
   meetingAppLabel,
+  meetingRingLabel,
   MIC_DEBOUNCE_MS,
   onCaptureMicEvent,
   onMicEvent,
@@ -165,15 +166,23 @@ export class MicWatcher {
             event?: string
             running?: boolean
             bundles?: string[]
+            outputBundles?: string[]
           }
           if (event.event === 'micmon' && typeof event.running === 'boolean') {
             // Only capture by an actual meeting app counts as "busy" —
-            // dictation tools like FluidVoice must never prompt.
+            // dictation tools like FluidVoice must never prompt. Sustained
+            // meeting-app OUTPUT (an incoming call ringing) counts too, so
+            // the prompt lands before the call is even answered.
             const bundles = Array.isArray(event.bundles) ? event.bundles.map(String) : []
-            const label = event.running ? meetingAppLabel(bundles) : null
-            this.currentAppLabel = label
-            this.handleMicEvent(event.running && label !== null)
-            this.handleEndWatch(label !== null)
+            const output = Array.isArray(event.outputBundles)
+              ? event.outputBundles.map(String)
+              : []
+            const inputLabel = event.running ? meetingAppLabel(bundles) : null
+            const ringLabel = meetingRingLabel(output)
+            this.currentAppLabel = inputLabel ?? ringLabel
+            this.handleMicEvent(inputLabel !== null || ringLabel !== null)
+            // The end watch keys on the MIC only — output lingers on dings.
+            this.handleEndWatch(inputLabel !== null)
           }
         } catch {
           // CoreML/CoreAudio noise on stdout — NDJSON hosts skip unparseable lines.

--- a/apps/desktop/src/main/prompt-panel.ts
+++ b/apps/desktop/src/main/prompt-panel.ts
@@ -92,10 +92,10 @@ function escapeHtml(s: string): string {
 
 function panelDataUrl(prompt: CalendarStartMeetingEvent): string {
   const heading = prompt.adHoc
-    ? 'Looks like you’re in a meeting'
+    ? 'Looks like you’re on a call'
     : `${escapeHtml(prompt.subject)} is starting`
   const sub = prompt.adHoc
-    ? 'Your microphone is live — want notes?'
+    ? 'Want DoodleNote to record and take notes?'
     : 'Want DoodleNote to take notes?'
   // Follows nativeTheme, which the renderer keeps in sync with the in-app pref.
   const dark = nativeTheme.shouldUseDarkColors

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -559,7 +559,7 @@ function App(): React.JSX.Element {
           </span>
           <span className="mb-text">
             {banner.adHoc ? (
-              <>Looks like you&rsquo;re in a meeting</>
+              <>Looks like you&rsquo;re on a call</>
             ) : (
               <>
                 <strong>{banner.subject}</strong> is starting

--- a/engine/Sources/engine/MicMonitorCommand.swift
+++ b/engine/Sources/engine/MicMonitorCommand.swift
@@ -11,6 +11,7 @@ enum MicMonitorCommand {
     private static var deviceId = AudioObjectID(kAudioObjectUnknown)
     private static var lastRunning: Bool?
     private static var lastBundles: Set<String> = []
+    private static var lastOutputBundles: Set<String> = []
     private static let queue = DispatchQueue(label: "micmon")
     private static var timer: DispatchSourceTimer?
 
@@ -93,6 +94,17 @@ enum MicMonitorCommand {
 
     /// Bundle ids of every process currently capturing audio input.
     private static func capturingBundles() -> Set<String> {
+        processBundles(input: true)
+    }
+
+    /// Bundle ids of every process currently playing audio output — an
+    /// incoming Zoom/Teams/FaceTime call RINGS long before the mic engages,
+    /// and the ring is sustained meeting-app output.
+    private static func outputBundles() -> Set<String> {
+        processBundles(input: false)
+    }
+
+    private static func processBundles(input: Bool) -> Set<String> {
         guard #available(macOS 14.4, *) else { return [] }
         var listAddress = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyProcessObjectList,
@@ -112,7 +124,7 @@ enum MicMonitorCommand {
         var bundles: Set<String> = []
         for process in processes {
             var inputAddress = AudioObjectPropertyAddress(
-                mSelector: kAudioProcessPropertyIsRunningInput,
+                mSelector: input ? kAudioProcessPropertyIsRunningInput : kAudioProcessPropertyIsRunningOutput,
                 mScope: kAudioObjectPropertyScopeGlobal,
                 mElement: kAudioObjectPropertyElementMain
             )
@@ -144,15 +156,19 @@ enum MicMonitorCommand {
     private static func emitCurrent() {
         lastRunning = isRunningSomewhere()
         lastBundles = capturingBundles()
+        lastOutputBundles = outputBundles()
         emit()
     }
 
     private static func emitIfChanged() {
         let running = isRunningSomewhere()
         let bundles = capturingBundles()
-        guard running != lastRunning || bundles != lastBundles else { return }
+        let output = outputBundles()
+        guard running != lastRunning || bundles != lastBundles || output != lastOutputBundles
+        else { return }
         lastRunning = running
         lastBundles = bundles
+        lastOutputBundles = output
         emit()
     }
 
@@ -160,7 +176,8 @@ enum MicMonitorCommand {
         Events.emit([
             "event": "micmon",
             "running": lastRunning ?? false,
-            "bundles": lastBundles.sorted()
+            "bundles": lastBundles.sorted(),
+            "outputBundles": lastOutputBundles.sorted()
         ])
     }
 }


### PR DESCRIPTION
Sean had a Zoom call come in and DoodleNote never asked. Root cause: mic detection only sees the call after it's answered, and manually starting a recording within the 8s debounce cancels the pending prompt.

Fix: the engine's micmon now also reports which apps are playing **audio output** — an incoming call rings with 15–30s of sustained meeting-app output, so the "Looks like you're on a call — want notes?" prompt appears **while it's still ringing**, before you even answer.

Guards: browsers excluded from ring detection (a YouTube tab is not a meeting); chat/notification dings die inside the 8s debounce; the meeting-end auto-stop stays keyed on mic input only.

Gates: desktop typecheck/build/test (41/41), engine builds ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)