### PR TITLE
Doodling paw-print animation while notes generate

### DIFF
--- a/apps/desktop/src/renderer/src/DoodlingIndicator.tsx
+++ b/apps/desktop/src/renderer/src/DoodlingIndicator.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * The "generating notes" state, on brand: a trot of paw prints padding
+ * across the pill while short doodle-flavored phrases rotate underneath the
+ * cursor — DoodleNote is named for Sean's Labradoodle/Goldendoodle and the
+ * doodles everyone leaves in the margins of real notepads. Replaces the raw
+ * streamed-word counter (which was noise, not progress).
+ */
+
+const PHRASES = ['Doodling your notes…', 'Fetching the highlights…', 'Connecting the dots…']
+const PHRASE_ROTATE_MS = 2_800
+
+function PawPrint({ size = 11 }: { size?: number }): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <ellipse cx="12" cy="16.5" rx="5.2" ry="4.6" />
+      <ellipse cx="4.6" cy="10.5" rx="2.4" ry="3.1" transform="rotate(-20 4.6 10.5)" />
+      <ellipse cx="9.4" cy="6.6" rx="2.5" ry="3.3" transform="rotate(-8 9.4 6.6)" />
+      <ellipse cx="14.6" cy="6.6" rx="2.5" ry="3.3" transform="rotate(8 14.6 6.6)" />
+      <ellipse cx="19.4" cy="10.5" rx="2.4" ry="3.1" transform="rotate(20 19.4 10.5)" />
+    </svg>
+  )
+}
+
+function DoodlingIndicator(): React.JSX.Element {
+  const [phrase, setPhrase] = useState(0)
+
+  useEffect(() => {
+    const timer = setInterval(() => setPhrase((p) => (p + 1) % PHRASES.length), PHRASE_ROTATE_MS)
+    return () => clearInterval(timer)
+  }, [])
+
+  return (
+    <span className="doodling" role="status" aria-label="Generating notes">
+      <span className="paw-walk" aria-hidden="true">
+        <span className="paw paw-1">
+          <PawPrint />
+        </span>
+        <span className="paw paw-2">
+          <PawPrint />
+        </span>
+        <span className="paw paw-3">
+          <PawPrint />
+        </span>
+        <span className="paw paw-4">
+          <PawPrint />
+        </span>
+      </span>
+      {/* key remount restarts the fade-in on every phrase change */}
+      <span className="doodling-phrase" key={phrase}>
+        {PHRASES[phrase]}
+      </span>
+    </span>
+  )
+}
+
+export default DoodlingIndicator

--- a/apps/desktop/src/renderer/src/MeetingView.tsx
+++ b/apps/desktop/src/renderer/src/MeetingView.tsx
@@ -13,6 +13,7 @@ import type {
   NotesTemplateInfo
 } from '../../shared/notes-api'
 import FolderPicker from './FolderPicker'
+import DoodlingIndicator from './DoodlingIndicator'
 import FormatToolbar from './FormatToolbar'
 import {
   CalendarIcon,
@@ -180,7 +181,6 @@ export default function MeetingView({
   const [enhancedMarkdown, setEnhancedMarkdown] = useState<string | null>(null)
   const [docView, setDocView] = useState<'notes' | 'enhanced'>('notes')
   const [enhanceStatus, setEnhanceStatus] = useState<EnhanceStatus>('idle')
-  const [enhanceStreamed, setEnhanceStreamed] = useState('')
   const [enhanceError, setEnhanceError] = useState<string | null>(null)
   const [transcriptOpen, setTranscriptOpen] = useState(false)
   const [chatOpen, setChatOpen] = useState(false)
@@ -374,14 +374,6 @@ export default function MeetingView({
           }
         }
         dispatch(ev)
-      }),
-    []
-  )
-
-  useEffect(
-    () =>
-      window.notes.onEnhanceToken(({ token }) => {
-        setEnhanceStreamed((s) => s + token)
       }),
     []
   )
