### PR TITLE
Release 0.3.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "Doodle Note desktop app \u2014 spawns the Swift transcription sidecar and shows its live transcript stream",
   "main": "./out/main/index.js",

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -10,6 +10,14 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.3.1",
+    date: "July 7, 2026",
+    highlights: [
+      "Welcome tour: a first-run walkthrough of recording, calendars, meeting detection, cloud sync, and notes models — replay it anytime from Settings → General",
+      "Fixed: the Windows app icon showed the default Electron logo instead of the DoodleNote mascot",
+    ],
+  },
+  {
     version: "0.3.0",
     date: "July 7, 2026",
     highlights: [

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -31,8 +31,8 @@ const FEATURES = [
 
 /** Update feed on Vercel Blob — publish-release.mjs uploads these. */
 const DOWNLOADS = {
-  mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.2.5-arm64-mac.zip",
-  win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.0-setup.exe",
+  mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.1-arm64-mac.zip",
+  win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.1-setup.exe",
 };
 
 export default function Home() {


### PR DESCRIPTION
Version bump + changelog + landing-page download links for 0.3.1 (onboarding tour, Windows app icon fix). Merged after both platform artifacts are live on the update feed so the download links never 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)