### PR TITLE
MVP polish: search, transcript footer, invites, image sync, persistent engine

### DIFF
--- a/apps/desktop/src/main/calendar-service.ts
+++ b/apps/desktop/src/main/calendar-service.ts
@@ -773,7 +773,7 @@ export class CalendarService {
       if (!Notification.isSupported()) return
       const notification = new Notification({
         title: prompt.adHoc
-          ? 'Looks like you’re in a meeting'
+          ? 'Looks like you’re on a call'
           : `${prompt.subject} is starting`,
         body: 'Click to start taking notes'
       })

--- a/apps/desktop/src/main/engine-process.ts
+++ b/apps/desktop/src/main/engine-process.ts
@@ -32,7 +32,109 @@ export class EngineProcess {
   private stdoutBuffer = ''
   private readonly listeners = new Set<EngineEventListener>()
 
+  /* Persistent `serve` sidecar: models stay loaded across sessions. */
+  private serveChild: EngineChild | null = null
+  private serveBuffer = ''
+  private serveReady = false
+  private serveSessionActive = false
+  private serveRestartTimer: NodeJS.Timeout | null = null
+  private disposed = false
+
   constructor(private readonly binaryPath: string) {}
+
+  /**
+   * Launch the persistent engine. Models load once here; live sessions then
+   * start instantly via stdin commands. Restarts itself on crash; while it
+   * is down (or still loading), live falls back to the classic per-session
+   * spawn, so recording always works.
+   */
+  startServe(): void {
+    if (this.serveChild || this.disposed || !existsSync(this.binaryPath)) return
+    let child: EngineChild
+    try {
+      child = spawn(this.binaryPath, ['serve'], { stdio: ['pipe', 'pipe', 'pipe'] })
+    } catch (err) {
+      console.error('[engine serve] spawn failed:', err)
+      return
+    }
+    this.serveChild = child
+    this.serveBuffer = ''
+    this.serveReady = false
+
+    child.stdout.setEncoding('utf8')
+    child.stdout.on('data', (chunk: string) => {
+      if (this.serveChild !== child) return
+      this.serveBuffer += chunk
+      let nl = this.serveBuffer.indexOf('\n')
+      while (nl !== -1) {
+        const line = this.serveBuffer.slice(0, nl)
+        this.serveBuffer = this.serveBuffer.slice(nl + 1)
+        this.handleServeLine(line)
+        nl = this.serveBuffer.indexOf('\n')
+      }
+    })
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk: string) => {
+      for (const line of chunk.split('\n')) {
+        if (line.trim().length > 0) console.error(`[engine serve] ${line}`)
+      }
+    })
+    child.on('error', (err) => {
+      console.error('[engine serve] error:', err.message)
+    })
+    child.on('close', () => {
+      if (this.serveChild !== child) return
+      this.serveChild = null
+      this.serveReady = false
+      // A crash mid-session must end the session for the renderer too.
+      if (this.serveSessionActive) {
+        this.serveSessionActive = false
+        this.emit({ event: 'exit', code: null, signal: 'SIGTERM' })
+      }
+      if (!this.disposed) {
+        this.serveRestartTimer = setTimeout(() => this.startServe(), 5_000)
+        this.serveRestartTimer.unref()
+      }
+    })
+  }
+
+  private handleServeLine(rawLine: string): void {
+    const line = rawLine.trim()
+    if (line.length === 0) return
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(line)
+    } catch {
+      return // CoreML noise
+    }
+    const event = parsed as { event?: string; stage?: string }
+    if (typeof event.event !== 'string') return
+    if (event.event === 'status' && event.stage === 'serve_ready') {
+      this.serveReady = true
+      return
+    }
+    if (event.event === 'status' && event.stage === 'serve_loading_models') return
+    // Session events flow only while a session is active — boot noise stays out.
+    if (!this.serveSessionActive) return
+    this.emit(parsed as EngineSidecarEvent)
+    if (event.event === 'done') {
+      this.serveSessionActive = false
+      // The legacy path signalled session end with the child's exit; serve
+      // stays alive, so synthesize it for unchanged renderer semantics.
+      this.emit({ event: 'exit', code: 0, signal: null })
+    }
+  }
+
+  private serveWrite(command: object): boolean {
+    const child = this.serveChild
+    if (!child) return false
+    try {
+      child.stdin.write(`${JSON.stringify(command)}\n`)
+      return true
+    } catch {
+      return false
+    }
+  }
 
   onEvent(listener: EngineEventListener): () => void {
     this.listeners.add(listener)
@@ -42,12 +144,27 @@ export class EngineProcess {
   }
 
   get running(): boolean {
-    return this.child !== null
+    return this.child !== null || this.serveSessionActive
   }
 
   start(command: EngineCommand, filePath?: string, opts: EngineStartOptions = {}): void {
     // Only one sidecar at a time; a new start supersedes (hard-discards) the previous run.
     this.discard()
+
+    // Instant path: the persistent engine has models loaded and is idle.
+    if (command === 'live' && this.serveReady && this.serveChild && !this.serveSessionActive) {
+      this.serveSessionActive = true
+      this.emit({ event: 'started', command, filePath, binaryPath: this.binaryPath })
+      const ok = this.serveWrite({ cmd: 'start', source: opts.source ?? 'both' })
+      if (ok) return
+      this.serveSessionActive = false // fall through to the classic spawn
+    }
+    // A superseding start while a serve session runs: hard-restart serve (its
+    // tail events must not leak into the new session) and use the classic
+    // spawn for this one.
+    if (command === 'live' && this.serveSessionActive) {
+      this.restartServe()
+    }
 
     if (command !== 'stream' && command !== 'transcribe' && command !== 'live') {
       this.emit({ event: 'spawn-error', message: `Unknown engine command: ${String(command)}` })
@@ -130,6 +247,16 @@ export class EngineProcess {
    * Escalates to SIGKILL if the sidecar hangs.
    */
   stop(): void {
+    if (this.serveSessionActive) {
+      this.serveWrite({ cmd: 'stop' })
+      // If the serve engine wedges mid-finish, restart it — the close handler
+      // ends the session for the renderer.
+      const escalate = setTimeout(() => {
+        if (this.serveSessionActive) this.restartServe()
+      }, 25_000)
+      escalate.unref()
+      return
+    }
     const child = this.child
     if (!child) return
     if (child.exitCode === null && child.signalCode === null) {
@@ -170,8 +297,36 @@ export class EngineProcess {
     this.emit({ event: 'exit', code: null, signal: 'SIGTERM' })
   }
 
-  /** Kill the sidecar on app shutdown. */
+  /** Hard-restart the persistent engine (crash recovery / supersede). */
+  private restartServe(): void {
+    const child = this.serveChild
+    this.serveChild = null
+    this.serveReady = false
+    if (this.serveSessionActive) {
+      this.serveSessionActive = false
+      this.emit({ event: 'exit', code: null, signal: 'SIGTERM' })
+    }
+    if (child) {
+      child.removeAllListeners()
+      child.stdout.removeAllListeners()
+      child.stderr.removeAllListeners()
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL')
+    }
+    if (!this.disposed) {
+      this.serveRestartTimer = setTimeout(() => this.startServe(), 1_000)
+      this.serveRestartTimer.unref()
+    }
+  }
+
+  /** Kill the sidecars on app shutdown. */
   dispose(): void {
+    this.disposed = true
+    if (this.serveRestartTimer) clearTimeout(this.serveRestartTimer)
+    const serve = this.serveChild
+    this.serveChild = null
+    if (serve && serve.exitCode === null && serve.signalCode === null) {
+      serve.stdin.end() // its stdin watchdog exits it cleanly
+    }
     this.discard()
     this.listeners.clear()
   }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -122,6 +122,15 @@ function createWindow(): void {
     return { action: 'deny' }
   })
 
+  // In-page link clicks (e.g. the transcript footer in generated notes) go
+  // to the system browser — the app itself never navigates away.
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (/^https?:/i.test(url)) {
+      event.preventDefault()
+      shell.openExternal(url)
+    }
+  })
+
   // HMR for renderer based on electron-vite cli.
   // Load the remote URL for development or the local html file for production.
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
@@ -146,8 +155,19 @@ app.whenReady().then(() => {
       if (line.length > 0) console.error(`[engine preflight] ${line}`)
     })
     preflight.on('error', (err) => console.error('[engine preflight] spawn failed:', err.message))
+    // Persistent engine: models load once here, so hitting record is instant.
+    // Started after preflight so the two don't race the model download.
+    let serveStarted = false
+    const startServeOnce = (): void => {
+      if (serveStarted) return
+      serveStarted = true
+      engine.startServe()
+    }
+    preflight.on('exit', startServeOnce)
+    setTimeout(startServeOnce, 120_000).unref()
   } catch (err) {
     console.error('[engine preflight] failed:', err)
+    engine.startServe()
   }
 
   electronApp.setAppUserModelId('com.doodlenote.desktop')

--- a/apps/desktop/src/main/meetings-service.ts
+++ b/apps/desktop/src/main/meetings-service.ts
@@ -6,9 +6,11 @@ import {
   MEETINGS_DELETE_CHANNEL,
   MEETINGS_GET_CHANNEL,
   MEETINGS_LIST_CHANNEL,
+  MEETINGS_SEARCH_CHANNEL,
   MEETINGS_UPSERT_CHANNEL,
   type MeetingChatEntry,
   type MeetingRecord,
+  type MeetingSearchHit,
   type MeetingSummary,
   type MeetingUpsert
 } from '../shared/meetings-api'
@@ -38,6 +40,9 @@ export class MeetingsService {
       this.upsert((patch ?? {}) as MeetingUpsert)
     )
     ipcMain.handle(MEETINGS_DELETE_CHANNEL, (_event, id: unknown) => this.delete(String(id)))
+    ipcMain.handle(MEETINGS_SEARCH_CHANNEL, (_event, query: unknown) =>
+      this.search(String(query ?? ''))
+    )
   }
 
   /* ---- queries ---- */
@@ -81,6 +86,31 @@ export class MeetingsService {
       if (record) records.push(record)
     }
     return records
+  }
+
+  /**
+   * Case-insensitive substring search across every stored document. A few
+   * hundred JSON files scan in single-digit milliseconds — no index needed
+   * at this scale. Reports the strongest matching field per meeting
+   * (title > notes > transcript) so the UI can hint where the hit was.
+   */
+  search(query: string): MeetingSearchHit[] {
+    const q = query.trim().toLowerCase()
+    if (q.length === 0) return []
+    const hits: MeetingSearchHit[] = []
+    for (const record of this.readAll()) {
+      if ((record.title || '').toLowerCase().includes(q)) {
+        hits.push({ id: record.id, field: 'title' })
+      } else if (
+        record.rawNotesMarkdown.toLowerCase().includes(q) ||
+        (record.enhancedMarkdown ?? '').toLowerCase().includes(q)
+      ) {
+        hits.push({ id: record.id, field: 'notes' })
+      } else if (record.segments.some((s) => s.text.toLowerCase().includes(q))) {
+        hits.push({ id: record.id, field: 'transcript' })
+      }
+    }
+    return hits
   }
 
   /* ---- writes ---- */

