### PR TITLE
Local model load: CPU fallback when the GPU compute layer fails

### DIFF
--- a/packages/ai/src/local-engine.ts
+++ b/packages/ai/src/local-engine.ts
@@ -64,8 +64,30 @@ export class LocalNotesEngine implements NotesEngine {
         if (totalSize > 0) this.options.onDownloadProgress?.(downloadedSize / totalSize)
       }
     })
-    this.llama = await getLlama()
-    this.model = await this.llama.loadModel({ modelPath: this.modelPath })
+    // Staged load: the default compute layer first (Metal on mac, Vulkan on
+    // Windows when present), then CPU-only. Weak/quirky GPUs — typically
+    // laptop iGPUs under Vulkan — can fail at model-load with llama.cpp's
+    // bare "failed to load model"; the CPU binary always loads given enough
+    // RAM. build:'never' everywhere: a packaged app must never attempt a
+    // from-source build (no toolchain on user machines).
+    try {
+      this.llama = await getLlama({ build: 'never' })
+      this.model = await this.llama.loadModel({ modelPath: this.modelPath })
+    } catch (gpuErr) {
+      console.error('[local-engine] default compute layer failed, retrying CPU-only:', gpuErr)
+      try {
+        this.llama = await getLlama({ gpu: false, build: 'never' })
+        this.model = await this.llama.loadModel({ modelPath: this.modelPath })
+      } catch (cpuErr) {
+        this.llama = null
+        this.model = null
+        const detail = cpuErr instanceof Error ? cpuErr.message : String(cpuErr)
+        throw new Error(
+          `The on-device model could not be loaded (tried GPU, then CPU): ${detail}. ` +
+            'If this keeps happening, re-download the model from Settings → Notes model.'
+        )
+      }
+    }
   }
 
   async generateNotes(input: MergeInput, onToken?: (text: string) => void): Promise<MergedNotes> {

--- a/packages/ai/src/local-engine.ts
+++ b/packages/ai/src/local-engine.ts
@@ -45,6 +45,8 @@ export class LocalNotesEngine implements NotesEngine {
   private llama: Llama | null = null
   private model: LlamaModel | null = null
   private modelPath: string | null = null
+  /** GPU layer failed once (load or context) — stay on CPU from then on. */
+  private forceCpu = false
   private readonly options: LocalEngineOptions
 
   constructor(options: LocalEngineOptions) {
@@ -65,28 +67,34 @@ export class LocalNotesEngine implements NotesEngine {
       }
     })
     // Staged load: the default compute layer first (Metal on mac, Vulkan on
-    // Windows when present), then CPU-only. Weak/quirky GPUs — typically
-    // laptop iGPUs under Vulkan — can fail at model-load with llama.cpp's
-    // bare "failed to load model"; the CPU binary always loads given enough
-    // RAM. build:'never' everywhere: a packaged app must never attempt a
+    // Windows when present), then CPU-only. Shared laptop iGPUs under Vulkan
+    // fail intermittently — whether the weights or the KV cache fit depends
+    // on what else is using GPU memory at that moment — with llama.cpp's
+    // bare "failed to load model". The CPU binary always loads given enough
+    // RAM, and once the GPU misbehaves we stop trusting it (forceCpu).
+    // build:'never' everywhere: a packaged app must never attempt a
     // from-source build (no toolchain on user machines).
-    try {
-      this.llama = await getLlama({ build: 'never' })
-      this.model = await this.llama.loadModel({ modelPath: this.modelPath })
-    } catch (gpuErr) {
-      console.error('[local-engine] default compute layer failed, retrying CPU-only:', gpuErr)
+    if (!this.forceCpu) {
       try {
-        this.llama = await getLlama({ gpu: false, build: 'never' })
+        this.llama = await getLlama({ build: 'never' })
         this.model = await this.llama.loadModel({ modelPath: this.modelPath })
-      } catch (cpuErr) {
-        this.llama = null
-        this.model = null
-        const detail = cpuErr instanceof Error ? cpuErr.message : String(cpuErr)
-        throw new Error(
-          `The on-device model could not be loaded (tried GPU, then CPU): ${detail}. ` +
-            'If this keeps happening, re-download the model from Settings → Notes model.'
-        )
+        return
+      } catch (gpuErr) {
+        console.error('[local-engine] default compute layer failed, retrying CPU-only:', gpuErr)
+        this.forceCpu = true
       }
+    }
+    try {
+      this.llama = await getLlama({ gpu: false, build: 'never' })
+      this.model = await this.llama.loadModel({ modelPath: this.modelPath })
+    } catch (cpuErr) {
+      this.llama = null
+      this.model = null
+      const detail = cpuErr instanceof Error ? cpuErr.message : String(cpuErr)
+      throw new Error(
+        `The on-device model could not be loaded (tried GPU, then CPU): ${detail}. ` +
+          'If this keeps happening, re-download the model from Settings → Notes model.'
+      )
     }
   }
 
@@ -118,9 +126,24 @@ export class LocalNotesEngine implements NotesEngine {
     const { LlamaChatSession } = await loadNodeLlamaCpp()
     const started = Date.now()
 
-    const context = await this.model!.createContext({
-      contextSize: this.options.contextSize ?? 8192
-    })
+    let context: Awaited<ReturnType<LlamaModel['createContext']>>
+    try {
+      context = await this.model!.createContext({
+        contextSize: this.options.contextSize ?? 8192
+      })
+    } catch (err) {
+      if (this.forceCpu) throw err
+      // Weights fit on the GPU but the KV cache didn't — reload on CPU.
+      console.error('[local-engine] context creation failed on GPU, reloading CPU-only:', err)
+      this.forceCpu = true
+      await this.model?.dispose()
+      this.model = null
+      this.llama = null
+      await this.prepare()
+      context = await this.model!.createContext({
+        contextSize: this.options.contextSize ?? 8192
+      })
+    }
     try {
       const session = new LlamaChatSession({
         contextSequence: context.getSequence(),


### PR DESCRIPTION
## Report
Windows: generating notes fails with "failed to load the model" (Mac fine). The Fast model shows ACTIVE — download/activation succeeded; the load at generate-time is what dies.

## Cause
`getLlama()` ran with defaults. On Windows that prefers the shipped **Vulkan** binary; on laptops with modest integrated GPUs, `loadModel` fails at GPU allocation with llama.cpp's bare *"failed to load model"* (which is why the string appears nowhere in this repo). Defaults also permit a from-source build attempt when a binary won't load — impossible inside a packaged app, adding a second cryptic failure path. The Mac never hits any of this because Metal always loads.

## Fix
Staged load in `LocalNotesEngine.prepare()`:
1. default compute layer (`Metal`/`Vulkan`) with `build: 'never'`
2. on failure: log the GPU error, retry `gpu: false` (CPU-only — always loads given enough RAM)
3. if both fail: an actionable error carrying the underlying detail and pointing at re-download

Behavior on healthy-GPU machines (all Macs, Windows boxes with proper Vulkan) is unchanged — the fallback only engages on failure.

Gates: `@repo/ai` + desktop typecheck clean, 42 tests pass, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)