### PR TITLE
Release 0.3.2

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "description": "Doodle Note desktop app \u2014 spawns the Swift transcription sidecar and shows its live transcript stream",
   "main": "./out/main/index.js",

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -10,6 +10,16 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.3.2",
+    date: "July 7, 2026",
+    highlights: [
+      "Windows: recording now stops and notes generate automatically when your meeting ends, and DoodleNote offers to take notes when a meeting app grabs the mic — same as Mac",
+      "Paw prints! Generating notes now shows a trot of paw prints and doodle-flavored phrases instead of a word counter",
+      "Fixed: \u201cCheck for updates\u201d could report stale versions (the update feed was cached too aggressively)",
+      "Fixed: the Windows desktop icon showed black corners; Settings copy no longer says \u201cMac\u201d on Windows",
+    ],
+  },
+  {
     version: "0.3.1",
     date: "July 7, 2026",
     highlights: [

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -31,8 +31,8 @@ const FEATURES = [
 
 /** Update feed on Vercel Blob — publish-release.mjs uploads these. */
 const DOWNLOADS = {
-  mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.1-arm64-mac.zip",
-  win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.1-setup.exe",
+  mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.2-arm64-mac.zip",
+  win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.2-setup.exe",
 };
 
 export default function Home() {


### PR DESCRIPTION
Version bump + changelog + landing links for 0.3.2 (Windows meeting detection/auto-stop, doodling indicator, update-feed TTL + icon fixes). Merged after both platform artifacts are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)