--- a/apps/desktop/src/main/mic-watcher-logic.test.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.test.ts
@@ -7,6 +7,7 @@ import {
   markPrompted,
   MEETING_END_DEBOUNCE_MS,
   meetingAppLabel,
+  meetingRingLabel,
   MIC_COOLDOWN_MS,
   MIC_DEBOUNCE_MS,
   onCaptureMicEvent,
@@ -116,5 +117,15 @@ describe('meeting-end watch', () => {
     s = onCaptureMicEvent(s, false, T0 + 10_000)
     s = markEnded(s)
     assert.equal(shouldAutoStop(s, T0 + 10 * 60_000), false)
+  })
+})
+
+describe('meetingRingLabel', () => {
+  it('rings only for native meeting apps, never browsers', () => {
+    assert.equal(meetingRingLabel(['us.zoom.xos']), 'Zoom')
+    assert.equal(meetingRingLabel(['com.apple.FaceTime']), 'FaceTime')
+    assert.equal(meetingRingLabel(['com.google.Chrome']), null) // YouTube ≠ meeting
+    assert.equal(meetingRingLabel(['com.spotify.client']), null)
+    assert.equal(meetingRingLabel([]), null)
   })
 })

--- a/apps/desktop/src/main/mic-watcher-logic.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.ts
@@ -45,6 +45,17 @@ export function meetingAppLabel(bundles: readonly string[]): string | null {
   return null
 }
 
