### PR TITLE
First-run onboarding tour

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -9,8 +9,10 @@ import type { MeetingSummary } from '../../shared/meetings-api'
 import DevConsole from './DevConsole'
 import HomeView, { type HomeFilter } from './HomeView'
 import MeetingView from './MeetingView'
-import ModelsView from './ModelsView'
+import ModelsView, { type SettingsSection } from './ModelsView'
+import OnboardingTour from './OnboardingTour'
 import mascotUrl from './assets/mascot-square.png'
+import { isOnboardingDone } from './lib/onboarding'
 import { startWinCapture, stopWinCapture } from './lib/win-capture'
 import {
   CalendarIcon,
@@ -52,6 +54,11 @@ function App(): React.JSX.Element {
   const [newFolderName, setNewFolderName] = useState('')
   const [calendar, setCalendar] = useState<CalendarState | null>(null)
   const [banner, setBanner] = useState<CalendarStartMeetingEvent | null>(null)
+  // First launch opens the welcome tour; Settings → General can replay it.
+  const [tourOpen, setTourOpen] = useState(() => !isOnboardingDone())
+  const [settingsJump, setSettingsJump] = useState<{ section: SettingsSection; n: number } | null>(
+    null
+  )
   const searchRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -541,7 +548,11 @@ function App(): React.JSX.Element {
             />
           </div>
           <div className={view === 'settings' ? 'content-slot' : 'content-slot hidden'}>
-            <ModelsView active={view === 'settings'} />
+            <ModelsView
+              active={view === 'settings'}
+              jump={settingsJump}
+              onShowTour={() => setTourOpen(true)}
+            />
           </div>
           <div className={view === 'dev' ? 'content-slot' : 'content-slot hidden'}>
             <DevConsole />
@@ -561,6 +572,18 @@ function App(): React.JSX.Element {
             onOpenSettings={() => setView('settings')}
           />
         </div>
+      )}
+
+      {tourOpen && (
+        <OnboardingTour
+          calendar={calendar}
+          onOpenModelSettings={() => {
+            setSettingsJump({ section: 'model', n: Date.now() })
+            setView('settings')
+          }}
+          onNewMeeting={() => void newMeeting()}
+          onClose={() => setTourOpen(false)}
+        />
       )}
 
       {/* "Meeting is starting" toast: fixed top-center so it shows over Home

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -133,7 +133,7 @@ function Toggle({
   )
 }
 
-type SettingsSection = 'general' | 'calendar' | 'sync' | 'model'
+export type SettingsSection = 'general' | 'calendar' | 'sync' | 'model'
 
 const SETTINGS_NAV: Array<{ key: SettingsSection; icon: React.JSX.Element; label: string }> = [
   { key: 'general', icon: <GearIcon size={15} />, label: 'General' },
@@ -142,8 +142,25 @@ const SETTINGS_NAV: Array<{ key: SettingsSection; icon: React.JSX.Element; label
   { key: 'model', icon: <SparkleIcon size={15} />, label: 'Notes model' }
 ]
 
-export default function ModelsView({ active }: { active: boolean }): React.JSX.Element {
+export default function ModelsView({
+  active,
+  jump,
+  onShowTour
+}: {
+  active: boolean
+  /** External deep-link into a section (n bumps to re-trigger). */
+  jump?: { section: SettingsSection; n: number } | null
+  onShowTour?: () => void
+}): React.JSX.Element {
   const [section, setSection] = useState<SettingsSection>('general')
+
+  // Deep-link consumption: derived state during render (no effect) so an
+  // external jump wins exactly once, then normal nav takes over.
+  const [consumedJump, setConsumedJump] = useState(0)
+  if (jump && jump.n !== consumedJump) {
+    setConsumedJump(jump.n)
+    setSection(jump.section)
+  }
   const [data, setData] = useState<NotesModelsResponse | null>(null)
   const [settings, setSettings] = useState<NotesSettingsView | null>(null)
   const [downloading, setDownloading] = useState<{ id: string; progress: number } | null>(null)
@@ -496,554 +513,601 @@ export default function ModelsView({ active }: { active: boolean }): React.JSX.E
               {error && <div className="models-error">{error}</div>}
 
               <div className="model-cards">
-        {data === null && <span className="placeholder">loading models…</span>}
-        {data?.models.map((m) => (
-          <div
-            key={m.id}
-            className={`model-card${m.available ? '' : ' unavailable'}${m.active ? ' is-active' : ''}`}
-          >
-            <div className="model-head">
-              <span className="model-label">{m.label}</span>
-              {m.downloaded && !m.active && <span className="badge">Downloaded</span>}
-            </div>
-            <div className="model-desc">{m.description}</div>
-            <div className="model-meta">
-              {m.sizeGB.toFixed(1)} GB download · needs {m.minRamGB} GB RAM
-            </div>
-            <div className="model-action">{renderAction(m)}</div>
-          </div>
-        ))}
-      </div>
+                {data === null && <span className="placeholder">loading models…</span>}
+                {data?.models.map((m) => (
+                  <div
+                    key={m.id}
+                    className={`model-card${m.available ? '' : ' unavailable'}${m.active ? ' is-active' : ''}`}
+                  >
+                    <div className="model-head">
+                      <span className="model-label">{m.label}</span>
+                      {m.downloaded && !m.active && <span className="badge">Downloaded</span>}
+                    </div>
+                    <div className="model-desc">{m.description}</div>
+                    <div className="model-meta">
+                      {m.sizeGB.toFixed(1)} GB download · needs {m.minRamGB} GB RAM
+                    </div>
+                    <div className="model-action">{renderAction(m)}</div>
+                  </div>
+                ))}
+              </div>
             </section>
           )}
 
           {section === 'calendar' && (
-      <section className="keys-section calendar-section">
-        <h3>Calendar</h3>
-        <p className="models-sub">
-          Sign in with any Microsoft account — work, school, or personal — to see the week&rsquo;s
-          meetings on Home and get a nudge to take notes the moment one starts. DoodleNote only
-          reads your calendar.
-        </p>
+            <section className="keys-section calendar-section">
+              <h3>Calendar</h3>
+              <p className="models-sub">
+                Sign in with any Microsoft account — work, school, or personal — to see the
+                week&rsquo;s meetings on Home and get a nudge to take notes the moment one starts.
+                DoodleNote only reads your calendar.
+              </p>
 
-        {calState?.error && <div className="models-error">{calState.error}</div>}
+              {calState?.error && <div className="models-error">{calState.error}</div>}
 
-        {calState === null ? (
-          <span className="calendar-note">loading calendar settings…</span>
-        ) : (!calState.configured && !calState.builtIn) || editingCalConfig ? (
-          <>
-            <div className="key-form">
-              <input
-                type="text"
-                spellCheck={false}
-                placeholder="Client ID"
-                value={clientId}
-                onChange={(e) => setClientId(e.target.value)}
-              />
-              <input
-                type="text"
-                spellCheck={false}
-                placeholder="Tenant ID"
-                value={tenantId}
-                onChange={(e) => setTenantId(e.target.value)}
-              />
-              <button type="button" onClick={() => void saveCalendarConfig()}>
-                Save
-              </button>
-              {editingCalConfig && (
-                <button type="button" onClick={() => setEditingCalConfig(false)}>
-                  Cancel
-                </button>
-              )}
-            </div>
-            <p className="calendar-help">
-              Entra admin center → App registrations → DoodleNote — paste the Application (client)
-              ID and Directory (tenant) ID from there.
-            </p>
-          </>
-        ) : !calState.signedIn ? (
-          <div className="calendar-actions">
-            <button
-              type="button"
-              className="ms-signin"
-              disabled={connecting}
-              onClick={() => void connectCalendar()}
-            >
-              <MicrosoftLogo />
-              <span>{connecting ? 'Waiting for your browser…' : 'Sign in with Microsoft'}</span>
-            </button>
-            <button
-              type="button"
-              className="ms-signin"
-              disabled={googleConnecting}
-              onClick={() => void connectGoogle()}
-            >
-              <GoogleLogo />
-              <span>{googleConnecting ? 'Waiting for your browser…' : 'Sign in with Google'}</span>
-            </button>
-            {!calState.builtIn && (
-              <button
-                type="button"
-                className="calendar-ghost"
-                onClick={() => setEditingCalConfig(true)}
-              >
-                Edit IDs
-              </button>
-            )}
-            {connecting && (
-              <span className="calendar-note">
-                finish signing in in your browser, then come back
-              </span>
-            )}
-          </div>
-        ) : (
-          <div className="calendar-connected">
-            <span className="calendar-status">
-              {calState.msSignedIn && (
+              {calState === null ? (
+                <span className="calendar-note">loading calendar settings…</span>
+              ) : (!calState.configured && !calState.builtIn) || editingCalConfig ? (
                 <>
-                  Microsoft:{' '}
-                  <strong>{calState.account?.email ?? 'connected'}</strong>
+                  <div className="key-form">
+                    <input
+                      type="text"
+                      spellCheck={false}
+                      placeholder="Client ID"
+                      value={clientId}
+                      onChange={(e) => setClientId(e.target.value)}
+                    />
+                    <input
+                      type="text"
+                      spellCheck={false}
+                      placeholder="Tenant ID"
+                      value={tenantId}
+                      onChange={(e) => setTenantId(e.target.value)}
+                    />
+                    <button type="button" onClick={() => void saveCalendarConfig()}>
+                      Save
+                    </button>
+                    {editingCalConfig && (
+                      <button type="button" onClick={() => setEditingCalConfig(false)}>
+                        Cancel
+                      </button>
+                    )}
+                  </div>
+                  <p className="calendar-help">
+                    Entra admin center → App registrations → DoodleNote — paste the Application
+                    (client) ID and Directory (tenant) ID from there.
+                  </p>
                 </>
-              )}
-              {calState.msSignedIn && calState.googleSignedIn && ' · '}
-              {calState.googleSignedIn && (
-                <>
-                  Google: <strong>{calState.googleAccount?.email ?? 'connected'}</strong>
-                </>
-              )}
-              {calState.lastSyncIso && (
-                <span className="calendar-note"> · {lastSyncLabel(calState.lastSyncIso)}</span>
-              )}
-            </span>
-            <div className="calendar-actions">
-              <button type="button" disabled={syncing} onClick={() => void syncCalendar()}>
-                {syncing ? 'Syncing…' : 'Sync now'}
-              </button>
-              {calState.msSignedIn && calState.error && (
-                <button type="button" disabled={connecting} onClick={() => void connectCalendar()}>
-                  {connecting ? 'Waiting for your browser…' : 'Sign in again'}
-                </button>
-              )}
-              {!calState.msSignedIn && (
-                <button
-                  type="button"
-                  className="provider-btn"
-                  disabled={connecting}
-                  onClick={() => void connectCalendar()}
-                >
-                  <MicrosoftLogo />
-                  {connecting ? 'Waiting for your browser…' : 'Connect Microsoft'}
-                </button>
-              )}
-              {calState.msSignedIn && (
-                <button
-                  type="button"
-                  className="provider-btn"
-                  onClick={() => void disconnectCalendar()}
-                >
-                  <MicrosoftLogo />
-                  Disconnect Microsoft
-                </button>
-              )}
-              {!calState.googleSignedIn && (
-                <button
-                  type="button"
-                  className="provider-btn"
-                  disabled={googleConnecting}
-                  onClick={() => void connectGoogle()}
-                >
-                  <GoogleLogo />
-                  {googleConnecting ? 'Waiting for your browser…' : 'Connect Google'}
-                </button>
-              )}
-              {calState.googleSignedIn && (
-                <button
-                  type="button"
-                  className="provider-btn"
-                  onClick={() => {
-                    void window.calendar.disconnectGoogle().then(setCalState)
-                  }}
-                >
-                  <GoogleLogo />
-                  Disconnect Google
-                </button>
-              )}
-            </div>
-
-            <div className="cal-subcard">
-              <div className="cal-subcard-head">Display</div>
-              <div className="cal-row">
-                <span className="cal-row-icon">
-                  <MenuBarIcon />
-                </span>
-                <span className="cal-row-main">
-                  <span className="cal-row-label">Show upcoming meetings in menu bar</span>
-                  <span className="cal-row-sub">
-                    Display your next meeting and time until it starts in the macOS menu bar
-                  </span>
-                </span>
-                <Toggle
-                  checked={calState.prefs.showMenuBar}
-                  label="Show upcoming meetings in menu bar"
-                  onChange={() => setCalPrefs({ showMenuBar: !calState.prefs.showMenuBar })}
-                />
-              </div>
-              <div className="cal-row">
-                <span className="cal-row-icon">
-                  <PeopleIcon />
-                </span>
-                <span className="cal-row-main">
-                  <span className="cal-row-label">Show events with no participants</span>
-                  <span className="cal-row-sub">
-                    &ldquo;Coming up&rdquo; section will include events without participants or a
-                    video link
-                  </span>
-                </span>
-                <Toggle
-                  checked={calState.prefs.showNoParticipants}
-                  label="Show events with no participants"
-                  onChange={() =>
-                    setCalPrefs({ showNoParticipants: !calState.prefs.showNoParticipants })
-                  }
-                />
-              </div>
-            </div>
-
-            <div className="cal-subcard">
-              <div className="cal-subcard-head">
-                Visible calendars
-                <button
-                  type="button"
-                  className="link-btn cal-reset"
-                  title="Back to your default calendar only"
-                  onClick={() => setCalPrefs({ visibleCalendarIds: null })}
-                >
-                  Reset
-                </button>
-              </div>
-              {calState.calendars.length === 0 ? (
-                <div className="cal-row">
-                  <span className="calendar-note">
-                    No calendars synced yet — hit Sync now above
-                  </span>
+              ) : !calState.signedIn ? (
+                <div className="calendar-actions">
+                  <button
+                    type="button"
+                    className="ms-signin"
+                    disabled={connecting}
+                    onClick={() => void connectCalendar()}
+                  >
+                    <MicrosoftLogo />
+                    <span>
+                      {connecting ? 'Waiting for your browser…' : 'Sign in with Microsoft'}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    className="ms-signin"
+                    disabled={googleConnecting}
+                    onClick={() => void connectGoogle()}
+                  >
+                    <GoogleLogo />
+                    <span>
+                      {googleConnecting ? 'Waiting for your browser…' : 'Sign in with Google'}
+                    </span>
+                  </button>
+                  {!calState.builtIn && (
+                    <button
+                      type="button"
+                      className="calendar-ghost"
+                      onClick={() => setEditingCalConfig(true)}
+                    >
+                      Edit IDs
+                    </button>
+                  )}
+                  {connecting && (
+                    <span className="calendar-note">
+                      finish signing in in your browser, then come back
+                    </span>
+                  )}
                 </div>
               ) : (
-                calState.calendars.map((cal) => {
-                  const visible = visibleCalendarIds(calState)
-                  const isOn = visible.has(cal.id)
-                  const lastOne = isOn && visible.size === 1
-                  return (
-                    <div key={cal.id} className="cal-row">
-                      <span
-                        className="cal-dot"
-                        style={{ background: cal.colorHex }}
-                        aria-hidden="true"
-                      />
+                <div className="calendar-connected">
+                  <span className="calendar-status">
+                    {calState.msSignedIn && (
+                      <>
+                        Microsoft: <strong>{calState.account?.email ?? 'connected'}</strong>
+                      </>
+                    )}
+                    {calState.msSignedIn && calState.googleSignedIn && ' · '}
+                    {calState.googleSignedIn && (
+                      <>
+                        Google: <strong>{calState.googleAccount?.email ?? 'connected'}</strong>
+                      </>
+                    )}
+                    {calState.lastSyncIso && (
+                      <span className="calendar-note">
+                        {' '}
+                        · {lastSyncLabel(calState.lastSyncIso)}
+                      </span>
+                    )}
+                  </span>
+                  <div className="calendar-actions">
+                    <button type="button" disabled={syncing} onClick={() => void syncCalendar()}>
+                      {syncing ? 'Syncing…' : 'Sync now'}
+                    </button>
+                    {calState.msSignedIn && calState.error && (
+                      <button
+                        type="button"
+                        disabled={connecting}
+                        onClick={() => void connectCalendar()}
+                      >
+                        {connecting ? 'Waiting for your browser…' : 'Sign in again'}
+                      </button>
+                    )}
+                    {!calState.msSignedIn && (
+                      <button
+                        type="button"
+                        className="provider-btn"
+                        disabled={connecting}
+                        onClick={() => void connectCalendar()}
+                      >
+                        <MicrosoftLogo />
+                        {connecting ? 'Waiting for your browser…' : 'Connect Microsoft'}
+                      </button>
+                    )}
+                    {calState.msSignedIn && (
+                      <button
+                        type="button"
+                        className="provider-btn"
+                        onClick={() => void disconnectCalendar()}
+                      >
+                        <MicrosoftLogo />
+                        Disconnect Microsoft
+                      </button>
+                    )}
+                    {!calState.googleSignedIn && (
+                      <button
+                        type="button"
+                        className="provider-btn"
+                        disabled={googleConnecting}
+                        onClick={() => void connectGoogle()}
+                      >
+                        <GoogleLogo />
+                        {googleConnecting ? 'Waiting for your browser…' : 'Connect Google'}
+                      </button>
+                    )}
+                    {calState.googleSignedIn && (
+                      <button
+                        type="button"
+                        className="provider-btn"
+                        onClick={() => {
+                          void window.calendar.disconnectGoogle().then(setCalState)
+                        }}
+                      >
+                        <GoogleLogo />
+                        Disconnect Google
+                      </button>
+                    )}
+                  </div>
+
+                  <div className="cal-subcard">
+                    <div className="cal-subcard-head">Display</div>
+                    <div className="cal-row">
+                      <span className="cal-row-icon">
+                        <MenuBarIcon />
+                      </span>
                       <span className="cal-row-main">
-                        <span className="cal-row-label">{cal.name}</span>
+                        <span className="cal-row-label">Show upcoming meetings in menu bar</span>
+                        <span className="cal-row-sub">
+                          Display your next meeting and time until it starts in the macOS menu bar
+                        </span>
                       </span>
                       <Toggle
-                        checked={isOn}
-                        disabled={lastOne}
-                        label={`Show ${cal.name} in Coming up`}
-                        title={lastOne ? 'At least one calendar stays visible' : undefined}
-                        onChange={() => toggleCalendar(calState, cal.id)}
+                        checked={calState.prefs.showMenuBar}
+                        label="Show upcoming meetings in menu bar"
+                        onChange={() => setCalPrefs({ showMenuBar: !calState.prefs.showMenuBar })}
                       />
                     </div>
-                  )
-                })
+                    <div className="cal-row">
+                      <span className="cal-row-icon">
+                        <PeopleIcon />
+                      </span>
+                      <span className="cal-row-main">
+                        <span className="cal-row-label">Show events with no participants</span>
+                        <span className="cal-row-sub">
+                          &ldquo;Coming up&rdquo; section will include events without participants
+                          or a video link
+                        </span>
+                      </span>
+                      <Toggle
+                        checked={calState.prefs.showNoParticipants}
+                        label="Show events with no participants"
+                        onChange={() =>
+                          setCalPrefs({ showNoParticipants: !calState.prefs.showNoParticipants })
+                        }
+                      />
+                    </div>
+                  </div>
+
+                  <div className="cal-subcard">
+                    <div className="cal-subcard-head">
+                      Visible calendars
+                      <button
+                        type="button"
+                        className="link-btn cal-reset"
+                        title="Back to your default calendar only"
+                        onClick={() => setCalPrefs({ visibleCalendarIds: null })}
+                      >
+                        Reset
+                      </button>
+                    </div>
+                    {calState.calendars.length === 0 ? (
+                      <div className="cal-row">
+                        <span className="calendar-note">
+                          No calendars synced yet — hit Sync now above
+                        </span>
+                      </div>
+                    ) : (
+                      calState.calendars.map((cal) => {
+                        const visible = visibleCalendarIds(calState)
+                        const isOn = visible.has(cal.id)
+                        const lastOne = isOn && visible.size === 1
+                        return (
+                          <div key={cal.id} className="cal-row">
+                            <span
+                              className="cal-dot"
+                              style={{ background: cal.colorHex }}
+                              aria-hidden="true"
+                            />
+                            <span className="cal-row-main">
+                              <span className="cal-row-label">{cal.name}</span>
+                            </span>
+                            <Toggle
+                              checked={isOn}
+                              disabled={lastOne}
+                              label={`Show ${cal.name} in Coming up`}
+                              title={lastOne ? 'At least one calendar stays visible' : undefined}
+                              onChange={() => toggleCalendar(calState, cal.id)}
+                            />
+                          </div>
+                        )
+                      })
+                    )}
+                  </div>
+                </div>
               )}
-            </div>
-          </div>
-        )}
-      </section>
+            </section>
           )}
 
           {section === 'general' && (
             <>
-      <section className="keys-section">
-        <h3>Appearance</h3>
-        <div className="theme-seg" role="radiogroup" aria-label="Appearance">
-          {(
-            [
-              ['system', 'Match system'],
-              ['light', 'Light'],
-              ['dark', 'Dark']
-            ] as const
-          ).map(([value, label]) => (
-            <button
-              key={value}
-              type="button"
-              role="radio"
-              aria-checked={theme === value}
-              className={theme === value ? 'theme-seg-btn on' : 'theme-seg-btn'}
-              onClick={() => {
-                setThemePref(value)
-                setTheme(value)
-              }}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-      </section>
+              <section className="keys-section">
+                <h3>Appearance</h3>
+                <div className="theme-seg" role="radiogroup" aria-label="Appearance">
+                  {(
+                    [
+                      ['system', 'Match system'],
+                      ['light', 'Light'],
+                      ['dark', 'Dark']
+                    ] as const
+                  ).map(([value, label]) => (
+                    <button
+                      key={value}
+                      type="button"
+                      role="radio"
+                      aria-checked={theme === value}
+                      className={theme === value ? 'theme-seg-btn on' : 'theme-seg-btn'}
+                      onClick={() => {
+                        setThemePref(value)
+                        setTheme(value)
+                      }}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              </section>
 
-      <section className="keys-section">
-        <h3>Updates</h3>
-        <div className="cal-subcard">
-          <div className="cal-row">
-            <span className="cal-row-main">
-              <span className="cal-row-label">
-                DoodleNote v{update?.currentVersion ?? '…'}
-              </span>
-              <span className="cal-row-sub">
-                {update ? updateStatusLine(update) : 'loading…'}
-              </span>
-            </span>
-            {update?.status === 'downloaded' ? (
-              <button
-                type="button"
-                className="pill-btn"
-                onClick={() => void window.updates.install()}
-              >
-                Restart to update
-              </button>
-            ) : (
-              <button
-                type="button"
-                className="pill-btn"
-                disabled={
-                  checkPending ||
-                  update?.supported === false ||
-                  update?.status === 'checking' ||
-                  update?.status === 'downloading'
-                }
-                onClick={() => void checkForUpdates()}
-              >
-                Check for updates
-              </button>
-            )}
-          </div>
-        </div>
-      </section>
+              <section className="keys-section">
+                <h3>Updates</h3>
+                <div className="cal-subcard">
+                  <div className="cal-row">
+                    <span className="cal-row-main">
+                      <span className="cal-row-label">
+                        DoodleNote v{update?.currentVersion ?? '…'}
+                      </span>
+                      <span className="cal-row-sub">
+                        {update ? updateStatusLine(update) : 'loading…'}
+                      </span>
+                    </span>
+                    {update?.status === 'downloaded' ? (
+                      <button
+                        type="button"
+                        className="pill-btn"
+                        onClick={() => void window.updates.install()}
+                      >
+                        Restart to update
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        className="pill-btn"
+                        disabled={
+                          checkPending ||
+                          update?.supported === false ||
+                          update?.status === 'checking' ||
+                          update?.status === 'downloading'
+                        }
+                        onClick={() => void checkForUpdates()}
+                      >
+                        Check for updates
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </section>
 
-      <section className="keys-section calendar-section">
-        <h3>Meeting detection</h3>
-        <p className="models-sub">
-          DoodleNote already nudges you when a calendar meeting starts. These make sure it never
-          misses one.
-        </p>
-        {detect === null ? (
-          <span className="calendar-note">loading detection settings…</span>
-        ) : (
-          <div className="cal-subcard">
-            <div className="cal-row">
-              <span className="cal-row-main">
-                <span className="cal-row-label">Start DoodleNote at login</span>
-                <span className="cal-row-sub">
-                  Keeps meeting prompts working without remembering to open the app
-                </span>
-              </span>
-              <Toggle
-                checked={detect.loginItem}
-                label="Start DoodleNote at login"
-                onChange={() => {
-                  void window.detect.setPrefs({ loginItem: !detect.loginItem }).then(setDetect)
-                }}
-              />
-            </div>
-            {detect.micDetectSupported && (
-            <div className="cal-row">
-              <span className="cal-row-main">
-                <span className="cal-row-label">Detect meetings from mic activity</span>
-                <span className="cal-row-sub">
-                  Prompts when a meeting app — Zoom, Teams, Webex, Slack, FaceTime, or a browser
-                  — holds your microphone, even without a calendar event. Dictation tools are
-                  ignored.
-                </span>
-              </span>
-              <Toggle
-                checked={detect.micDetect}
-                label="Detect meetings from mic activity"
-                onChange={() => {
-                  void window.detect.setPrefs({ micDetect: !detect.micDetect }).then(setDetect)
-                }}
-              />
-            </div>
-            )}
-            {detect.micDetectSupported && (
-            <div className="cal-row">
-              <span className="cal-row-main">
-                <span className="cal-row-label">Stop recording when the meeting ends</span>
-                <span className="cal-row-sub">
-                  When the meeting app hangs up, DoodleNote stops recording on its own — no more
-                  minutes of empty audio after everyone leaves
-                </span>
-              </span>
-              <Toggle
-                checked={detect.autoStop}
-                label="Stop recording when the meeting ends"
-                onChange={() => {
-                  void window.detect.setPrefs({ autoStop: !detect.autoStop }).then(setDetect)
-                }}
-              />
-            </div>
-            )}
-          </div>
-        )}
-      </section>
+              <section className="keys-section">
+                <h3>Welcome tour</h3>
+                <div className="cal-subcard">
+                  <div className="cal-row">
+                    <span className="cal-row-main">
+                      <span className="cal-row-label">Replay the first-run tour</span>
+                      <span className="cal-row-sub">
+                        A quick tour of recording, calendars, detection, sync, and models.
+                      </span>
+                    </span>
+                    <button type="button" className="pill-btn" onClick={() => onShowTour?.()}>
+                      Show tour
+                    </button>
+                  </div>
+                </div>
+              </section>
+
+              <section className="keys-section calendar-section">
+                <h3>Meeting detection</h3>
+                <p className="models-sub">
+                  DoodleNote already nudges you when a calendar meeting starts. These make sure it
+                  never misses one.
+                </p>
+                {detect === null ? (
+                  <span className="calendar-note">loading detection settings…</span>
+                ) : (
+                  <div className="cal-subcard">
+                    <div className="cal-row">
+                      <span className="cal-row-main">
+                        <span className="cal-row-label">Start DoodleNote at login</span>
+                        <span className="cal-row-sub">
+                          Keeps meeting prompts working without remembering to open the app
+                        </span>
+                      </span>
+                      <Toggle
+                        checked={detect.loginItem}
+                        label="Start DoodleNote at login"
+                        onChange={() => {
+                          void window.detect
+                            .setPrefs({ loginItem: !detect.loginItem })
+                            .then(setDetect)
+                        }}
+                      />
+                    </div>
+                    {detect.micDetectSupported && (
+                      <div className="cal-row">
+                        <span className="cal-row-main">
+                          <span className="cal-row-label">Detect meetings from mic activity</span>
+                          <span className="cal-row-sub">
+                            Prompts when a meeting app — Zoom, Teams, Webex, Slack, FaceTime, or a
+                            browser — holds your microphone, even without a calendar event.
+                            Dictation tools are ignored.
+                          </span>
+                        </span>
+                        <Toggle
+                          checked={detect.micDetect}
+                          label="Detect meetings from mic activity"
+                          onChange={() => {
+                            void window.detect
+                              .setPrefs({ micDetect: !detect.micDetect })
+                              .then(setDetect)
+                          }}
+                        />
+                      </div>
+                    )}
+                    {detect.micDetectSupported && (
+                      <div className="cal-row">
+                        <span className="cal-row-main">
+                          <span className="cal-row-label">
+                            Stop recording when the meeting ends
+                          </span>
+                          <span className="cal-row-sub">
+                            When the meeting app hangs up, DoodleNote stops recording on its own —
+                            no more minutes of empty audio after everyone leaves
+                          </span>
+                        </span>
+                        <Toggle
+                          checked={detect.autoStop}
+                          label="Stop recording when the meeting ends"
+                          onChange={() => {
+                            void window.detect
+                              .setPrefs({ autoStop: !detect.autoStop })
+                              .then(setDetect)
+                          }}
+                        />
+                      </div>
+                    )}
+                  </div>
+                )}
+              </section>
             </>
           )}
 
           {section === 'sync' && (
-      <section className="keys-section calendar-section">
-        <h3>Sync with cloud</h3>
-        <p className="models-sub">
-          Off by default — your meetings live only on this Mac. Turn it on to push meetings,
-          transcripts, and notes to your DoodleNote workspace so you can browse and share them on
-          the web.
-        </p>
+            <section className="keys-section calendar-section">
+              <h3>Sync with cloud</h3>
+              <p className="models-sub">
+                Off by default — your meetings live only on this Mac. Turn it on to push meetings,
+                transcripts, and notes to your DoodleNote workspace so you can browse and share them
+                on the web.
+              </p>
 
-        {syncStatus?.lastError && <div className="models-error">{syncStatus.lastError}</div>}
+              {syncStatus?.lastError && <div className="models-error">{syncStatus.lastError}</div>}
 
-        {syncStatus === null ? (
-          <span className="calendar-note">loading sync settings…</span>
-        ) : !syncStatus.connected ? (
-          <div className="calendar-actions">
-            <button
-              type="button"
-              className="ms-signin"
-              disabled={linkPending || syncStatus.linking}
-              onClick={() => void connectSync()}
-            >
-              <span>
-                {linkPending || syncStatus.linking
-                  ? 'Waiting for your browser…'
-                  : 'Connect DoodleNote Cloud'}
-              </span>
-            </button>
-            {(linkPending || syncStatus.linking) && (
-              <span className="calendar-note">
-                approve the connection in your browser, then come back
-              </span>
-            )}
-          </div>
-        ) : (
-          <div className="calendar-connected">
-            <span className="calendar-status">
-              Connected as <strong>{syncStatus.email ?? 'your account'}</strong>
-              {syncStatus.workspaceName && (
-                <span className="calendar-note"> · workspace “{syncStatus.workspaceName}”</span>
-              )}
-              {syncStatus.lastSyncAt && (
-                <span className="calendar-note"> · {lastSyncLabel(syncStatus.lastSyncAt)}</span>
-              )}
-            </span>
-
-            <div className="cal-subcard">
-              <div className="cal-row">
-                <span className="cal-row-main">
-                  <span className="cal-row-label">Sync meetings to the cloud</span>
-                  <span className="cal-row-sub">
-                    {syncStatus.enabled
-                      ? syncStatus.syncing
-                        ? 'Syncing now…'
-                        : syncStatus.pendingCount > 0
-                          ? `${syncStatus.pendingCount} meeting${syncStatus.pendingCount === 1 ? '' : 's'} waiting to sync`
-                          : 'Everything is synced'
-                      : 'Paused — nothing is uploaded while this is off'}
+              {syncStatus === null ? (
+                <span className="calendar-note">loading sync settings…</span>
+              ) : !syncStatus.connected ? (
+                <div className="calendar-actions">
+                  <button
+                    type="button"
+                    className="ms-signin"
+                    disabled={linkPending || syncStatus.linking}
+                    onClick={() => void connectSync()}
+                  >
+                    <span>
+                      {linkPending || syncStatus.linking
+                        ? 'Waiting for your browser…'
+                        : 'Connect DoodleNote Cloud'}
+                    </span>
+                  </button>
+                  {(linkPending || syncStatus.linking) && (
+                    <span className="calendar-note">
+                      approve the connection in your browser, then come back
+                    </span>
+                  )}
+                </div>
+              ) : (
+                <div className="calendar-connected">
+                  <span className="calendar-status">
+                    Connected as <strong>{syncStatus.email ?? 'your account'}</strong>
+                    {syncStatus.workspaceName && (
+                      <span className="calendar-note">
+                        {' '}
+                        · workspace “{syncStatus.workspaceName}”
+                      </span>
+                    )}
+                    {syncStatus.lastSyncAt && (
+                      <span className="calendar-note">
+                        {' '}
+                        · {lastSyncLabel(syncStatus.lastSyncAt)}
+                      </span>
+                    )}
                   </span>
-                </span>
-                <Toggle
-                  checked={syncStatus.enabled}
-                  label="Sync meetings to the cloud"
-                  onChange={() => {
-                    void window.sync.setEnabled(!syncStatus.enabled).then(setSyncStatus)
-                  }}
-                />
-              </div>
-            </div>
 
-            <div className="calendar-actions">
-              <button
-                type="button"
-                disabled={syncStatus.syncing || !syncStatus.enabled}
-                onClick={() => {
-                  void window.sync.syncNow().then(setSyncStatus)
-                }}
-              >
-                {syncStatus.syncing ? 'Syncing…' : 'Sync now'}
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  void window.sync.disconnect().then(setSyncStatus)
-                }}
-              >
-                Disconnect
-              </button>
-            </div>
-          </div>
-        )}
-      </section>
+                  <div className="cal-subcard">
+                    <div className="cal-row">
+                      <span className="cal-row-main">
+                        <span className="cal-row-label">Sync meetings to the cloud</span>
+                        <span className="cal-row-sub">
+                          {syncStatus.enabled
+                            ? syncStatus.syncing
+                              ? 'Syncing now…'
+                              : syncStatus.pendingCount > 0
+                                ? `${syncStatus.pendingCount} meeting${syncStatus.pendingCount === 1 ? '' : 's'} waiting to sync`
+                                : 'Everything is synced'
+                            : 'Paused — nothing is uploaded while this is off'}
+                        </span>
+                      </span>
+                      <Toggle
+                        checked={syncStatus.enabled}
+                        label="Sync meetings to the cloud"
+                        onChange={() => {
+                          void window.sync.setEnabled(!syncStatus.enabled).then(setSyncStatus)
+                        }}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="calendar-actions">
+                    <button
+                      type="button"
+                      disabled={syncStatus.syncing || !syncStatus.enabled}
+                      onClick={() => {
+                        void window.sync.syncNow().then(setSyncStatus)
+                      }}
+                    >
+                      {syncStatus.syncing ? 'Syncing…' : 'Sync now'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void window.sync.disconnect().then(setSyncStatus)
+                      }}
+                    >
+                      Disconnect
+                    </button>
+                  </div>
+                </div>
+              )}
+            </section>
           )}
 
           {section === 'model' && (
-      <section className="keys-section">
-        <h3>AI keys (optional)</h3>
-        <p className="models-sub">
-          On-device is the default and needs no account. Add your own API key only if you want
-          cloud-quality notes — the key is encrypted with the macOS keychain and never shown again.
-        </p>
+            <section className="keys-section">
+              <h3>AI keys (optional)</h3>
+              <p className="models-sub">
+                On-device is the default and needs no account. Add your own API key only if you want
+                cloud-quality notes — the key is encrypted with the macOS keychain and never shown
+                again.
+              </p>
 
-        <div className="engine-choice">
-          <label>
-            <input
-              type="radio"
-              name="engine-choice"
-              checked={engineChoice === 'local'}
-              onChange={() => void chooseEngine('local')}
-            />
-            On-device (default)
-          </label>
-          <label>
-            <input
-              type="radio"
-              name="engine-choice"
-              checked={engineChoice === 'cloud'}
-              onChange={() => void chooseEngine('cloud')}
-            />
-            Cloud with my key
-            {engineChoice === 'cloud' && !settings?.cloud?.hasKey && (
-              <span className="model-note"> (no key saved yet — on-device will be used)</span>
-            )}
-          </label>
-        </div>
+              <div className="engine-choice">
+                <label>
+                  <input
+                    type="radio"
+                    name="engine-choice"
+                    checked={engineChoice === 'local'}
+                    onChange={() => void chooseEngine('local')}
+                  />
+                  On-device (default)
+                </label>
+                <label>
+                  <input
+                    type="radio"
+                    name="engine-choice"
+                    checked={engineChoice === 'cloud'}
+                    onChange={() => void chooseEngine('cloud')}
+                  />
+                  Cloud with my key
+                  {engineChoice === 'cloud' && !settings?.cloud?.hasKey && (
+                    <span className="model-note"> (no key saved yet — on-device will be used)</span>
+                  )}
+                </label>
+              </div>
 
-        <div className="key-form">
-          <select value={provider} onChange={(e) => setProvider(e.target.value as CloudProvider)}>
-            <option value="anthropic">Anthropic</option>
-            <option value="openai">OpenAI</option>
-          </select>
-          <input
-            type="text"
-            spellCheck={false}
-            placeholder="model (optional, e.g. claude-sonnet-5)"
-            value={cloudModel}
-            onChange={(e) => setCloudModel(e.target.value)}
-          />
-          <input
-            type="password"
-            placeholder={settings?.cloud?.hasKey ? '••••••••  (key saved)' : 'API key'}
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-          />
-          <button type="button" onClick={() => void saveCloudKey()}>
-            Save
-          </button>
-          {(keySaved || settings?.cloud?.hasKey) && <span className="key-saved">key saved ✓</span>}
-        </div>
-      </section>
+              <div className="key-form">
+                <select
+                  value={provider}
+                  onChange={(e) => setProvider(e.target.value as CloudProvider)}
+                >
+                  <option value="anthropic">Anthropic</option>
+                  <option value="openai">OpenAI</option>
+                </select>
+                <input
+                  type="text"
+                  spellCheck={false}
+                  placeholder="model (optional, e.g. claude-sonnet-5)"
+                  value={cloudModel}
+                  onChange={(e) => setCloudModel(e.target.value)}
+                />
+                <input
+                  type="password"
+                  placeholder={settings?.cloud?.hasKey ? '••••••••  (key saved)' : 'API key'}
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                />
+                <button type="button" onClick={() => void saveCloudKey()}>
+                  Save
+                </button>
+                {(keySaved || settings?.cloud?.hasKey) && (
+                  <span className="key-saved">key saved ✓</span>
+                )}
+              </div>
+            </section>
           )}
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/OnboardingTour.tsx
+++ b/apps/desktop/src/renderer/src/OnboardingTour.tsx
@@ -1,0 +1,417 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { CalendarState } from '../../shared/calendar-api'
+import type { DetectState } from '../../shared/detect-api'
+import type { NotesSettingsView } from '../../shared/notes-api'
+import type { SyncStatus } from '../../shared/sync-api'
+import mascotUrl from './assets/mascot-square.png'
+import { CalendarIcon, CloudIcon, MicIcon, SparkleIcon } from './icons'
+import { markOnboardingDone } from './lib/onboarding'
+
+/**
+ * First-run tour: a short, status-aware wizard that walks a new user
+ * through the setup that makes DoodleNote sing — recording basics, calendar
+ * connections, meeting detection (macOS), cloud sync, and the notes model.
+ * Steps with live state show real checkmarks: connecting a calendar from
+ * the wizard flips its step to done the moment the OAuth flow lands.
+ *
+ * Persistence is a localStorage flag (same pattern as the theme pref) —
+ * closing the tour by any path marks it seen; Settings → General offers a
+ * replay.
+ */
+
+type StepId = 'welcome' | 'record' | 'calendar' | 'detect' | 'sync' | 'model' | 'finish'
+
+interface TourProps {
+  calendar: CalendarState | null
+  onOpenModelSettings: () => void
+  onNewMeeting: () => void
+  onClose: () => void
+}
+
+function OnboardingTour({
+  calendar,
+  onOpenModelSettings,
+  onNewMeeting,
+  onClose
+}: TourProps): React.JSX.Element {
+  const [detect, setDetect] = useState<DetectState | null>(null)
+  const [sync, setSync] = useState<SyncStatus | null>(null)
+  const [notes, setNotes] = useState<NotesSettingsView | null>(null)
+  const [busy, setBusy] = useState<'ms' | 'google' | 'sync' | null>(null)
+  const [stepIndex, setStepIndex] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    void window.detect
+      .getState()
+      .then((s) => {
+        if (!cancelled) setDetect(s)
+      })
+      .catch(() => {})
+    void window.sync
+      .getStatus()
+      .then((s) => {
+        if (!cancelled) setSync(s)
+      })
+      .catch(() => {})
+    void window.notes
+      .getSettings()
+      .then((s) => {
+        if (!cancelled) setNotes(s)
+      })
+      .catch(() => {})
+    const offSync = window.sync.onStatus(setSync)
+    return () => {
+      cancelled = true
+      offSync()
+    }
+  }, [])
+
+  // The detect step only exists where mic-activity detection does (macOS).
+  const steps = useMemo<StepId[]>(() => {
+    const base: StepId[] = ['welcome', 'record', 'calendar']
+    if (detect?.micDetectSupported !== false) base.push('detect')
+    base.push('sync', 'model', 'finish')
+    return base
+  }, [detect])
+  const step = steps[Math.min(stepIndex, steps.length - 1)]!
+
+  const finish = useCallback(() => {
+    markOnboardingDone()
+    onClose()
+  }, [onClose])
+
+  // Escape closes (and never shows again) — the tour is a guide, not a gate.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') finish()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [finish])
+
+  const connectMs = useCallback(async () => {
+    setBusy('ms')
+    try {
+      await window.calendar.connect()
+    } finally {
+      setBusy(null)
+    }
+  }, [])
+
+  const connectGoogle = useCallback(async () => {
+    setBusy('google')
+    try {
+      await window.calendar.connectGoogle()
+    } finally {
+      setBusy(null)
+    }
+  }, [])
+
+  const connectSync = useCallback(async () => {
+    setBusy('sync')
+    try {
+      setSync(await window.sync.connect())
+    } finally {
+      setBusy(null)
+    }
+  }, [])
+
+  const setDetectPref = useCallback(
+    async (update: { loginItem?: boolean; micDetect?: boolean; autoStop?: boolean }) => {
+      setDetect(await window.detect.setPrefs(update))
+    },
+    []
+  )
+
+  const calendarConnected = calendar?.msSignedIn === true || calendar?.googleSignedIn === true
+  const detectionOn = detect?.micDetect === true
+  const syncConnected = sync?.connected === true
+  const modelReady =
+    notes !== null &&
+    (notes.engineChoice === 'cloud'
+      ? notes.cloud?.hasKey === true
+      : typeof notes.activeLocalModelId === 'string' && notes.activeLocalModelId.length > 0)
+  const isWindows = detect?.micDetectSupported === false
+
+  const next = (): void => setStepIndex((i) => Math.min(i + 1, steps.length - 1))
+  const back = (): void => setStepIndex((i) => Math.max(i - 1, 0))
+
+  return (
+    <div className="tour-overlay no-drag" role="dialog" aria-modal="true" aria-label="Welcome tour">
+      <div className="tour-card">
+        <button type="button" className="tour-skip" onClick={finish}>
+          Skip tour
+        </button>
+
+        {step === 'welcome' && (
+          <div className="tour-body">
+            <img className="tour-mascot" src={mascotUrl} alt="" draggable={false} />
+            <h2 className="tour-title">Welcome to DoodleNote</h2>
+            <p className="tour-lede">
+              Your meetings, transcribed and summarized — right on this computer, with no bot
+              joining your calls. Two minutes of setup gets you the full experience.
+            </p>
+            <ul className="tour-points">
+              <li>
+                <MicIcon size={14} /> Captures your mic and the other side of the call, natively
+              </li>
+              <li>
+                <SparkleIcon size={14} /> Turns rough notes + transcript into polished summaries
+              </li>
+              <li>
+                <CloudIcon size={14} /> Local &amp; private by default — cloud sync is opt-in
+              </li>
+            </ul>
+          </div>
+        )}
+
+        {step === 'record' && (
+          <div className="tour-body">
+            <h2 className="tour-title">Recording a meeting</h2>
+            <p className="tour-lede">
+              Hit <strong>+ New meeting</strong> and recording starts instantly. Talk normally — the
+              transcript builds live, labeling your mic &ldquo;You&rdquo; and the call audio
+              &ldquo;Them.&rdquo; Works with Zoom, Teams, Meet, or anything else that makes sound.
+            </p>
+            <ul className="tour-points">
+              <li>Take rough notes while you talk — bullets, fragments, half-thoughts are fine</li>
+              <li>
+                When the meeting ends, <strong>Generate notes</strong> merges your notes with the
+                transcript into a clean summary
+              </li>
+              <li>
+                {isWindows
+                  ? 'First recording asks for microphone permission, and the speech model finishes downloading on first launch'
+                  : 'First recording asks for microphone and system-audio permission — one-time macOS prompts'}
+              </li>
+            </ul>
+          </div>
+        )}
+
+        {step === 'calendar' && (
+          <div className="tour-body">
+            <span className="tour-glyph">
+              <CalendarIcon size={22} />
+            </span>
+            <h2 className="tour-title">Connect your calendar</h2>
+            <p className="tour-lede">
+              See what&rsquo;s coming up, and get a &ldquo;start taking notes?&rdquo; nudge the
+              moment a meeting begins — pre-titled from the event.
+            </p>
+            {calendarConnected ? (
+              <p className="tour-done">✓ Calendar connected — you&rsquo;re set here.</p>
+            ) : (
+              <div className="tour-actions-row">
+                <button
+                  type="button"
+                  className="tour-action"
+                  disabled={busy !== null}
+                  onClick={() => void connectMs()}
+                >
+                  {busy === 'ms' ? 'Waiting for browser…' : 'Connect Microsoft 365'}
+                </button>
+                <button
+                  type="button"
+                  className="tour-action"
+                  disabled={busy !== null}
+                  onClick={() => void connectGoogle()}
+                >
+                  {busy === 'google' ? 'Waiting for browser…' : 'Connect Google'}
+                </button>
+              </div>
+            )}
+            <p className="tour-footnote">Optional — you can always start meetings by hand.</p>
+          </div>
+        )}
+
+        {step === 'detect' && (
+          <div className="tour-body">
+            <span className="tour-glyph">
+              <MicIcon size={22} />
+            </span>
+            <h2 className="tour-title">Never miss a meeting</h2>
+            <p className="tour-lede">
+              DoodleNote can notice when a call starts — even ad-hoc ones that aren&rsquo;t on your
+              calendar — and offer to take notes. It can also stop recording by itself when the call
+              ends.
+            </p>
+            <div className="tour-toggle-row">
+              <span>Detect meetings from mic activity</span>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={detect?.micDetect === true}
+                aria-label="Detect meetings from mic activity"
+                className={detect?.micDetect ? 'toggle on' : 'toggle'}
+                onClick={() => void setDetectPref({ micDetect: !(detect?.micDetect ?? false) })}
+              >
+                <span className="toggle-knob" aria-hidden="true" />
+              </button>
+            </div>
+            <div className="tour-toggle-row">
+              <span>Stop recording when the meeting ends</span>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={detect?.autoStop === true}
+                aria-label="Stop recording when the meeting ends"
+                className={detect?.autoStop ? 'toggle on' : 'toggle'}
+                onClick={() => void setDetectPref({ autoStop: !(detect?.autoStop ?? false) })}
+              >
+                <span className="toggle-knob" aria-hidden="true" />
+              </button>
+            </div>
+            <div className="tour-toggle-row">
+              <span>Start DoodleNote when you log in</span>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={detect?.loginItem === true}
+                aria-label="Start DoodleNote when you log in"
+                className={detect?.loginItem ? 'toggle on' : 'toggle'}
+                onClick={() => void setDetectPref({ loginItem: !(detect?.loginItem ?? false) })}
+              >
+                <span className="toggle-knob" aria-hidden="true" />
+              </button>
+            </div>
+            {detectionOn && (
+              <p className="tour-footnote">
+                Tip: launch at login keeps detection watching even before you open the app.
+              </p>
+            )}
+          </div>
+        )}
+
+        {step === 'sync' && (
+          <div className="tour-body">
+            <span className="tour-glyph">
+              <CloudIcon size={22} />
+            </span>
+            <h2 className="tour-title">Cloud sync &amp; sharing</h2>
+            <p className="tour-lede">
+              Everything works offline. Connect the cloud when you want your meetings on the web
+              dashboard, searchable from any device, and shareable with a link.
+            </p>
+            {syncConnected ? (
+              <p className="tour-done">
+                ✓ Synced{sync?.email ? ` as ${sync.email}` : ''} — your meetings back up
+                automatically.
+              </p>
+            ) : (
+              <div className="tour-actions-row">
+                <button
+                  type="button"
+                  className="tour-action"
+                  disabled={busy !== null || sync?.linking === true}
+                  onClick={() => void connectSync()}
+                >
+                  {busy === 'sync' || sync?.linking ? 'Waiting for browser…' : 'Connect cloud sync'}
+                </button>
+              </div>
+            )}
+            <p className="tour-footnote">Optional and off by default — local-first, always.</p>
+          </div>
+        )}
+
+        {step === 'model' && (
+          <div className="tour-body">
+            <span className="tour-glyph">
+              <SparkleIcon size={22} />
+            </span>
+            <h2 className="tour-title">Pick your notes model</h2>
+            <p className="tour-lede">
+              Generate notes needs an AI model: download a local one that runs entirely on this
+              computer, or plug in your own Anthropic/OpenAI key for cloud-quality summaries.
+            </p>
+            {modelReady ? (
+              <p className="tour-done">
+                ✓ {notes?.engineChoice === 'cloud' ? 'Cloud key saved' : 'Local model ready'} —
+                Generate notes is good to go.
+              </p>
+            ) : (
+              <div className="tour-actions-row">
+                <button
+                  type="button"
+                  className="tour-action"
+                  onClick={() => {
+                    markOnboardingDone()
+                    onOpenModelSettings()
+                    onClose()
+                  }}
+                >
+                  Choose a model in Settings
+                </button>
+              </div>
+            )}
+            <p className="tour-footnote">
+              Recording and transcription work without this — it&rsquo;s only for generated
+              summaries.
+            </p>
+          </div>
+        )}
+
+        {step === 'finish' && (
+          <div className="tour-body">
+            <img className="tour-mascot" src={mascotUrl} alt="" draggable={false} />
+            <h2 className="tour-title">You&rsquo;re all set</h2>
+            <ul className="tour-checklist">
+              <li className={calendarConnected ? 'done' : ''}>
+                {calendarConnected ? '✓' : '○'} Calendar{' '}
+                {calendarConnected ? 'connected' : 'not connected'}
+              </li>
+              {!isWindows && (
+                <li className={detectionOn ? 'done' : ''}>
+                  {detectionOn ? '✓' : '○'} Meeting detection {detectionOn ? 'on' : 'off'}
+                </li>
+              )}
+              <li className={syncConnected ? 'done' : ''}>
+                {syncConnected ? '✓' : '○'} Cloud sync {syncConnected ? 'on' : 'off'}
+              </li>
+              <li className={modelReady ? 'done' : ''}>
+                {modelReady ? '✓' : '○'} Notes model {modelReady ? 'ready' : 'not set up'}
+              </li>
+            </ul>
+            <p className="tour-footnote">
+              Anything you skipped lives in Settings — and this tour replays from Settings →
+              General.
+            </p>
+          </div>
+        )}
+
+        <div className="tour-footer">
+          <div className="tour-dots" aria-hidden="true">
+            {steps.map((s, i) => (
+              <span key={s} className={i === stepIndex ? 'tour-dot on' : 'tour-dot'} />
+            ))}
+          </div>
+          <div className="tour-nav">
+            {stepIndex > 0 && (
+              <button type="button" className="tour-back" onClick={back}>
+                Back
+              </button>
+            )}
+            {step === 'finish' ? (
+              <button
+                type="button"
+                className="tour-next"
+                onClick={() => {
+                  finish()
+                  onNewMeeting()
+                }}
+              >
+                Start your first meeting
+              </button>
+            ) : (
+              <button type="button" className="tour-next" onClick={next}>
+                {step === 'welcome' ? 'Show me around' : 'Next'}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default OnboardingTour

--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -3236,3 +3236,219 @@ button.fp-row:hover {
   font-size: 18.5px;
   letter-spacing: -0.015em;
 }
+
+/* ---- first-run welcome tour ---- */
+
+.tour-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(30, 32, 24, 0.45);
+  backdrop-filter: blur(3px);
+}
+.tour-card {
+  position: relative;
+  width: min(560px, calc(100vw - 48px));
+  max-height: calc(100vh - 72px);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  box-shadow: var(--shadow-panel);
+  padding: 30px 32px 18px;
+}
+.tour-skip {
+  position: absolute;
+  top: 14px;
+  right: 18px;
+  font-size: 12px;
+  color: var(--muted);
+  padding: 4px 8px;
+  border-radius: 8px;
+}
+.tour-skip:hover {
+  color: var(--ink);
+  background: var(--fill);
+}
+.tour-body {
+  min-height: 268px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+}
+.tour-mascot {
+  width: 54px;
+  height: 54px;
+  border-radius: 14px;
+  align-self: center;
+}
+.tour-glyph {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--sage-fill);
+  color: var(--accent-deep);
+}
+.tour-title {
+  font-family: var(--serif);
+  font-size: 23px;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 0;
+  align-self: stretch;
+}
+.tour-body:has(.tour-mascot) .tour-title {
+  text-align: center;
+}
+.tour-lede {
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--body);
+  margin: 0;
+}
+.tour-points {
+  list-style: none;
+  margin: 2px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  align-self: stretch;
+}
+.tour-points li {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--body);
+}
+.tour-points li svg {
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: var(--accent-deep);
+}
+.tour-actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 2px;
+}
+.tour-action {
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 15px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--card-soft);
+  color: var(--ink);
+}
+.tour-action:hover:not(:disabled) {
+  background: var(--sage-fill);
+  border-color: var(--accent);
+}
+.tour-action:disabled {
+  opacity: 0.55;
+}
+.tour-done {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--accent-deep);
+  background: var(--sage-fill);
+  padding: 9px 13px;
+  border-radius: 10px;
+  margin: 2px 0 0;
+}
+.tour-footnote {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 0;
+}
+.tour-toggle-row {
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13.5px;
+  color: var(--body);
+  padding: 8px 0;
+}
+.tour-toggle-row + .tour-toggle-row {
+  border-top: 1px solid var(--border);
+}
+.tour-checklist {
+  list-style: none;
+  margin: 2px 0 0;
+  padding: 0;
+  align-self: center;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 13.5px;
+  color: var(--muted);
+}
+.tour-checklist li.done {
+  color: var(--accent-deep);
+}
+.tour-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 20px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+.tour-dots {
+  display: flex;
+  gap: 6px;
+}
+.tour-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--control-track);
+  transition:
+    width 0.18s ease,
+    background 0.18s ease;
+}
+.tour-dot.on {
+  width: 16px;
+  background: var(--accent);
+}
+.tour-nav {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.tour-back {
+  font-size: 13px;
+  color: var(--muted);
+  padding: 6px 10px;
+  border-radius: 8px;
+}
+.tour-back:hover {
+  color: var(--ink);
+  background: var(--fill);
+}
+.tour-next {
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 18px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+}
+.tour-next:hover {
+  background: var(--accent-deep);
+}

--- a/apps/desktop/src/renderer/src/lib/onboarding.ts
+++ b/apps/desktop/src/renderer/src/lib/onboarding.ts
@@ -1,0 +1,23 @@
+/**
+ * First-run tour persistence: a localStorage flag (same pattern as the
+ * theme pref). Closing the tour by any path marks it seen; Settings →
+ * General offers a replay.
+ */
+
+const STORAGE_KEY = 'doodle-onboarding-done'
+
+export function isOnboardingDone(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === '1'
+  } catch {
+    return true // storage unavailable — never trap the user in a loop
+  }
+}
+
+export function markOnboardingDone(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, '1')
+  } catch {
+    // best-effort
+  }
+}