@@ -610,7 +602,6 @@ export default function MeetingView({
     refreshNotesMeta()
     setEnhanceError(null)
     setEnhanceStatus('running')
-    setEnhanceStreamed('')
     // Make sure the freshest rough notes go into the merge.
     if (docViewRef.current === 'notes') {
       roughMarkdownRef.current = docToMarkdown(editor.getJSON())
@@ -827,7 +818,6 @@ export default function MeetingView({
   const folderName =
     folderId !== null ? (folders.find((f) => f.id === folderId)?.name ?? null) : null
 
-  const streamedWords = enhanceStreamed.length > 0 ? enhanceStreamed.trim().split(/\s+/).length : 0
   const transcriptEmpty = allSegments.length === 0 && Object.values(state.partials).every((p) => !p)
   const firstSegmentTime = allSegments.length > 0 ? segmentTime(allSegments[0]!) : 0
 
@@ -964,7 +954,7 @@ export default function MeetingView({
             )}
             {enhancedMarkdown !== null && enhanceStatus === 'running' && (
               <span className="chip-regen-status">
-                {streamedWords > 0 ? `Writing… ${streamedWords} words` : 'Generating…'}
+                <DoodlingIndicator />
               </span>
             )}
           </div>
@@ -1158,10 +1148,7 @@ export default function MeetingView({
             onClick={() => void runEnhance()}
           >
             {enhanceStatus === 'running' ? (
-              <>
-                <span className="spinner" aria-hidden="true" />
-                {streamedWords > 0 ? `Writing… ${streamedWords} words` : 'Generating…'}
-              </>
+              <DoodlingIndicator />
             ) : (
               <>
                 <SparkleIcon size={14} /> Generate notes

--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -3452,3 +3452,72 @@ button.fp-row:hover {
 .tour-next:hover {
   background: var(--accent-deep);
 }
+
+/* ---- doodling indicator (notes are generating) ---- */
+
+.doodling {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+}
+.paw-walk {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+.paw {
+  display: inline-flex;
+  opacity: 0;
+  animation: paw-step 1.6s ease-in-out infinite;
+}
+/* A right-bound trot: prints angled with the walk, alternating footfalls. */
+.paw-1,
+.paw-3 {
+  transform: translateY(-2.5px) rotate(82deg);
+}
+.paw-2,
+.paw-4 {
+  transform: translateY(2.5px) rotate(98deg);
+}
+.paw-1 {
+  animation-delay: 0s;
+}
+.paw-2 {
+  animation-delay: 0.35s;
+}
+.paw-3 {
+  animation-delay: 0.7s;
+}
+.paw-4 {
+  animation-delay: 1.05s;
+}
+@keyframes paw-step {
+  0% {
+    opacity: 0;
+  }
+  15% {
+    opacity: 0.95;
+  }
+  55% {
+    opacity: 0.95;
+  }
+  80% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+.doodling-phrase {
+  animation: doodling-fade 0.35s ease;
+}
+@keyframes doodling-fade {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## What

The Generate pill (and the smaller regenerate chip) now show a **trot of paw prints** padding left-to-right across the button — four prints that appear and fade in sequence like footprints, angled with the direction of travel, alternating footfalls — alongside rotating phrases:

- *Doodling your notes…*
- *Fetching the highlights…*
- *Connecting the dots…*

This replaces the `Writing… N words` counter. Beyond being on-brand (a notepad named for a Labradoodle/Goldendoodle and margin-doodles), it's more honest UI: the word count was an unbounded number, not progress toward anything.

## Details
- Pure CSS animation (opacity keyframes + static per-paw transforms), inherits `currentColor` so it reads correctly on the sage pill and on the muted toolbar chip, light and dark
- Phrases rotate every 2.8s with a soft fade; `role="status"` keeps it announced as "Generating notes" for screen readers
- Drops the now-dead `enhanceStreamed` state and its token listener (one less re-render per streamed token)

## Gates
- Typecheck clean, 42 tests pass, eslint clean on both touched components

🤖 Generated with [Claude Code](https://claude.com/claude-code)