+/**
+ * Ring detection works on audio OUTPUT — an incoming call rings long before
+ * the mic engages. Browsers are excluded here (any tab playing audio would
+ * read as a meeting); only native meeting apps count, and the debounce
+ * filters their short notification dings.
+ */
+export function meetingRingLabel(bundles: readonly string[]): string | null {
+  const label = meetingAppLabel(bundles)
+  return label === 'browser' ? null : label
+}
+
 export interface MicPromptState {
   /** Epoch ms when the mic went busy; null while idle. */
   busySinceMs: number | null

--- a/apps/desktop/src/main/mic-watcher.ts
+++ b/apps/desktop/src/main/mic-watcher.ts
@@ -8,6 +8,7 @@ import {
   markPrompted,
   MEETING_END_DEBOUNCE_MS,
   meetingAppLabel,
+  meetingRingLabel,
   MIC_DEBOUNCE_MS,
   onCaptureMicEvent,
   onMicEvent,
@@ -165,15 +166,23 @@ export class MicWatcher {
             event?: string
             running?: boolean
             bundles?: string[]
+            outputBundles?: string[]
           }
           if (event.event === 'micmon' && typeof event.running === 'boolean') {
             // Only capture by an actual meeting app counts as "busy" —
-            // dictation tools like FluidVoice must never prompt.
+            // dictation tools like FluidVoice must never prompt. Sustained
+            // meeting-app OUTPUT (an incoming call ringing) counts too, so
+            // the prompt lands before the call is even answered.
             const bundles = Array.isArray(event.bundles) ? event.bundles.map(String) : []
-            const label = event.running ? meetingAppLabel(bundles) : null
-            this.currentAppLabel = label
-            this.handleMicEvent(event.running && label !== null)
-            this.handleEndWatch(label !== null)
+            const output = Array.isArray(event.outputBundles)
+              ? event.outputBundles.map(String)
+              : []
+            const inputLabel = event.running ? meetingAppLabel(bundles) : null
+            const ringLabel = meetingRingLabel(output)
+            this.currentAppLabel = inputLabel ?? ringLabel
+            this.handleMicEvent(inputLabel !== null || ringLabel !== null)
+            // The end watch keys on the MIC only — output lingers on dings.
+            this.handleEndWatch(inputLabel !== null)
           }
         } catch {
           // CoreML/CoreAudio noise on stdout — NDJSON hosts skip unparseable lines.

--- a/apps/desktop/src/main/prompt-panel.ts
+++ b/apps/desktop/src/main/prompt-panel.ts
@@ -92,10 +92,10 @@ function escapeHtml(s: string): string {
 
 function panelDataUrl(prompt: CalendarStartMeetingEvent): string {
   const heading = prompt.adHoc
-    ? 'Looks like you’re in a meeting'
+    ? 'Looks like you’re on a call'
     : `${escapeHtml(prompt.subject)} is starting`
   const sub = prompt.adHoc
-    ? 'Your microphone is live — want notes?'
+    ? 'Want DoodleNote to record and take notes?'
     : 'Want DoodleNote to take notes?'
   // Follows nativeTheme, which the renderer keeps in sync with the in-app pref.
   const dark = nativeTheme.shouldUseDarkColors

--- a/apps/desktop/src/main/sync-service.ts
+++ b/apps/desktop/src/main/sync-service.ts
@@ -34,6 +34,8 @@ interface SyncConfig {
   lastSyncAt?: string
   /** meetingId → content hash at last successful push. */
   pushed: Record<string, string>
+  /** attachment file name → public blob URL (uploaded once, reused). */
+  mediaUrls: Record<string, string>
   /** Local meetings deleted/trashed whose cloud copy still needs removing. */
   pendingDeletes: string[]
 }
@@ -53,12 +55,15 @@ export class SyncService {
   private debounceTimer: NodeJS.Timeout | null = null
   private linkServer: Server | null = null
 
+  private readonly attachmentsDir: string
+
   constructor(
     userDataDir: string,
     private readonly meetings: MeetingsService,
     private readonly broadcast: (channel: string, payload: unknown) => void
   ) {
     this.configPath = join(userDataDir, 'sync.json')
+    this.attachmentsDir = join(userDataDir, 'attachments')
     this.baseUrl = process.env.DOODLE_SYNC_URL || DEFAULT_BASE_URL
     this.config = this.readConfig()
   }
@@ -108,7 +113,8 @@ export class SyncService {
       ...(this.config.lastSyncAt ? { lastSyncAt: this.config.lastSyncAt } : {}),
       pendingCount: this.pendingMeetings().length + this.config.pendingDeletes.length,
       ...(this.lastError ? { lastError: this.lastError } : {}),
-      linking: this.linking
+      linking: this.linking,
+      baseUrl: this.baseUrl
     }
   }
 
@@ -197,6 +203,7 @@ export class SyncService {
     this.config = {
       enabled: false,
       pushed: {},
+      mediaUrls: {},
       pendingDeletes: []
     }
     this.writeConfig()
@@ -226,15 +233,16 @@ export class SyncService {
     if (!record) return { error: 'Meeting not found' }
 
     try {
+      await this.uploadReferencedMedia(record, token)
       const pushResponse = await fetch(`${this.baseUrl}/api/sync/push`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-        body: JSON.stringify({ meetings: [toPushMeeting(record)] })
+        body: JSON.stringify({ meetings: [toPushMeeting(record, this.config.mediaUrls)] })
       })
       if (!pushResponse.ok) {
         return { error: `Could not sync the meeting (HTTP ${pushResponse.status})` }
       }
-      this.config.pushed[record.id] = contentHash(record)
+      this.config.pushed[record.id] = contentHash(record, this.config.mediaUrls)
       this.writeConfig()
 
       const shareResponse = await fetch(`${this.baseUrl}/api/sync/share`, {
@@ -266,7 +274,9 @@ export class SyncService {
     return this.meetings
       .readAll()
       .filter((record) => !record.trashedAt)
-      .filter((record) => this.config.pushed[record.id] !== contentHash(record))
+      .filter(
+        (record) => this.config.pushed[record.id] !== contentHash(record, this.config.mediaUrls)
+      )
   }
 
   private async pushAll(): Promise<void> {
@@ -294,13 +304,14 @@ export class SyncService {
       }
 
       for (const record of this.pendingMeetings()) {
+        await this.uploadReferencedMedia(record, token)
         const response = await fetch(`${this.baseUrl}/api/sync/push`, {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify({ meetings: [toPushMeeting(record)] })
+          body: JSON.stringify({ meetings: [toPushMeeting(record, this.config.mediaUrls)] })
         })
         if (!response.ok) {
           const body = (await response.json().catch(() => ({}))) as { error?: string }
@@ -315,7 +326,7 @@ export class SyncService {
           console.error('[sync] meeting rejected:', record.id, result?.error)
           continue
         }
-        this.config.pushed[record.id] = contentHash(record)
+        this.config.pushed[record.id] = contentHash(record, this.config.mediaUrls)
         this.writeConfig()
       }
 
@@ -328,6 +339,39 @@ export class SyncService {
     } finally {
       this.syncing = false
       this.emitStatus()
+    }
+  }
+
+  /**
+   * Upload attachments referenced by this meeting's markdown that haven't
+   * been uploaded yet (name → URL cached in config). Images over the API's
+   * 3MB cap (or with missing files) stay local — their refs are left as-is.
+   */
+  private async uploadReferencedMedia(record: MeetingRecord, token: string): Promise<void> {
+    for (const name of mediaRefs(record)) {
+      if (this.config.mediaUrls[name]) continue
+      let bytes: Buffer
+      try {
+        bytes = readFileSync(join(this.attachmentsDir, name))
+      } catch {
+        continue // file gone — nothing to upload
+      }
+      if (bytes.byteLength > 3 * 1024 * 1024) continue
+      try {
+        const response = await fetch(`${this.baseUrl}/api/sync/media`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, data: bytes.toString('base64') })
+        })
+        if (!response.ok) continue
+        const body = (await response.json()) as { url?: string }
+        if (typeof body.url === 'string' && body.url.startsWith('https://')) {
+          this.config.mediaUrls[name] = body.url
+          this.writeConfig()
+        }
+      } catch {
+        // Network hiccup — the ref stays local; a later push retries.
+      }
     }
   }
 
@@ -353,10 +397,14 @@ export class SyncService {
         ...(typeof raw.workspaceName === 'string' ? { workspaceName: raw.workspaceName } : {}),
         ...(typeof raw.lastSyncAt === 'string' ? { lastSyncAt: raw.lastSyncAt } : {}),
         pushed: raw.pushed && typeof raw.pushed === 'object' ? (raw.pushed as Record<string, string>) : {},
+        mediaUrls:
+          raw.mediaUrls && typeof raw.mediaUrls === 'object'
+            ? (raw.mediaUrls as Record<string, string>)
+            : {},
         pendingDeletes: Array.isArray(raw.pendingDeletes) ? raw.pendingDeletes.map(String) : []
       }
     } catch {
-      return { enabled: false, pushed: {}, pendingDeletes: [] }
+      return { enabled: false, pushed: {}, mediaUrls: {}, pendingDeletes: [] }
     }
   }
 
@@ -369,22 +417,38 @@ export class SyncService {
   }
 }
 
-/** Stable hash of everything the push carries — change detection. */
-function contentHash(record: MeetingRecord): string {
+const MEDIA_REF = /doodle-media:\/\/([a-z0-9.-]+)/g
+
+/** Attachment names referenced in the meeting's markdown. */
+function mediaRefs(record: MeetingRecord): string[] {
+  const text = `${record.rawNotesMarkdown}\n${record.enhancedMarkdown ?? ''}`
+  return [...new Set([...text.matchAll(MEDIA_REF)].map((m) => m[1]!))]
+}
+
+/** Local doodle-media:// refs → public blob URLs (only those uploaded). */
+function rewriteMedia(markdown: string, mediaUrls: Record<string, string>): string {
+  return markdown.replace(MEDIA_REF, (whole, name: string) => mediaUrls[name] ?? whole)
+}
+
+/** Stable hash of everything the push carries — change detection. Includes
+ *  the media rewrite so a late-arriving upload URL triggers a re-push. */
+function contentHash(record: MeetingRecord, mediaUrls: Record<string, string>): string {
   const projection = {
     title: record.title,
     createdAt: record.createdAt,
     startedAt: record.startedAt ?? null,
     endedAt: record.endedAt ?? null,
     calendarEventId: record.calendarEventId ?? null,
-    rawNotesMarkdown: record.rawNotesMarkdown,
-    enhancedMarkdown: record.enhancedMarkdown ?? null,
+    rawNotesMarkdown: rewriteMedia(record.rawNotesMarkdown, mediaUrls),
+    enhancedMarkdown: record.enhancedMarkdown
+      ? rewriteMedia(record.enhancedMarkdown, mediaUrls)
+      : null,
     segments: record.segments.map((s) => [s.channel, s.speaker, s.text, s.startMs, s.endMs])
   }
   return createHash('sha256').update(JSON.stringify(projection)).digest('hex')
 }
 
-function toPushMeeting(record: MeetingRecord): object {
+function toPushMeeting(record: MeetingRecord, mediaUrls: Record<string, string>): object {
   return {
     id: record.id,
     title: record.title,
@@ -392,8 +456,12 @@ function toPushMeeting(record: MeetingRecord): object {
     ...(record.startedAt ? { startedAt: record.startedAt } : {}),
     ...(record.endedAt ? { endedAt: record.endedAt } : {}),
     ...(record.calendarEventId ? { calendarEventId: record.calendarEventId } : {}),
-    ...(record.rawNotesMarkdown ? { rawNotesMarkdown: record.rawNotesMarkdown } : {}),
-    ...(record.enhancedMarkdown ? { enhancedMarkdown: record.enhancedMarkdown } : {}),
+    ...(record.rawNotesMarkdown
+      ? { rawNotesMarkdown: rewriteMedia(record.rawNotesMarkdown, mediaUrls) }
+      : {}),
+    ...(record.enhancedMarkdown
+      ? { enhancedMarkdown: rewriteMedia(record.enhancedMarkdown, mediaUrls) }
+      : {}),
     // Echo-flagged segments are far-side bleed the UI hides — don't sync them.
     segments: record.segments
       .filter((s) => !s.echo)

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -46,8 +46,10 @@ import {
   MEETINGS_DELETE_CHANNEL,
   MEETINGS_GET_CHANNEL,
   MEETINGS_LIST_CHANNEL,
+  MEETINGS_SEARCH_CHANNEL,
   MEETINGS_UPSERT_CHANNEL,
   type MeetingRecord,
+  type MeetingSearchHit,
   type MeetingSummary,
   type MeetingUpsert,
   type MeetingsApi
@@ -197,6 +199,10 @@ const notesApi: NotesApi = {
 }
 
 const meetingsApi: MeetingsApi = {
+  search(query: string): Promise<MeetingSearchHit[]> {
+    return ipcRenderer.invoke(MEETINGS_SEARCH_CHANNEL, query) as Promise<MeetingSearchHit[]>
+  },
+
   list(): Promise<MeetingSummary[]> {
     return ipcRenderer.invoke(MEETINGS_LIST_CHANNEL) as Promise<MeetingSummary[]>
   },

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -559,7 +559,7 @@ function App(): React.JSX.Element {
           </span>
           <span className="mb-text">
             {banner.adHoc ? (
-              <>Looks like you&rsquo;re in a meeting</>
+              <>Looks like you&rsquo;re on a call</>
             ) : (
               <>
                 <strong>{banner.subject}</strong> is starting

--- a/apps/desktop/src/renderer/src/HomeView.tsx
+++ b/apps/desktop/src/renderer/src/HomeView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { CalendarEvent, CalendarState } from '../../shared/calendar-api'
 import type { FolderRecord } from '../../shared/folders-api'
-import type { MeetingSummary } from '../../shared/meetings-api'
+import type { MeetingSearchHit, MeetingSummary } from '../../shared/meetings-api'
 import type {
   GlobalChatEntry,
   NotesModelsResponse,
@@ -522,6 +522,29 @@ export default function HomeView({
   const cloudReady = settings?.engineChoice === 'cloud' && settings.cloud?.hasKey === true
   const modelReady = cloudReady || anyDownloaded
 
+  /** Full-text hits for the current query (id → matched field); null while
+   *  the query is empty. Debounced main-process scan. */
+  const [searchHits, setSearchHits] = useState<Map<string, MeetingSearchHit['field']> | null>(null)
+
+  useEffect(() => {
+    const q = search.trim()
+    if (q.length === 0) {
+      setSearchHits(null)
+      return
+    }
+    let cancelled = false
+    const timer = setTimeout(() => {
+      void window.meetings.search(q).then((hits) => {
+        if (cancelled) return
+        setSearchHits(new Map(hits.map((h) => [h.id, h.field])))
+      })
+    }, 150)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [search])
+
   const visible = useMemo(() => {
     const all = meetings ?? []
     if (filter.kind === 'trash') return all.filter((m) => Boolean(m.trashedAt))
@@ -531,9 +554,13 @@ export default function HomeView({
 
   const groups = useMemo(() => {
     const query = search.trim().toLowerCase()
-    const filtered = visible.filter(
-      (m) => query.length === 0 || (m.title || 'New meeting').toLowerCase().includes(query)
-    )
+    const filtered = visible.filter((m) => {
+      if (query.length === 0) return true
+      // Instant title match keeps typing snappy; the async full-text hits
+      // widen the net to notes and transcripts as they arrive.
+      if ((m.title || 'New meeting').toLowerCase().includes(query)) return true
+      return searchHits?.has(m.id) ?? false
+    })
     const out: Array<{ label: string; items: MeetingSummary[]; older: boolean }> = []
     for (const m of filtered) {
       const label = dayLabel(m.createdAt)
@@ -545,7 +572,7 @@ export default function HomeView({
       }
     }
     return out
-  }, [visible, search])
+  }, [visible, search, searchHits])
 
   /* ---- mutations (upsert/delete, then let App refetch) ---- */
 
@@ -701,6 +728,12 @@ export default function HomeView({
                         <span className="row-sub">
                           {m.kind === 'note' ? 'Note' : 'Me'}
                           {m.durationMin !== undefined ? ` · ${m.durationMin} min` : ''}
+                          {search.trim().length > 0 &&
+                            (searchHits?.get(m.id) === 'transcript'
+                              ? ' · matches transcript'
+                              : searchHits?.get(m.id) === 'notes'
+                                ? ' · matches notes'
+                                : '')}
                         </span>
                       </span>
                       <span className="row-time">{timeLabel(m.createdAt)}</span>

--- a/apps/desktop/src/renderer/src/MeetingView.tsx
+++ b/apps/desktop/src/renderer/src/MeetingView.tsx
@@ -626,15 +626,27 @@ export default function MeetingView({
       setEnhanceError(result.error ?? 'Enhance failed with no output')
       return
     }
+    // Granola-style footer: when the meeting lives in the cloud too, the
+    // notes link to its web page (full transcript + chat). Skipped while
+    // sync is off — local-first notes carry no dead links.
+    let markdown = result.markdown
+    try {
+      const sync = await window.sync.getStatus()
+      if (sync.connected && sync.enabled) {
+        markdown += `\n\n---\n\n[View transcript & chat](${sync.baseUrl}/app/meeting/${meetingId})`
+      }
+    } catch {
+      // status unavailable — plain notes are fine
+    }
     setEnhanceStatus('idle')
-    setEnhancedMarkdown(result.markdown)
+    setEnhancedMarkdown(markdown)
     persist({
-      enhancedMarkdown: result.markdown,
+      enhancedMarkdown: markdown,
       ...(result.engine ? { engine: result.engine } : {})
     })
     setDocView('enhanced')
     docViewRef.current = 'enhanced'
-    setEditorMarkdown(result.markdown, false)
+    setEditorMarkdown(markdown, false)
   }
 
   /** Pick a template: remember it on the meeting and (re)generate with it. */

--- a/apps/desktop/src/renderer/src/lib/markdown.ts
+++ b/apps/desktop/src/renderer/src/lib/markdown.ts
@@ -132,6 +132,11 @@ function escapeHtml(s: string): string {
 
 function inlineHtml(s: string): string {
   let out = escapeHtml(s)
+  // Links: http(s) only — anything else stays literal text.
+  out = out.replace(
+    /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+    '<a href="$2" rel="noreferrer">$1</a>'
+  )
   out = out.replace(/`([^`]+)`/g, '<code>$1</code>')
   out = out.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
   out = out.replace(/(^|[^*])\*([^*\s][^*]*)\*/g, '$1<em>$2</em>')

--- a/apps/desktop/src/shared/meetings-api.ts
+++ b/apps/desktop/src/shared/meetings-api.ts
@@ -12,6 +12,7 @@ import type { TranscriptSegment } from './engine-events'
 export const MEETINGS_LIST_CHANNEL = 'meetings:list'
 export const MEETINGS_GET_CHANNEL = 'meetings:get'
 export const MEETINGS_UPSERT_CHANNEL = 'meetings:upsert'
+export const MEETINGS_SEARCH_CHANNEL = 'meetings:search'
 export const MEETINGS_DELETE_CHANNEL = 'meetings:delete'
 
 /** One persisted "ask anything" exchange. */
@@ -82,7 +83,15 @@ export interface MeetingSummary {
 export type MeetingUpsert = Partial<Omit<MeetingRecord, 'id'>> & { id: string }
 
 /** API surface exposed on `window.meetings` by the preload script. */
+/** Where a full-text search query matched (strongest field reported). */
+export interface MeetingSearchHit {
+  id: string
+  field: 'title' | 'notes' | 'transcript'
+}
+
 export interface MeetingsApi {
+  /** Case-insensitive search across titles, notes, and transcripts. */
+  search(query: string): Promise<MeetingSearchHit[]>
   list(): Promise<MeetingSummary[]>
   get(id: string): Promise<MeetingRecord | null>
   upsert(meeting: MeetingUpsert): Promise<MeetingRecord>

--- a/apps/desktop/src/shared/sync-api.ts
+++ b/apps/desktop/src/shared/sync-api.ts
@@ -25,6 +25,8 @@ export interface SyncStatus {
   lastError?: string
   /** True while the browser link flow is waiting for approval. */
   linking: boolean
+  /** Web app origin (prod, or DOODLE_SYNC_URL override) for building links. */
+  baseUrl: string
 }
 
 export type ShareResult = { url: string } | { error: string }

--- a/apps/web/app/api/sync/media/route.ts
+++ b/apps/web/app/api/sync/media/route.ts
@@ -1,0 +1,66 @@
+import { put } from "@vercel/blob";
+import { NextResponse } from "next/server";
+
+import { authenticateSyncRequest } from "@/lib/sync-auth";
+
+/** Keeps the JSON body under Vercel's request limit (base64 ≈ 4/3 size). */
+const MAX_BYTES = 3 * 1024 * 1024;
+
+const NAME_RE = /^[a-z0-9-]+\.(png|jpg|jpeg|gif|webp)$/;
+const MIME_BY_EXT: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+};
+
+/**
+ * Upload one note attachment. Bearer-authenticated; images land in the
+ * public Blob store under the workspace's prefix and the desktop rewrites
+ * its markdown to the returned URL when pushing.
+ */
+export async function POST(request: Request) {
+  const device = await authenticateSyncRequest(request);
+  if (!device) {
+    return NextResponse.json({ error: "Invalid sync token" }, { status: 401 });
+  }
+
+  let body: { name?: unknown; data?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const name = String(body.name ?? "");
+  if (!NAME_RE.test(name)) {
+    return NextResponse.json({ error: "Bad attachment name" }, { status: 400 });
+  }
+  const ext = name.split(".").pop()!;
+  const data = typeof body.data === "string" ? body.data : "";
+  const buffer = Buffer.from(data, "base64");
+  if (buffer.byteLength === 0 || buffer.byteLength > MAX_BYTES) {
+    return NextResponse.json(
+      { error: `Attachment must be 1 byte – ${MAX_BYTES / 1024 / 1024} MB` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const blob = await put(
+      `attachments/${device.organizationId}/${name}`,
+      buffer,
+      {
+        access: "public",
+        contentType: MIME_BY_EXT[ext],
+        addRandomSuffix: false,
+      },
+    );
+    return NextResponse.json({ url: blob.url });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Upload failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { desc, eq, getDb, meetings, notes, sql } from "@repo/db";
+import { and, desc, eq, getDb, ilike, meetings, notes, or, sql } from "@repo/db";
 
 import { auth } from "@/lib/auth";
 import { ensurePersonalWorkspace } from "@/lib/workspace";
@@ -19,7 +19,13 @@ function formatWhen(date: Date | null): string {
   });
 }
 
-export default async function MeetingsPage() {
+export default async function MeetingsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>;
+}) {
+  const { q } = await searchParams;
+  const query = (q ?? "").trim().slice(0, 200);
   const requestHeaders = await headers();
   const session = await auth.api.getSession({ headers: requestHeaders });
   if (!session) redirect("/login");
@@ -36,6 +42,8 @@ export default async function MeetingsPage() {
     personal;
 
   const db = getDb();
+  const pattern = `%${query}%`;
+  const scope = eq(meetings.organizationId, activeOrg.id);
   const rows = await db
     .select({
       id: meetings.id,
@@ -47,7 +55,19 @@ export default async function MeetingsPage() {
     })
     .from(meetings)
     .leftJoin(notes, eq(notes.meetingId, meetings.id))
-    .where(eq(meetings.organizationId, activeOrg.id))
+    .where(
+      query.length === 0
+        ? scope
+        : and(
+            scope,
+            or(
+              ilike(meetings.title, pattern),
+              sql`${notes.rawContent}->>'markdown' ilike ${pattern}`,
+              sql`${notes.enhancedContent}->>'markdown' ilike ${pattern}`,
+              sql`exists (select 1 from transcript_segments ts where ts.meeting_id = ${meetings.id} and ts.text ilike ${pattern})`,
+            ),
+          ),
+    )
     .orderBy(desc(sql`coalesce(${meetings.startedAt}, ${meetings.createdAt})`))
     .limit(200);
 
@@ -60,7 +80,21 @@ export default async function MeetingsPage() {
         <span className="text-sm text-stone">{activeOrg.name}</span>
       </div>
 
-      {rows.length === 0 ? (
+      <form method="get" className="mt-4">
+        <input
+          type="search"
+          name="q"
+          defaultValue={query}
+          placeholder="Search titles, notes, and transcripts…"
+          className="w-full rounded-md border border-sand bg-white px-3 py-2 text-sm text-ink outline-none placeholder:text-stone focus:border-sage"
+        />
+      </form>
+
+      {rows.length === 0 && query.length > 0 ? (
+        <p className="mt-8 rounded-xl border border-sand bg-card-soft p-6 text-center text-sm text-stone">
+          Nothing matches &ldquo;{query}&rdquo;.
+        </p>
+      ) : rows.length === 0 ? (
         <div className="mt-10 rounded-xl border border-sand bg-card-soft p-8 text-center">
           <h2 className="text-base font-semibold text-ink">
             No meetings synced yet

--- a/apps/web/app/app/workspaces/page.tsx
+++ b/apps/web/app/app/workspaces/page.tsx
@@ -2,6 +2,7 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { auth } from "@/lib/auth";
+import { ensurePersonalWorkspace } from "@/lib/workspace";
 
 import { WorkspacesPanel } from "./workspaces-panel";
 
@@ -12,6 +13,7 @@ export default async function WorkspacesPage() {
   const session = await auth.api.getSession({ headers: requestHeaders });
   if (!session) redirect("/login");
 
+  await ensurePersonalWorkspace(session.user.id);
   const organizations = await auth.api.listOrganizations({
     headers: requestHeaders,
   });
@@ -20,6 +22,28 @@ export default async function WorkspacesPage() {
   // means the first one is treated as active.
   const activeOrganizationId =
     session.session.activeOrganizationId ?? organizations[0]?.id ?? null;
+
+  // Members + pending invitations of the active workspace, for the panel.
+  let members: Array<{ id: string; email: string; role: string }> = [];
+  let invitations: Array<{ id: string; email: string; status: string }> = [];
+  if (activeOrganizationId) {
+    try {
+      const full = await auth.api.getFullOrganization({
+        headers: requestHeaders,
+        query: { organizationId: activeOrganizationId },
+      });
+      members = (full?.members ?? []).map((m) => ({
+        id: m.id,
+        email: m.user?.email ?? "",
+        role: m.role,
+      }));
+      invitations = (full?.invitations ?? [])
+        .filter((i) => i.status === "pending")
+        .map((i) => ({ id: i.id, email: i.email, status: i.status }));
+    } catch {
+      // Not a member of the active org (stale session) — panel shows basics.
+    }
+  }
 
   return (
     <WorkspacesPanel
@@ -30,6 +54,8 @@ export default async function WorkspacesPage() {
         name: org.name,
         slug: org.slug,
       }))}
+      members={members}
+      invitations={invitations}
     />
   );
 }

--- a/apps/web/app/app/workspaces/workspaces-panel.tsx
+++ b/apps/web/app/app/workspaces/workspaces-panel.tsx
@@ -11,23 +11,85 @@ interface Workspace {
   slug: string;
 }
 
+interface Member {
+  id: string;
+  email: string;
+  role: string;
+}
+
+interface Invitation {
+  id: string;
+  email: string;
+  status: string;
+}
+
 export function WorkspacesPanel({
   userEmail,
   activeOrganizationId,
   organizations,
+  members,
+  invitations,
 }: {
   userEmail: string;
   activeOrganizationId: string | null;
   organizations: Workspace[];
+  members: Member[];
+  invitations: Invitation[];
 }) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [invitePending, setInvitePending] = useState(false);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
 
   async function handleSetActive(organizationId: string) {
     setError(null);
     const result = await authClient.organization.setActive({ organizationId });
     if (result.error) {
       setError(result.error.message ?? "Could not switch workspace");
+      return;
+    }
+    router.refresh();
+  }
+
+  async function handleInvite(event: React.FormEvent) {
+    event.preventDefault();
+    const email = inviteEmail.trim();
+    if (!email || !activeOrganizationId) return;
+    setError(null);
+    setInvitePending(true);
+    const result = await authClient.organization.inviteMember({
+      email,
+      role: "member",
+      organizationId: activeOrganizationId,
+    });
+    setInvitePending(false);
+    if (result.error) {
+      setError(result.error.message ?? "Could not create the invitation");
+      return;
+    }
+    setInviteEmail("");
+    router.refresh();
+  }
+
+  async function copyInviteLink(invitationId: string) {
+    const url = `${window.location.origin}/invite/${invitationId}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedId(invitationId);
+      setTimeout(() => setCopiedId(null), 2500);
+    } catch {
+      setError(url); // clipboard blocked — surface the link itself
+    }
+  }
+
+  async function cancelInvite(invitationId: string) {
+    setError(null);
+    const result = await authClient.organization.cancelInvitation({
+      invitationId,
+    });
+    if (result.error) {
+      setError(result.error.message ?? "Could not cancel the invitation");
       return;
     }
     router.refresh();
@@ -44,14 +106,14 @@ export function WorkspacesPanel({
       </p>
 
       {error && (
-        <p role="alert" className="mt-4 text-sm text-red-700">
+        <p role="alert" className="mt-4 break-all text-sm text-red-700">
           {error}
         </p>
       )}
 
       {organizations.length === 0 ? (
         <p className="mt-6 rounded-xl border border-dashed border-sand bg-card-soft px-4 py-6 text-center text-sm text-stone">
-          No workspaces yet — create your first one below.
+          No workspaces yet.
         </p>
       ) : (
         <ul className="mt-6 divide-y divide-sand rounded-xl border border-sand bg-white">
@@ -87,18 +149,75 @@ export function WorkspacesPanel({
         </ul>
       )}
 
-      <div className="mt-4 rounded-xl border border-dashed border-sand bg-card-soft px-5 py-4">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-ink">Team workspaces</span>
-          <span className="rounded-full bg-sage-fill px-2 py-0.5 text-xs font-medium text-sage-deep">
-            coming soon
-          </span>
-        </div>
+      <section className="mt-8">
+        <h2 className="text-base font-semibold text-ink">Members</h2>
         <p className="mt-1 text-sm text-stone">
-          Invite your team to a shared meeting library — everyone&rsquo;s
-          synced meetings, searchable in one place.
+          Everyone in the active workspace sees its synced meetings.
         </p>
-      </div>
+
+        <ul className="mt-3 divide-y divide-sand rounded-xl border border-sand bg-white">
+          {members.map((member) => (
+            <li
+              key={member.id}
+              className="flex items-center justify-between gap-4 px-5 py-3"
+            >
+              <span className="truncate text-sm text-ink">{member.email}</span>
+              <span className="shrink-0 text-xs text-stone">{member.role}</span>
+            </li>
+          ))}
+          {invitations.map((invite) => (
+            <li
+              key={invite.id}
+              className="flex items-center justify-between gap-4 px-5 py-3"
+            >
+              <span className="min-w-0">
+                <span className="block truncate text-sm text-ink">
+                  {invite.email}
+                </span>
+                <span className="text-xs text-stone">invited — send them the link</span>
+              </span>
+              <span className="flex shrink-0 items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => copyInviteLink(invite.id)}
+                  className="rounded-md border border-sand bg-white px-2.5 py-1 text-xs text-ink transition-colors hover:bg-sage-fill"
+                >
+                  {copiedId === invite.id ? "Copied ✓" : "Copy invite link"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => cancelInvite(invite.id)}
+                  className="rounded-md px-2 py-1 text-xs text-stone hover:text-red-700"
+                  title="Cancel invitation"
+                >
+                  ✕
+                </button>
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        <form onSubmit={handleInvite} className="mt-3 flex items-start gap-2">
+          <input
+            type="email"
+            placeholder="teammate@company.com"
+            value={inviteEmail}
+            onChange={(e) => setInviteEmail(e.target.value)}
+            className="flex-1 rounded-md border border-sand bg-white px-3 py-2 text-sm text-ink outline-none placeholder:text-stone focus:border-sage"
+          />
+          <button
+            type="submit"
+            disabled={invitePending || !inviteEmail.trim() || !activeOrganizationId}
+            className="rounded-md bg-ink px-3 py-2 text-sm font-medium text-cream transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            {invitePending ? "Inviting…" : "Invite"}
+          </button>
+        </form>
+        <p className="mt-2 text-xs text-stone">
+          Invitations don&rsquo;t send email yet — copy the link and send it
+          yourself. It works once they sign in with the invited address.
+        </p>
+      </section>
     </main>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -70,6 +70,13 @@ body {
   padding: 0.1em 0.35em;
   font-size: 0.85em;
 }
+.prose-notes img {
+  max-width: min(100%, 560px);
+  border-radius: 10px;
+  border: 1px solid var(--color-sand);
+  display: block;
+  margin: 0.6em 0;
+}
 .prose-notes blockquote {
   border-left: 3px solid var(--color-sand);
   margin: 0.6em 0;

--- a/apps/web/app/invite/[id]/accept-invite.tsx
+++ b/apps/web/app/invite/[id]/accept-invite.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { authClient } from "@/lib/auth-client";
+
+export function AcceptInvite({ invitationId }: { invitationId: string }) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function accept() {
+    setError(null);
+    setPending(true);
+    const result = await authClient.organization.acceptInvitation({
+      invitationId,
+    });
+    setPending(false);
+    if (result.error) {
+      setError(result.error.message ?? "Could not accept the invitation");
+      return;
+    }
+    await authClient.organization.setActive({
+      organizationId: result.data.invitation.organizationId,
+    });
+    router.push("/app");
+    router.refresh();
+  }
+
+  return (
+    <>
+      {error && (
+        <p role="alert" className="mt-3 text-sm text-red-700">
+          {error}
+        </p>
+      )}
+      <button
+        type="button"
+        disabled={pending}
+        onClick={() => void accept()}
+        className="mt-4 w-full rounded-md bg-ink px-3 py-2 text-sm font-medium text-cream transition-opacity hover:opacity-90 disabled:opacity-50"
+      >
+        {pending ? "Joining…" : "Join workspace"}
+      </button>
+    </>
+  );
+}

--- a/apps/web/app/invite/[id]/page.tsx
+++ b/apps/web/app/invite/[id]/page.tsx
@@ -1,0 +1,66 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { auth } from "@/lib/auth";
+
+import { AcceptInvite } from "./accept-invite";
+
+export const metadata = { title: "Workspace invitation — DoodleNote" };
+
+/** Invitation landing page: sign in (with the invited email), then accept. */
+export default async function InvitePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const requestHeaders = await headers();
+  const session = await auth.api.getSession({ headers: requestHeaders });
+  if (!session) {
+    redirect(`/login?${new URLSearchParams({ next: `/invite/${id}` })}`);
+  }
+
+  let organizationName: string | null = null;
+  let inviterEmail: string | null = null;
+  let problem: string | null = null;
+  try {
+    const invitation = await auth.api.getInvitation({
+      headers: requestHeaders,
+      query: { id },
+    });
+    organizationName = invitation.organizationName;
+    inviterEmail = invitation.inviterEmail;
+  } catch {
+    problem =
+      "This invitation doesn't exist, has expired, or was sent to a different email address. Make sure you're signed in with the address that was invited.";
+  }
+
+  return (
+    <main className="flex flex-1 flex-col items-center justify-center bg-cream px-6 py-16">
+      <div className="w-full max-w-sm rounded-xl border border-sand bg-white p-6 text-center">
+        {problem ? (
+          <>
+            <h1 className="text-lg font-semibold text-ink">
+              Invitation not available
+            </h1>
+            <p className="mt-2 text-sm text-bark">{problem}</p>
+            <p className="mt-2 text-xs text-stone">
+              Signed in as {session!.user.email}
+            </p>
+          </>
+        ) : (
+          <>
+            <h1 className="text-lg font-semibold text-ink">
+              Join “{organizationName}”?
+            </h1>
+            <p className="mt-2 text-sm text-bark">
+              {inviterEmail} invited you to their DoodleNote workspace. You’ll
+            see the meetings and notes synced to it.
+            </p>
+            <AcceptInvite invitationId={id} />
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@repo/db": "workspace:*",
+    "@vercel/blob": "^2.5.0",
     "better-auth": "^1.6.23",
     "next": "16.2.10",
     "react": "19.2.4",

--- a/engine/Sources/engine/EngineMain.swift
+++ b/engine/Sources/engine/EngineMain.swift
@@ -24,6 +24,8 @@ struct EngineMain {
                 await PreflightCommand.run()
             case "micmon":
                 MicMonitorCommand.run()
+            case "serve":
+                try await ServeCommand.run(options)
             case "info":
                 Commands.info()
             default:

--- a/engine/Sources/engine/LiveCommand.swift
+++ b/engine/Sources/engine/LiveCommand.swift
@@ -17,7 +17,12 @@ enum LiveCommand {
         // Arm stop handling FIRST. A SIGTERM that arrives before the handlers
         // exist kills the process instantly and silently — which, during model
         // warm-up, meant an early Stop click threw the whole session away.
+        let stopper = Stopper()
         StopController.shared.arm()
+        Task {
+            await StopController.shared.wait(timeoutSeconds: nil)
+            stopper.stop()
+        }
 
         // Opt-in parent-death watchdog: hosts that spawn us with a live stdin
         // pipe pass this flag; when the pipe closes (host crashed/restarted),
@@ -34,13 +39,35 @@ enum LiveCommand {
             }.start()
         }
 
-        let source = options.values["source"] ?? "both"
+        try await LiveSession.run(
+            source: options.values["source"] ?? "both",
+            aec: options.values["aec"] == "on",
+            seconds: options.values["seconds"].flatMap(Double.init),
+            micManager: nil,
+            systemManager: nil,
+            stopper: stopper
+        )
+    }
+}
+
+// MARK: - The session itself (shared by `live` and `serve`)
+
+/// One capture-to-finals session. `serve` passes preloaded ASR managers so
+/// transcription starts instantly; `live` passes nil and loads per-session.
+enum LiveSession {
+    static func run(
+        source: String,
+        aec: Bool,
+        seconds: Double?,
+        micManager: StreamingUnifiedAsrManager?,
+        systemManager: StreamingUnifiedAsrManager?,
+        stopper: Stopper
+    ) async throws {
         let wantMic = source == "mic" || source == "both"
         let wantSystem = source == "system" || source == "both"
         guard wantMic || wantSystem else {
             throw EngineError.usage("--source must be mic | system | both")
         }
-        let seconds = options.values["seconds"].flatMap(Double.init)
 
         // Capture-first startup: pipelines are created WITHOUT loading models so
         // recording begins the moment permissions clear. Audio queues in each
@@ -48,8 +75,8 @@ enum LiveCommand {
         // show "recording" immediately and no audio is lost.
         var micPipeline: ChannelPipeline?
         var systemPipeline: ChannelPipeline?
-        if wantMic { micPipeline = ChannelPipeline(channel: "mic") }
-        if wantSystem { systemPipeline = ChannelPipeline(channel: "system") }
+        if wantMic { micPipeline = ChannelPipeline(channel: "mic", manager: micManager) }
+        if wantSystem { systemPipeline = ChannelPipeline(channel: "system", manager: systemManager) }
 
         var micCapture: MicCapture?
         var systemCapture: SystemAudioCapture?
@@ -77,7 +104,7 @@ enum LiveCommand {
             // initialize on some setups, and its teardown/retry can leave the
             // fallback mic silently dead. Cross-channel transcript dedup
             // handles speaker echo, so reliability wins by default.
-            micCapture = MicCapture(into: pipeline, enableAEC: options.values["aec"] == "on")
+            micCapture = MicCapture(into: pipeline, enableAEC: aec)
         }
 
         try micCapture?.start()
@@ -131,7 +158,7 @@ enum LiveCommand {
         // Warm-up complete — hosts can flip from "warming up" to live UI.
         Events.emit(["event": "status", "stage": "transcribing"])
 
-        await StopController.shared.wait(timeoutSeconds: seconds)
+        await stopper.wait(timeoutSeconds: seconds)
         Events.emit(["event": "status", "stage": "finishing"])
 
         micCapture?.stop()
@@ -157,17 +184,22 @@ final class ChannelPipeline {
     private let epochLock = NSLock()
     private var epochEmitted = false
 
-    init(channel: String) {
+    private let preloaded: Bool
+
+    init(channel: String, manager: StreamingUnifiedAsrManager? = nil) {
         self.channel = channel
-        self.manager = StreamingUnifiedAsrManager()
+        self.preloaded = manager != nil
+        self.manager = manager ?? StreamingUnifiedAsrManager()
         (self.bufferStream, self.bufferContinuation) = AsyncStream.makeStream(of: AVAudioPCMBuffer.self)
     }
 
-    /// Load models and wire callbacks. Called AFTER capture starts — audio
-    /// queues in the buffer stream until begin() drains it.
+    /// Load models (unless the serve host preloaded them) and wire callbacks.
+    /// Called AFTER capture starts — audio queues until begin() drains it.
     func prepare() async throws {
-        Events.emit(["event": "status", "stage": "loading_models", "channel": channel, "model": "parakeet-unified-en-0.6b"])
-        try await manager.loadModels()
+        if !preloaded {
+            Events.emit(["event": "status", "stage": "loading_models", "channel": channel, "model": "parakeet-unified-en-0.6b"])
+            try await manager.loadModels()
+        }
         let ch = channel
         await manager.setPartialTranscriptCallback { text in
             Events.emit(["event": "partial", "channel": ch, "text": text])
@@ -377,6 +409,42 @@ final class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate {
     func stream(_ stream: SCStream, didStopWithError error: Error) {
         Events.emit(["event": "error", "channel": "system", "message": "system capture stopped: \(error.localizedDescription)"])
         StopController.shared.stop()
+    }
+}
+
+// MARK: - Per-session stop flag (serve reuses the process across sessions)
+
+final class Stopper: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stopped = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func stop() {
+        lock.lock()
+        let resumable = waiters
+        waiters = []
+        stopped = true
+        lock.unlock()
+        resumable.forEach { $0.resume() }
+    }
+
+    func wait(timeoutSeconds: Double?) async {
+        if let timeoutSeconds {
+            Task {
+                try? await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                self.stop()
+            }
+        }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            if stopped {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                waiters.append(continuation)
+                lock.unlock()
+            }
+        }
     }
 }
 

--- a/engine/Sources/engine/MicMonitorCommand.swift
+++ b/engine/Sources/engine/MicMonitorCommand.swift
@@ -11,6 +11,7 @@ enum MicMonitorCommand {
     private static var deviceId = AudioObjectID(kAudioObjectUnknown)
     private static var lastRunning: Bool?
     private static var lastBundles: Set<String> = []
+    private static var lastOutputBundles: Set<String> = []
     private static let queue = DispatchQueue(label: "micmon")
     private static var timer: DispatchSourceTimer?
 
@@ -93,6 +94,17 @@ enum MicMonitorCommand {
 
     /// Bundle ids of every process currently capturing audio input.
     private static func capturingBundles() -> Set<String> {
+        processBundles(input: true)
+    }
+
+    /// Bundle ids of every process currently playing audio output — an
+    /// incoming Zoom/Teams/FaceTime call RINGS long before the mic engages,
+    /// and the ring is sustained meeting-app output.
+    private static func outputBundles() -> Set<String> {
+        processBundles(input: false)
+    }
+
+    private static func processBundles(input: Bool) -> Set<String> {
         guard #available(macOS 14.4, *) else { return [] }
         var listAddress = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyProcessObjectList,
@@ -112,7 +124,7 @@ enum MicMonitorCommand {
         var bundles: Set<String> = []
         for process in processes {
             var inputAddress = AudioObjectPropertyAddress(
-                mSelector: kAudioProcessPropertyIsRunningInput,
+                mSelector: input ? kAudioProcessPropertyIsRunningInput : kAudioProcessPropertyIsRunningOutput,
                 mScope: kAudioObjectPropertyScopeGlobal,
                 mElement: kAudioObjectPropertyElementMain
             )
@@ -144,15 +156,19 @@ enum MicMonitorCommand {
     private static func emitCurrent() {
         lastRunning = isRunningSomewhere()
         lastBundles = capturingBundles()
+        lastOutputBundles = outputBundles()
         emit()
     }
 
     private static func emitIfChanged() {
         let running = isRunningSomewhere()
         let bundles = capturingBundles()
-        guard running != lastRunning || bundles != lastBundles else { return }
+        let output = outputBundles()
+        guard running != lastRunning || bundles != lastBundles || output != lastOutputBundles
+        else { return }
         lastRunning = running
         lastBundles = bundles
+        lastOutputBundles = output
         emit()
     }
 
@@ -160,7 +176,8 @@ enum MicMonitorCommand {
         Events.emit([
             "event": "micmon",
             "running": lastRunning ?? false,
-            "bundles": lastBundles.sorted()
+            "bundles": lastBundles.sorted(),
+            "outputBundles": lastOutputBundles.sorted()
         ])
     }
 }

--- a/engine/Sources/engine/ServeCommand.swift
+++ b/engine/Sources/engine/ServeCommand.swift
@@ -1,0 +1,148 @@
+import FluidAudio
+import Foundation
+
+/// Persistent engine: load the ASR models ONCE, then run capture sessions on
+/// demand — recording starts Granola-instant instead of paying the per-spawn
+/// model warm-up. NDJSON commands on stdin:
+///   {"cmd":"start","source":"both","aec":"off"}
+///   {"cmd":"stop"}
+/// Session events on stdout are identical to the `live` command's, ending in
+/// "done"; between sessions the managers reset (models stay loaded). stdin
+/// EOF or SIGTERM stops any active session and exits.
+enum ServeCommand {
+    static func run(_ options: CLIOptions) async throws {
+        StopController.shared.arm()
+
+        Events.emit(["event": "status", "stage": "serve_loading_models"])
+        let micManager = StreamingUnifiedAsrManager()
+        let systemManager = StreamingUnifiedAsrManager()
+        try await micManager.loadModels()
+        try await systemManager.loadModels()
+        Events.emit(["event": "status", "stage": "serve_ready"])
+
+        let box = SessionBox()
+
+        // SIGTERM/SIGINT: host is quitting — drain the session, then exit.
+        Task {
+            await StopController.shared.wait(timeoutSeconds: nil)
+            box.stop()
+            await box.awaitCurrent()
+            exit(0)
+        }
+
+        for await line in stdinLines() {
+            guard
+                let data = line.data(using: .utf8),
+                let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let cmd = object["cmd"] as? String
+            else { continue }
+
+            switch cmd {
+            case "start":
+                let stopper = Stopper()
+                let source = object["source"] as? String ?? "both"
+                let aec = (object["aec"] as? String) == "on"
+                let started = box.begin(stopper) {
+                    do {
+                        try await LiveSession.run(
+                            source: source,
+                            aec: aec,
+                            seconds: nil,
+                            micManager: micManager,
+                            systemManager: systemManager,
+                            stopper: stopper
+                        )
+                    } catch {
+                        Events.emit(["event": "error", "message": "session failed: \(error)"])
+                        Events.emit(["event": "done"])
+                    }
+                    // Models stay loaded; transcription state clears for next time.
+                    try? await micManager.reset()
+                    try? await systemManager.reset()
+                }
+                if !started {
+                    Events.emit(["event": "error", "message": "a session is already active"])
+                }
+            case "stop":
+                box.stop()
+            default:
+                Events.log("serve: unknown command \(cmd)")
+            }
+        }
+
+        // stdin closed — host process is gone.
+        Events.log("serve: stdin closed — host gone; draining session")
+        box.stop()
+        await box.awaitCurrent()
+        exit(0)
+    }
+
+    /// stdin, line by line, as an AsyncStream (finishes on EOF).
+    private static func stdinLines() -> AsyncStream<String> {
+        AsyncStream { continuation in
+            Thread {
+                var buffer = Data()
+                while true {
+                    let chunk = FileHandle.standardInput.availableData
+                    if chunk.isEmpty { break }  // EOF
+                    buffer.append(chunk)
+                    while let newline = buffer.firstIndex(of: 0x0A) {
+                        let lineData = buffer.subdata(in: buffer.startIndex..<newline)
+                        buffer.removeSubrange(buffer.startIndex...newline)
+                        if let line = String(data: lineData, encoding: .utf8),
+                            !line.trimmingCharacters(in: .whitespaces).isEmpty
+                        {
+                            continuation.yield(line)
+                        }
+                    }
+                }
+                continuation.finish()
+            }.start()
+        }
+    }
+}
+
+/// At most one session at a time; thread-safe handle to stop/await it.
+final class SessionBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stopper: Stopper?
+    private var task: Task<Void, Never>?
+
+    /// Starts the session task unless one is already active.
+    func begin(_ stopper: Stopper, _ body: @escaping @Sendable () async -> Void) -> Bool {
+        lock.lock()
+        guard task == nil else {
+            lock.unlock()
+            return false
+        }
+        self.stopper = stopper
+        let task = Task {
+            await body()
+            self.clear()
+        }
+        self.task = task
+        lock.unlock()
+        return true
+    }
+
+    func stop() {
+        lock.lock()
+        let stopper = self.stopper
+        lock.unlock()
+        stopper?.stop()
+    }
+
+    func awaitCurrent() async {
+        lock.lock()
+        let task = self.task
+        lock.unlock()
+        await task?.value
+    }
+
+    private func clear() {
+        lock.lock()
+        stopper = nil
+        task = nil
+        lock.unlock()
+    }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,4 +3,4 @@ export * from "./auth-schema";
 export { getDb, schema, authSchema, fullSchema, type Db, type FullSchema } from "./client";
 // Query-builder helpers re-exported so consumers don't need their own
 // drizzle-orm dependency (keeps the version single-sourced here).
-export { and, asc, desc, eq, sql } from "drizzle-orm";
+export { and, asc, desc, eq, ilike, or, sql } from "drizzle-orm";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@repo/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@vercel/blob':
+        specifier: ^2.5.0
+        version: 2.5.0
       better-auth:
         specifier: ^1.6.23
         version: 1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(kysely@0.29.2))(next@16.2.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -141,7 +144,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.10
-        version: 16.2.10(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.10(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.3.2
@@ -2180,8 +2183,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/blob@2.5.0':
+    resolution: {integrity: sha512-ke6WnMMYlUu9nBFmyjwEkC2o03Ku2X7QIeJ3KtlOJzblS/8Xau209zt0ic76rd7IvV5nrKCH/BzP4MkFmoSLuw==}
+    engines: {node: '>=20.0.0'}
+
+  '@vercel/cli-config@0.2.0':
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+
+  '@vercel/cli-exec@1.0.0':
+    resolution: {integrity: sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==}
+    engines: {node: '>= 18'}
+
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vercel/oidc@3.8.0':
+    resolution: {integrity: sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==}
     engines: {node: '>= 20'}
 
   '@vitejs/plugin-react@5.2.0':
@@ -3110,6 +3128,10 @@ packages:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
@@ -3259,6 +3281,10 @@ packages:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
@@ -3366,6 +3392,10 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -3425,6 +3455,10 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
+
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
 
   is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
@@ -3491,6 +3525,9 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
@@ -3514,6 +3551,10 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -3580,6 +3621,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
@@ -3842,6 +3886,9 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -3925,6 +3972,10 @@ packages:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
     hasBin: true
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -4063,6 +4114,10 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -4098,6 +4153,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -4112,6 +4171,10 @@ packages:
 
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -4644,6 +4707,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -4704,6 +4771,10 @@ packages:
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
     engines: {node: '>=6.0.0'}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
@@ -4960,6 +5031,14 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
@@ -4999,6 +5078,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -6601,7 +6683,31 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  '@vercel/blob@2.5.0':
+    dependencies:
+      '@vercel/oidc': 3.8.0
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.27.0
+
+  '@vercel/cli-config@0.2.0':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@1.0.0':
+    dependencies:
+      execa: 5.1.1
+
   '@vercel/oidc@3.2.0': {}
+
+  '@vercel/oidc@3.8.0':
+    dependencies:
+      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-exec': 1.0.0
+      jose: 5.10.0
 
   '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0))':
     dependencies:
@@ -7481,13 +7587,13 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.2.10(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  eslint-config-next@16.2.10(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.10
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -7513,7 +7619,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7524,21 +7630,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7549,7 +7656,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -7560,6 +7667,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -7705,6 +7814,18 @@ snapshots:
   eventemitter3@5.0.4: {}
 
   eventsource-parser@3.1.0: {}
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
 
   exponential-backoff@3.1.3: {}
 
@@ -7868,6 +7989,8 @@ snapshots:
     dependencies:
       pump: 3.0.4
 
+  get-stream@6.0.1: {}
+
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -8011,6 +8134,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-signals@2.1.0: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -8093,6 +8218,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-buffer@2.0.5: {}
+
   is-bun-module@2.0.0:
     dependencies:
       semver: 7.8.5
@@ -8152,6 +8279,8 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-node-process@1.2.0: {}
+
   is-number-object@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -8173,6 +8302,8 @@ snapshots:
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
+
+  is-stream@2.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -8232,6 +8363,8 @@ snapshots:
       picocolors: 1.1.1
 
   jiti@2.7.0: {}
+
+  jose@5.10.0: {}
 
   jose@6.2.3: {}
 
@@ -8526,6 +8659,8 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  merge-stream@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromark-core-commonmark@2.0.3:
@@ -8673,6 +8808,8 @@ snapshots:
       mime-db: 1.52.0
 
   mime@2.6.0: {}
+
+  mimic-fn@2.1.0: {}
 
   mimic-function@5.0.1: {}
 
@@ -8835,6 +8972,10 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -8881,6 +9022,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -8906,6 +9051,8 @@ snapshots:
       string-width: 8.2.1
 
   orderedmap@2.1.1: {}
+
+  os-paths@4.4.0: {}
 
   own-keys@1.0.1:
     dependencies:
@@ -9598,6 +9745,8 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-final-newline@2.0.0: {}
+
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
@@ -9652,6 +9801,8 @@ snapshots:
     dependencies:
       mkdirp: 0.5.6
       rimraf: 2.6.3
+
+  throttleit@2.1.0: {}
 
   tiny-async-pool@1.3.0:
     dependencies:
@@ -9969,6 +10120,15 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   xmlbuilder@15.1.1: {}
 
   y18n@5.0.8: {}
@@ -9998,6 +10158,8 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@4.1.11: {}
 
   zod@4.4.3: {}
 


### PR DESCRIPTION
Items 1–5 of the agreed run (6–7 are Sean-side console steps):

1. **Full-text search** — desktop searches titles + notes + transcripts (with a "matches transcript" hint); web library gets a ?q= search over the same fields in Postgres.
2. **Transcript-link footer** — generated notes link to the meeting's web page when cloud sync is on; safe link rendering + external-browser navigation guard.
3. **Workspace invites** — invite by email, copyable /invite/[id] link, accept page, member + pending lists. Two-account e2e verified.
4. **Image sync** — `doodle-media` Blob store provisioned + connected; desktop uploads note attachments on push and rewrites refs to public URLs; web + share pages render them. Live-store e2e verified.
5. **Persistent engine** — `engine serve` keeps ASR models loaded across sessions (instant record start); EngineProcess drives it over stdin with crash-restart and automatic fallback to per-session spawn. No renderer changes needed.

No new DB migrations this round.

Gates: desktop 41/41, web typecheck/build, engine builds, db smoke ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)