### PR TITLE
Windows meeting detection + auto-stop (Phase 2)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -323,7 +323,8 @@ app.whenReady().then(() => {
     micDetect: micWatcher.enabled,
     autoStop: micWatcher.autoStop,
     micMonitorAlive: micWatcher.monitorAlive,
-    micDetectSupported: process.platform === 'darwin',
+    micDetectSupported: process.platform === 'darwin' || process.platform === 'win32',
+    platform: process.platform,
     appVersion: app.getVersion()
   })
   ipcMain.handle(DETECT_GET_STATE_CHANNEL, (): DetectState => detectState())
@@ -339,7 +340,8 @@ app.whenReady().then(() => {
     }
     return detectState()
   })
-  if (process.platform === 'darwin') micWatcher.start()
+  // macOS: engine micmon (CoreAudio). Windows: ConsentStore registry poll.
+  if (process.platform === 'darwin' || process.platform === 'win32') micWatcher.start()
   initAutoUpdater(broadcast)
 
   // node-llama-cpp's async workers SIGABRT if they complete during Electron's

--- a/apps/desktop/src/main/mic-watcher-logic.test.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.test.ts
@@ -21,7 +21,7 @@ const T0 = 1_000_000
 
 describe('mic-watcher-logic', () => {
   it('prompts only after the debounce window', () => {
-    let s = onMicEvent(initialMicState(), true, T0)
+    const s = onMicEvent(initialMicState(), true, T0)
     assert.equal(shouldPrompt(s, T0 + MIC_DEBOUNCE_MS - 1), false)
     assert.equal(shouldPrompt(s, T0 + MIC_DEBOUNCE_MS), true)
   })
@@ -67,6 +67,22 @@ describe('mic-watcher-logic', () => {
     assert.equal(meetingAppLabel([]), null)
     // A meeting app among others still wins.
     assert.equal(meetingAppLabel(['com.fluidvoice.app', 'us.zoom.xos']), 'Zoom')
+  })
+
+  it('recognizes Windows ConsentStore key names (exe paths + package families)', () => {
+    // NonPackaged keys are exe paths with '#' for '\', lowercased by win-micmon.
+    assert.equal(meetingAppLabel(['c:#users#sean#appdata#roaming#zoom#bin#zoom.exe']), 'Zoom')
+    // New Teams is a Store app — package family name.
+    assert.equal(meetingAppLabel(['msteams_8wekyb3d8bbwe']), 'Teams')
+    assert.equal(meetingAppLabel(['c:#program files#slack#slack.exe']), 'Slack')
+    assert.equal(
+      meetingAppLabel(['c:#program files#google#chrome#application#chrome.exe']),
+      'browser'
+    )
+    // DoodleNote's own capture shows up in the ConsentStore — never a meeting.
+    assert.equal(meetingAppLabel(['c:#program files#doodlenote#doodlenote.exe']), null)
+    // Windows browsers are excluded from ring labels like mac ones.
+    assert.equal(meetingRingLabel(['c:#...#msedge.exe']), null)
   })
 
   it('suppression swallows events and requires a fresh edge after lifting', () => {

--- a/apps/desktop/src/main/mic-watcher-logic.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.ts
@@ -29,7 +29,22 @@ const MEETING_BUNDLE_PATTERNS: ReadonlyArray<{ pattern: string; label: string }>
   { pattern: 'org.mozilla.firefox', label: 'browser' },
   { pattern: 'com.microsoft.edgemac', label: 'browser' },
   { pattern: 'company.thebrowser', label: 'browser' }, // Arc
-  { pattern: 'com.brave.browser', label: 'browser' }
+  { pattern: 'com.brave.browser', label: 'browser' },
+  // Windows: ConsentStore key names — exe paths ('#' for '\') for classic
+  // apps, package family names for Store apps (new Teams = MSTeams_…).
+  { pattern: 'zoom.exe', label: 'Zoom' },
+  { pattern: 'msteams', label: 'Teams' },
+  { pattern: 'teams.exe', label: 'Teams' },
+  { pattern: 'webex', label: 'Webex' },
+  { pattern: 'ciscocollab', label: 'Webex' },
+  { pattern: 'slack.exe', label: 'Slack' },
+  { pattern: 'discord.exe', label: 'Discord' },
+  { pattern: 'skype.exe', label: 'Skype' },
+  { pattern: 'chrome.exe', label: 'browser' },
+  { pattern: 'msedge', label: 'browser' },
+  { pattern: 'firefox.exe', label: 'browser' },
+  { pattern: 'brave.exe', label: 'browser' },
+  { pattern: 'arc.exe', label: 'browser' }
 ]
 
 /**

--- a/apps/desktop/src/main/mic-watcher.ts
+++ b/apps/desktop/src/main/mic-watcher.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { appendFileSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { WIN_MICMON_ARGS } from './win-micmon'
 import {
   initialEndState,
   initialMicState,
@@ -30,11 +31,15 @@ interface MicWatcherConfig {
 }
 
 /**
- * Ad-hoc meeting detection: runs the engine's `micmon` command (CoreAudio
- * "device is running somewhere" listener) and prompts when some other app
- * holds the microphone open past the debounce — a Zoom/Teams/Meet call that
- * never made it onto the calendar. Decision logic is pure and tested
- * (mic-watcher-logic.ts); this class owns the child process and timers.
+ * Ad-hoc meeting detection: watches which apps hold the microphone and
+ * prompts when a meeting app keeps it open past the debounce — a
+ * Zoom/Teams/Meet call that never made it onto the calendar. The signal
+ * source is per-platform (same NDJSON contract): macOS runs the engine's
+ * `micmon` command (CoreAudio process attribution); Windows runs a
+ * PowerShell poll of the ConsentStore registry (win-micmon.ts). Ring
+ * detection (audio OUTPUT) exists only in the macOS source. Decision logic
+ * is pure and tested (mic-watcher-logic.ts); this class owns the child
+ * process and timers.
  */
 export class MicWatcher {
   private config: MicWatcherConfig
@@ -160,8 +165,17 @@ export class MicWatcher {
     if (this.child || this.stopping) return
     let child: ChildProcessWithoutNullStreams
     try {
-      // stdin stays open as the parent-death watchdog handle.
-      child = spawn(this.enginePath, ['micmon'], { stdio: ['pipe', 'pipe', 'pipe'] })
+      if (process.platform === 'win32') {
+        // Parent-death watchdog is a PID check inside the script's poll loop.
+        child = spawn('powershell.exe', WIN_MICMON_ARGS, {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env: { ...process.env, DOODLE_PARENT_PID: String(process.pid) },
+          windowsHide: true
+        })
+      } else {
+        // stdin stays open as the parent-death watchdog handle.
+        child = spawn(this.enginePath, ['micmon'], { stdio: ['pipe', 'pipe', 'pipe'] })
+      }
     } catch (error) {
       console.error('[micwatch] spawn failed:', error)
       return
@@ -191,9 +205,7 @@ export class MicWatcher {
             // meeting-app OUTPUT (an incoming call ringing) counts too, so
             // the prompt lands before the call is even answered.
             const bundles = Array.isArray(event.bundles) ? event.bundles.map(String) : []
-            const output = Array.isArray(event.outputBundles)
-              ? event.outputBundles.map(String)
-              : []
+            const output = Array.isArray(event.outputBundles) ? event.outputBundles.map(String) : []
             const inputLabel = event.running ? meetingAppLabel(bundles) : null
             const ringLabel = meetingRingLabel(output)
             this.currentAppLabel = inputLabel ?? ringLabel
@@ -215,7 +227,7 @@ export class MicWatcher {
     child.on('exit', () => {
       this.child = null
       this.clearDebounce()
-      if (!this.stopping && this.config.enabled) {
+      if (!this.stopping && this.childWanted) {
         this.restartTimer = setTimeout(() => this.spawnChild(), RESTART_DELAY_MS)
         this.restartTimer.unref?.()
       }

--- a/apps/desktop/src/main/win-micmon.ts
+++ b/apps/desktop/src/main/win-micmon.ts
@@ -1,0 +1,63 @@
+/**
+ * Windows counterpart of the engine's `micmon` command: a PowerShell poll
+ * loop over the CapabilityAccessManager ConsentStore, which Windows keeps
+ * current for every app that touches the microphone (it powers the systray
+ * mic indicator). An app with LastUsedTimeStart set and LastUsedTimeStop=0
+ * holds the mic RIGHT NOW — that's the same per-app attribution macOS 14.4
+ * gives us via CoreAudio process objects, with zero native code.
+ *
+ * The script emits the exact micmon NDJSON shape on every state CHANGE
+ * (never per-poll — MicWatcher's debounce re-arms on each event):
+ *   {"event":"micmon","running":bool,"bundles":[keyNames],"outputBundles":[]}
+ *
+ * bundles are lowercased ConsentStore key names: NonPackaged keys are exe
+ * paths with '#' for '\' (…#zoom#bin#zoom.exe), packaged apps are package
+ * family names (MSTeams_8wekyb3d8bbwe) — mic-watcher-logic matches both by
+ * substring. outputBundles stays empty: the registry has no speaker-side
+ * equivalent, so ring detection remains macOS-only.
+ */
+
+export const WIN_MICMON_SCRIPT = `
+$ErrorActionPreference = 'SilentlyContinue'
+$root = 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\CapabilityAccessManager\\ConsentStore\\microphone'
+$prev = $null
+while ($true) {
+  if ($env:DOODLE_PARENT_PID) {
+    if (-not (Get-Process -Id ([int]$env:DOODLE_PARENT_PID) -ErrorAction SilentlyContinue)) { exit }
+  }
+  $inUse = New-Object System.Collections.Generic.List[string]
+  foreach ($key in (Get-ChildItem $root -ErrorAction SilentlyContinue)) {
+    if ($key.PSChildName -eq 'NonPackaged') {
+      foreach ($sub in (Get-ChildItem $key.PSPath -ErrorAction SilentlyContinue)) {
+        $v = Get-ItemProperty $sub.PSPath -ErrorAction SilentlyContinue
+        if ($v.LastUsedTimeStart -gt 0 -and $v.LastUsedTimeStop -eq 0) {
+          $inUse.Add($sub.PSChildName.ToLower())
+        }
+      }
+    } else {
+      $v = Get-ItemProperty $key.PSPath -ErrorAction SilentlyContinue
+      if ($v.LastUsedTimeStart -gt 0 -and $v.LastUsedTimeStop -eq 0) {
+        $inUse.Add($key.PSChildName.ToLower())
+      }
+    }
+  }
+  $list = @($inUse | Sort-Object -Unique)
+  $sig = $list -join '|'
+  if ($sig -ne $prev) {
+    $prev = $sig
+    $payload = @{ event = 'micmon'; running = ($list.Count -gt 0); bundles = $list; outputBundles = @() }
+    Write-Output (ConvertTo-Json $payload -Compress)
+  }
+  Start-Sleep -Milliseconds 1500
+}
+`
+
+/** Args for spawning powershell.exe with the monitor script. */
+export const WIN_MICMON_ARGS = [
+  '-NoProfile',
+  '-NonInteractive',
+  '-ExecutionPolicy',
+  'Bypass',
+  '-Command',
+  WIN_MICMON_SCRIPT
+]

--- a/apps/desktop/src/renderer/src/OnboardingTour.tsx
+++ b/apps/desktop/src/renderer/src/OnboardingTour.tsx
@@ -132,7 +132,7 @@ function OnboardingTour({
     (notes.engineChoice === 'cloud'
       ? notes.cloud?.hasKey === true
       : typeof notes.activeLocalModelId === 'string' && notes.activeLocalModelId.length > 0)
-  const isWindows = detect?.micDetectSupported === false
+  const isWindows = detect?.platform === 'win32'
 
   const next = (): void => setStepIndex((i) => Math.min(i + 1, steps.length - 1))
   const back = (): void => setStepIndex((i) => Math.max(i - 1, 0))
@@ -360,7 +360,7 @@ function OnboardingTour({
                 {calendarConnected ? '✓' : '○'} Calendar{' '}
                 {calendarConnected ? 'connected' : 'not connected'}
               </li>
-              {!isWindows && (
+              {detect?.micDetectSupported !== false && (
                 <li className={detectionOn ? 'done' : ''}>
                   {detectionOn ? '✓' : '○'} Meeting detection {detectionOn ? 'on' : 'off'}
                 </li>

--- a/apps/desktop/src/shared/detect-api.ts
+++ b/apps/desktop/src/shared/detect-api.ts
@@ -12,8 +12,10 @@ export interface DetectState {
   autoStop: boolean
   /** The engine micmon child is currently alive (diagnostic). */
   micMonitorAlive: boolean
-  /** Mic-activity detection exists on macOS only (CoreAudio attribution). */
+  /** Mic-activity detection: macOS (CoreAudio) and Windows (ConsentStore). */
   micDetectSupported: boolean
+  /** process.platform, for platform-specific renderer copy. */
+  platform: string
   /** Running app version (package.json), e.g. "0.2.1". */
   appVersion: string
 }


### PR DESCRIPTION
## The report

On the Windows laptop, a Zoom meeting ended but DoodleNote kept recording and never auto-generated notes. Expected: meeting-end auto-stop was **macOS-only** — the Phase 2 gap. This PR closes it.

## How

MicWatcher's prompt/end state machines were already pure and platform-neutral; only the mic-attribution signal was macOS-specific (engine `micmon` via CoreAudio process objects). Windows gets an equivalent source with **zero native code**: a PowerShell poll of `HKCU\...\CapabilityAccessManager\ConsentStore\microphone` — Windows keeps `LastUsedTimeStop = 0` for every app currently holding the mic (it's what drives the systray mic indicator). Per-app attribution for free.

The script emits the exact `micmon` NDJSON contract (`{event, running, bundles, outputBundles}`), only on state changes, so everything downstream runs unchanged.

## What works on Windows now
- **Auto-stop + auto-generate**: Zoom/Teams releases the mic → 12s debounce → recording stops → notes generate (same renderer path as macOS)
- **Ad-hoc meeting prompts**: a meeting app grabbing the mic prompts "start taking notes?" even without a calendar event
- Detection + auto-stop toggles unhidden in Settings; the onboarding tour shows its detection step on Windows
- *Not* included: ring detection (incoming-call audio output) — the registry has no speaker-side equivalent; needs a real audio-session helper later

## Details
- Bundle patterns extended with Windows ConsentStore key shapes: exe paths (`…#zoom#bin#zoom.exe`) and package family names (`MSTeams_8wekyb3d8bbwe`); DoodleNote's own exe matches nothing, so self-capture can't false-trigger
- Parent-death watchdog: the script exits when the app's PID disappears
- Fixed a pre-existing nit: the watcher child now restarts after a crash when only auto-stop is enabled (restart previously keyed off the prompt toggle alone)
- `DetectState.platform` added so renderer copy keys off the real platform

## Verification
- 42 tests pass (new coverage for Windows key-name matching), typecheck + eslint clean
- Script executed under PowerShell Core: emits once per change, valid JSON, arrays stay arrays (the PS single-item-unroll gotcha is guarded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)