### PR DESCRIPTION
## What this adds

A welcome wizard that opens on first launch and walks new users through the setup that makes DoodleNote most useful. Every step is **status-aware** — it reads real app state and shows a live ✓ the moment the user completes it, including mid-tour (e.g. finishing the calendar OAuth in the browser flips the step to done).

### Steps
1. **Welcome** — what DoodleNote is (no bot, on-device, private by default)
2. **Recording a meeting** — + New meeting, You/Them channels, Generate notes; platform-specific permission notes
3. **Connect your calendar** — inline Microsoft 365 / Google connect buttons (runs the real OAuth flow from the wizard)
4. **Never miss a meeting** *(macOS only)* — mic-activity detection, auto-stop, and launch-at-login toggles inline
5. **Cloud sync & sharing** — one-click device link; clearly labeled optional/off by default
6. **Pick your notes model** — deep-links into Settings → Notes model
7. **You're all set** — checklist recap + "Start your first meeting"

### Behavior
- Skippable at any point (Skip button or Escape); closing by any path marks it seen — it never shows twice
- Replayable from **Settings → General → Show tour**
- Persistence is a localStorage flag (`doodle-onboarding-done`), same pattern as the theme pref
- On Windows the detection step is dropped (Phase 2) and copy adjusts
- Existing installs see the tour once after updating (flag starts unset) — intentional, it doubles as a "what can this thing do" refresher

### Gates
- `pnpm typecheck` clean, all **41 tests** pass, eslint clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)