### PR TITLE
Two-way sync: pull meetings from the cloud to every linked device

### DIFF
--- a/apps/desktop/src/main/sync-pull-logic.test.ts
+++ b/apps/desktop/src/main/sync-pull-logic.test.ts
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { decidePullAction, shouldTrashLocally } from './sync-pull-logic'
+
+describe('decidePullAction', () => {
+  it('imports meetings that do not exist locally', () => {
+    assert.equal(
+      decidePullAction({
+        localExists: false,
+        localTrashed: false,
+        localHash: null,
+        syncedHash: null,
+        remoteHash: 'r1'
+      }),
+      'import'
+    )
+  })
+
+  it('skips identical content (the usual echo of our own push)', () => {
+    assert.equal(
+      decidePullAction({
+        localExists: true,
+        localTrashed: false,
+        localHash: 'same',
+        syncedHash: 'same',
+        remoteHash: 'same'
+      }),
+      'skip'
+    )
+  })
+
+  it('applies remote updates to a clean local copy', () => {
+    assert.equal(
+      decidePullAction({
+        localExists: true,
+        localTrashed: false,
+        localHash: 'old',
+        syncedHash: 'old', // local unchanged since last sync
+        remoteHash: 'new'
+      }),
+      'apply'
+    )
+  })
+
+  it('never overwrites local edits that have not been pushed', () => {
+    assert.equal(
+      decidePullAction({
+        localExists: true,
+        localTrashed: false,
+        localHash: 'edited-locally',
+        syncedHash: 'old', // dirty: local moved past the last sync
+        remoteHash: 'new'
+      }),
+      'skip'
+    )
+  })
+
+  it('never applies over a meeting with no sync history (conservative)', () => {
+    assert.equal(
+      decidePullAction({
+        localExists: true,
+        localTrashed: false,
+        localHash: 'local-only',
+        syncedHash: null,
+        remoteHash: 'new'
+      }),
+      'skip'
+    )
+  })
+
+  it('never resurrects a locally-trashed meeting', () => {
+    assert.equal(
+      decidePullAction({
+        localExists: true,
+        localTrashed: true,
+        localHash: 'x',
+        syncedHash: 'x',
+        remoteHash: 'y'
+      }),
+      'skip'
+    )
+  })
+})
+
+describe('shouldTrashLocally', () => {
+  it('trashes synced meetings that vanished from the cloud', () => {
+    assert.equal(
+      shouldTrashLocally({
+        wasSynced: true,
+        presentInCloud: false,
+        localTrashed: false,
+        localDirty: false
+      }),
+      true
+    )
+  })
+
+  it('leaves never-synced local meetings alone', () => {
+    assert.equal(
+      shouldTrashLocally({
+        wasSynced: false,
+        presentInCloud: false,
+        localTrashed: false,
+        localDirty: false
+      }),
+      false
+    )
+  })
+
+  it('spares dirty meetings — unsynced edits outrank a remote deletion', () => {
+    assert.equal(
+      shouldTrashLocally({
+        wasSynced: true,
+        presentInCloud: false,
+        localTrashed: false,
+        localDirty: true
+      }),
+      false
+    )
+  })
+
+  it('is a no-op for meetings already in the trash', () => {
+    assert.equal(
+      shouldTrashLocally({
+        wasSynced: true,
+        presentInCloud: false,
+        localTrashed: true,
+        localDirty: false
+      }),
+      false
+    )
+  })
+
+  it('does nothing while the id still exists in the cloud', () => {
+    assert.equal(
+      shouldTrashLocally({
+        wasSynced: true,
+        presentInCloud: true,
+        localTrashed: false,
+        localDirty: false
+      }),
+      false
+    )
+  })
+})

--- a/apps/desktop/src/main/sync-pull-logic.ts
+++ b/apps/desktop/src/main/sync-pull-logic.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure decision logic for applying pulled cloud meetings to the local
+ * store, Electron-free so it unit-tests with node:test. SyncService feeds
+ * it one remote meeting at a time plus the local bookkeeping hashes.
+ *
+ * The invariant behind every rule: LOCAL EDITS ALWAYS WIN until they've
+ * been pushed. A meeting is "dirty" when its current local hash differs
+ * from the hash recorded at its last successful push/pull — applying a
+ * remote copy over a dirty meeting would eat unsynced work.
+ */
+
+export type PullAction = 'import' | 'apply' | 'skip'
+
+export interface PullDecisionInput {
+  /** The meeting exists locally. */
+  localExists: boolean
+  /** Local copy is in the trash (user intent — never resurrect over it). */
+  localTrashed: boolean
+  /** Hash of the local record's current content, null when absent. */
+  localHash: string | null
+  /** Hash recorded at this meeting's last successful push/pull, if any. */
+  syncedHash: string | null
+  /** Hash of the remote content as it would be stored locally. */
+  remoteHash: string
+}
+
+/** What to do with one changed meeting from the pull feed. */
+export function decidePullAction(input: PullDecisionInput): PullAction {
+  if (!input.localExists) return 'import'
+  if (input.localTrashed) return 'skip' // pendingDeletes will clear the cloud copy
+  if (input.localHash === input.remoteHash) return 'skip' // already identical
+  // Dirty: local content differs from what was last synced — push wins.
+  if (input.syncedHash === null || input.localHash !== input.syncedHash) return 'skip'
+  return 'apply'
+}
+
+export interface DeleteDecisionInput {
+  /** The id was synced with the cloud at some point (pushed or imported). */
+  wasSynced: boolean
+  /** The id is present in the cloud's current full id list. */
+  presentInCloud: boolean
+  /** Local copy is already in the trash. */
+  localTrashed: boolean
+  /** Local copy has edits that never made it to the cloud. */
+  localDirty: boolean
+}
+
+/**
+ * True when a local meeting should be soft-trashed because its cloud copy
+ * disappeared (deleted on another device or on the dashboard). Soft-trash,
+ * never hard-delete: the user can restore from Trash if this was a surprise.
+ * Dirty meetings are spared — unsynced edits outrank a remote deletion.
+ */
+export function shouldTrashLocally(input: DeleteDecisionInput): boolean {
+  return input.wasSynced && !input.presentInCloud && !input.localTrashed && !input.localDirty
+}

--- a/apps/desktop/src/main/sync-service.ts
+++ b/apps/desktop/src/main/sync-service.ts
@@ -4,7 +4,8 @@ import { createServer, type Server } from 'node:http'
 import { hostname } from 'node:os'
 import { join } from 'node:path'
 import { ipcMain, safeStorage, shell } from 'electron'
-import type { MeetingRecord } from '../shared/meetings-api'
+import type { TranscriptSegment } from '../shared/engine-events'
+import { MEETINGS_CHANGED_EVENT_CHANNEL, type MeetingRecord } from '../shared/meetings-api'
 import {
   SYNC_CONNECT_CHANNEL,
   SYNC_SHARE_CHANNEL,
@@ -17,6 +18,7 @@ import {
   type SyncStatus
 } from '../shared/sync-api'
 import type { MeetingsService } from './meetings-service'
+import { decidePullAction, shouldTrashLocally } from './sync-pull-logic'
 
 /** Cloud base URL; override with DOODLE_SYNC_URL for local web-dev testing. */
 const DEFAULT_BASE_URL = 'https://doodle-note.vercel.app'
@@ -24,6 +26,9 @@ const DEFAULT_BASE_URL = 'https://doodle-note.vercel.app'
 const LINK_TIMEOUT_MS = 5 * 60_000
 const PUSH_DEBOUNCE_MS = 5_000
 const PUSH_INTERVAL_MS = 5 * 60_000
+/** Pull pages are capped server-side; this bounds a runaway loop. */
+const MAX_PULL_PAGES = 40
+const STARTUP_SYNC_DELAY_MS = 5_000
 
 interface SyncConfig {
   enabled: boolean
@@ -32,8 +37,10 @@ interface SyncConfig {
   email?: string
   workspaceName?: string
   lastSyncAt?: string
-  /** meetingId → content hash at last successful push. */
+  /** meetingId → content hash at last successful sync (push OR pull). */
   pushed: Record<string, string>
+  /** updatedAt high-water mark of the last pull. */
+  pullCursor?: string
   /** attachment file name → public blob URL (uploaded once, reused). */
   mediaUrls: Record<string, string>
   /** Local meetings deleted/trashed whose cloud copy still needs removing. */
@@ -41,15 +48,19 @@ interface SyncConfig {
 }
 
 /**
- * One-way desktop → cloud sync. Local storage stays the source of truth;
- * when enabled, every non-trashed meeting whose content hash changed is
- * pushed (meeting row + full segments + notes markdown) to the web app.
+ * Two-way desktop ↔ cloud sync. Local storage stays the source of truth
+ * for anything edited here: every non-trashed meeting whose content hash
+ * changed is pushed (meeting row + full segments + notes markdown), and a
+ * cursor-based pull imports meetings recorded on other devices. Local
+ * edits always win until pushed (see sync-pull-logic.ts); cloud deletions
+ * soft-trash the local copy, never hard-delete.
  */
 export class SyncService {
   private config: SyncConfig
   private readonly configPath: string
   private readonly baseUrl: string
   private syncing = false
+  private pulling = false
   private linking = false
   private lastError: string | undefined
   private debounceTimer: NodeJS.Timeout | null = null
@@ -81,8 +92,20 @@ export class SyncService {
     )
 
     setInterval(() => {
-      if (this.config.enabled && this.token()) void this.pushAll()
+      if (this.config.enabled && this.token()) void this.syncCycle()
     }, PUSH_INTERVAL_MS).unref()
+
+    // Boot sync: pick up meetings recorded on other devices since last run.
+    const startup = setTimeout(() => {
+      if (this.config.enabled && this.token()) void this.syncCycle()
+    }, STARTUP_SYNC_DELAY_MS)
+    startup.unref()
+  }
+
+  /** Push first (our edits win), then pull what other devices recorded. */
+  private async syncCycle(): Promise<void> {
+    await this.pushAll()
+    await this.pullAll()
   }
 
   /** MeetingsService calls this after every write; deletes pass deletedId. */
@@ -183,8 +206,8 @@ export class SyncService {
       this.config.workspaceName = token.workspace
       this.config.enabled = true
       this.writeConfig()
-      // First backfill right away — the whole point of connecting.
-      void this.pushAll()
+      // First sync right away — the whole point of connecting.
+      void this.syncCycle()
     } catch (error) {
       this.lastError = error instanceof Error ? error.message : 'Could not connect'
     } finally {
@@ -264,7 +287,7 @@ export class SyncService {
   }
 
   async syncNow(): Promise<SyncStatus> {
-    await this.pushAll()
+    await this.syncCycle()
     return this.status()
   }
 
@@ -342,6 +365,170 @@ export class SyncService {
     }
   }
 
+  /* ---- pulling ---- */
+
+  /**
+   * Cursor-based pull of meetings changed on other devices, applied under
+   * the rules in sync-pull-logic.ts. The full cloud id list rides along so
+   * remote deletions can soft-trash the local copy (no tombstones needed).
+   */
+  private async pullAll(): Promise<void> {
+    if (this.pulling || !this.config.enabled) return
+    const token = this.token()
+    if (!token) return
+    this.pulling = true
+    let storeChanged = false
+
+    try {
+      let cursor = this.config.pullCursor ?? ''
+      let cloudIds: Set<string> | null = null
+      for (let page = 0; page < MAX_PULL_PAGES; page++) {
+        const response = await fetch(
+          `${this.baseUrl}/api/sync/pull?since=${encodeURIComponent(cursor)}`,
+          { headers: { Authorization: `Bearer ${token}` } }
+        )
+        if (!response.ok) throw new Error(`Pull failed (HTTP ${response.status})`)
+        const body = (await response.json()) as {
+          allIds?: unknown
+          changed?: RemoteMeeting[]
+          hasMore?: boolean
+        }
+        cloudIds = new Set(Array.isArray(body.allIds) ? body.allIds.map(String) : [])
+        for (const remote of Array.isArray(body.changed) ? body.changed : []) {
+          if (this.applyRemote(remote)) storeChanged = true
+          if (typeof remote.updatedAt === 'string' && remote.updatedAt > cursor) {
+            cursor = remote.updatedAt
+          }
+        }
+        if (body.hasMore !== true) break
+      }
+      if (cloudIds) {
+        if (this.applyCloudDeletions(cloudIds)) storeChanged = true
+      }
+      this.config.pullCursor = cursor
+      this.config.lastSyncAt = new Date().toISOString()
+      this.writeConfig()
+      this.lastError = undefined
+    } catch (error) {
+      this.lastError = error instanceof Error ? error.message : 'Sync failed'
+      console.error('[sync] pull failed:', this.lastError)
+    } finally {
+      this.pulling = false
+      this.emitStatus()
+    }
+
+    if (storeChanged) {
+      // The Home list refetches on this — imported meetings show up live.
+      this.broadcast(MEETINGS_CHANGED_EVENT_CHANNEL, {})
+    }
+  }
+
+  /** Apply one changed cloud meeting. True when the local store changed. */
+  private applyRemote(remote: RemoteMeeting): boolean {
+    const id = String(remote.id ?? '')
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) return false
+
+    interface WireSegment {
+      channel: 'mic' | 'system'
+      speaker?: unknown
+      text: string
+      startMs: number
+      endMs: number
+      confidence?: unknown
+    }
+    const segments: TranscriptSegment[] = (Array.isArray(remote.segments) ? remote.segments : [])
+      .filter(
+        (s): s is WireSegment =>
+          (s.channel === 'mic' || s.channel === 'system') &&
+          typeof s.text === 'string' &&
+          typeof s.startMs === 'number' &&
+          Number.isFinite(s.startMs) &&
+          typeof s.endMs === 'number' &&
+          Number.isFinite(s.endMs)
+      )
+      .map((s, index) => ({
+        // Segment ids are local-only (the cloud stores its own); synthesize.
+        id: `${id}-pull-${index}`,
+        channel: s.channel,
+        speaker:
+          s.speaker === 'You' || s.speaker === 'Them'
+            ? s.speaker
+            : s.channel === 'mic'
+              ? ('You' as const)
+              : ('Them' as const),
+        text: s.text,
+        startMs: Math.round(s.startMs),
+        endMs: Math.round(s.endMs),
+        confidence:
+          typeof s.confidence === 'number' && Number.isFinite(s.confidence) ? s.confidence : 0.9
+      }))
+
+    const incoming: MeetingRecord = {
+      id,
+      title: typeof remote.title === 'string' ? remote.title : '',
+      createdAt:
+        typeof remote.createdAt === 'string' ? remote.createdAt : new Date().toISOString(),
+      ...(typeof remote.startedAt === 'string' ? { startedAt: remote.startedAt } : {}),
+      ...(typeof remote.endedAt === 'string' ? { endedAt: remote.endedAt } : {}),
+      ...(typeof remote.calendarEventId === 'string'
+        ? { calendarEventId: remote.calendarEventId }
+        : {}),
+      rawNotesMarkdown: typeof remote.rawNotesMarkdown === 'string' ? remote.rawNotesMarkdown : '',
+      ...(typeof remote.enhancedMarkdown === 'string'
+        ? { enhancedMarkdown: remote.enhancedMarkdown }
+        : {}),
+      segments,
+      echoSuppressed: 0
+    }
+    const remoteHash = contentHash(incoming, this.config.mediaUrls)
+
+    const local = this.meetings.get(id)
+    const action = decidePullAction({
+      localExists: local !== null,
+      localTrashed: Boolean(local?.trashedAt),
+      localHash: local ? contentHash(local, this.config.mediaUrls) : null,
+      syncedHash: this.config.pushed[id] ?? null,
+      remoteHash
+    })
+    if (action === 'skip') {
+      // Identical content still refreshes the bookkeeping hash.
+      if (local && contentHash(local, this.config.mediaUrls) === remoteHash) {
+        this.config.pushed[id] = remoteHash
+      }
+      return false
+    }
+
+    // Record the hash FIRST so the upsert's change hook sees this meeting
+    // as clean and the debounced push loop doesn't echo it straight back.
+    this.config.pushed[id] = remoteHash
+    this.writeConfig()
+    this.meetings.upsert(incoming)
+    return true
+  }
+
+  /** Soft-trash synced meetings whose cloud copy disappeared. */
+  private applyCloudDeletions(cloudIds: Set<string>): boolean {
+    let changed = false
+    for (const local of this.meetings.readAll()) {
+      const syncedHash = this.config.pushed[local.id]
+      const trash = shouldTrashLocally({
+        wasSynced: syncedHash !== undefined,
+        presentInCloud: cloudIds.has(local.id),
+        localTrashed: Boolean(local.trashedAt),
+        localDirty:
+          syncedHash !== undefined && contentHash(local, this.config.mediaUrls) !== syncedHash
+      })
+      if (!trash) continue
+      // Drop the hash first: the trash upsert fires the delete hook, and a
+      // missing entry keeps it from queueing a redundant cloud DELETE.
+      delete this.config.pushed[local.id]
+      this.writeConfig()
+      this.meetings.upsert({ id: local.id, trashedAt: new Date().toISOString() } as MeetingRecord)
+      changed = true
+    }
+    return changed
+  }
+
   /**
    * Upload attachments referenced by this meeting's markdown that haven't
    * been uploaded yet (name → URL cached in config). Images over the API's
@@ -415,6 +602,26 @@ export class SyncService {
       console.error('[sync] could not persist config:', error)
     }
   }
+}
+
+interface RemoteMeeting {
+  id?: unknown
+  title?: unknown
+  createdAt?: unknown
+  updatedAt?: unknown
+  startedAt?: unknown
+  endedAt?: unknown
+  calendarEventId?: unknown
+  rawNotesMarkdown?: unknown
+  enhancedMarkdown?: unknown
+  segments?: Array<{
+    channel?: unknown
+    speaker?: unknown
+    text?: unknown
+    startMs?: unknown
+    endMs?: unknown
+    confidence?: unknown
+  }>
 }
 
 const MEDIA_REF = /doodle-media:\/\/([a-z0-9.-]+)/g

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -47,6 +47,7 @@ import {
   type NotesTemplateInfo
 } from '../shared/notes-api'
 import {
+  MEETINGS_CHANGED_EVENT_CHANNEL,
   MEETINGS_DELETE_CHANNEL,
   MEETINGS_GET_CHANNEL,
   MEETINGS_LIST_CHANNEL,
@@ -249,6 +250,13 @@ const meetingsApi: MeetingsApi = {
 
   delete(id: string): Promise<void> {
     return ipcRenderer.invoke(MEETINGS_DELETE_CHANNEL, id) as Promise<void>
+  },
+  onChanged(cb) {
+    const listener = (): void => cb()
+    ipcRenderer.on(MEETINGS_CHANGED_EVENT_CHANNEL, listener)
+    return () => {
+      ipcRenderer.removeListener(MEETINGS_CHANGED_EVENT_CHANNEL, listener)
+    }
   }
 }
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -88,6 +88,9 @@ function App(): React.JSX.Element {
     setHomeRefresh((n) => n + 1)
   }, [])
 
+  // Cloud pull can add/update meetings while Home is on screen.
+  useEffect(() => window.meetings.onChanged(refreshHome), [refreshHome])
+
   // Windows: the main process asks the renderer to run audio capture
   // (Chromium mic + WASAPI loopback). macOS never sends these messages.
   useEffect(() => {

--- a/apps/desktop/src/shared/meetings-api.ts
+++ b/apps/desktop/src/shared/meetings-api.ts
@@ -14,6 +14,8 @@ export const MEETINGS_GET_CHANNEL = 'meetings:get'
 export const MEETINGS_UPSERT_CHANNEL = 'meetings:upsert'
 export const MEETINGS_SEARCH_CHANNEL = 'meetings:search'
 export const MEETINGS_DELETE_CHANNEL = 'meetings:delete'
+/** main → renderer: the store changed outside the renderer (cloud pull). */
+export const MEETINGS_CHANGED_EVENT_CHANNEL = 'meetings:changed-event'
 
 /** One persisted "ask anything" exchange. */
 export interface MeetingChatEntry {
@@ -95,5 +97,7 @@ export interface MeetingsApi {
   list(): Promise<MeetingSummary[]>
   get(id: string): Promise<MeetingRecord | null>
   upsert(meeting: MeetingUpsert): Promise<MeetingRecord>
+  /** Fires when cloud sync imports/updates/trashes meetings — refetch lists. */
+  onChanged(cb: () => void): () => void
   delete(id: string): Promise<void>
 }

--- a/apps/web/app/api/sync/pull/route.ts
+++ b/apps/web/app/api/sync/pull/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from "next/server";
+import {
+  and,
+  asc,
+  eq,
+  getDb,
+  gt,
+  inArray,
+  meetings,
+  notes,
+  transcriptSegments,
+} from "@repo/db";
+
+import { authenticateSyncRequest } from "@/lib/sync-auth";
+
+/** Meetings per page; the desktop loops while hasMore. */
+const PAGE_SIZE = 50;
+
+function markdownOf(envelope: unknown): string | null {
+  if (typeof envelope !== "object" || envelope === null) return null;
+  const md = (envelope as { markdown?: unknown }).markdown;
+  return typeof md === "string" && md.length > 0 ? md : null;
+}
+
+/**
+ * Cloud → desktop pull, the other half of two-way sync. Bearer-token
+ * authenticated like push. Returns the workspace's meetings changed since
+ * the `since` cursor (updatedAt ascending, paged) plus the complete id
+ * list — the id list is how deletions propagate without tombstones: a
+ * previously-synced id that is no longer present was deleted somewhere.
+ */
+export async function GET(request: Request) {
+  const device = await authenticateSyncRequest(request);
+  if (!device) {
+    return NextResponse.json({ error: "Invalid sync token" }, { status: 401 });
+  }
+
+  const url = new URL(request.url);
+  const sinceMs = Date.parse(url.searchParams.get("since") ?? "");
+  const since = Number.isNaN(sinceMs) ? new Date(0) : new Date(sinceMs);
+
+  const db = getDb();
+
+  const idRows = await db
+    .select({ id: meetings.id })
+    .from(meetings)
+    .where(eq(meetings.organizationId, device.organizationId));
+  const allIds = idRows.map((r) => r.id);
+
+  const changedRows = await db
+    .select()
+    .from(meetings)
+    .where(
+      and(
+        eq(meetings.organizationId, device.organizationId),
+        gt(meetings.updatedAt, since),
+      ),
+    )
+    .orderBy(asc(meetings.updatedAt))
+    .limit(PAGE_SIZE + 1);
+  const page = changedRows.slice(0, PAGE_SIZE);
+  const hasMore = changedRows.length > PAGE_SIZE;
+
+  const pageIds = page.map((m) => m.id);
+  const noteRows = pageIds.length
+    ? await db.select().from(notes).where(inArray(notes.meetingId, pageIds))
+    : [];
+  const notesByMeeting = new Map(noteRows.map((n) => [n.meetingId, n]));
+  const segmentRows = pageIds.length
+    ? await db
+        .select()
+        .from(transcriptSegments)
+        .where(inArray(transcriptSegments.meetingId, pageIds))
+        .orderBy(asc(transcriptSegments.startMs))
+    : [];
+  const segmentsByMeeting = new Map<string, typeof segmentRows>();
+  for (const seg of segmentRows) {
+    const list = segmentsByMeeting.get(seg.meetingId) ?? [];
+    list.push(seg);
+    segmentsByMeeting.set(seg.meetingId, list);
+  }
+
+  const changed = page.map((m) => {
+    const note = notesByMeeting.get(m.id);
+    return {
+      id: m.id,
+      title: m.title,
+      createdAt: (m.createdAt ?? new Date()).toISOString(),
+      updatedAt: (m.updatedAt ?? new Date()).toISOString(),
+      ...(m.startedAt ? { startedAt: m.startedAt.toISOString() } : {}),
+      ...(m.endedAt ? { endedAt: m.endedAt.toISOString() } : {}),
+      ...(m.calendarEventId ? { calendarEventId: m.calendarEventId } : {}),
+      rawNotesMarkdown: markdownOf(note?.rawContent) ?? "",
+      ...(markdownOf(note?.enhancedContent)
+        ? { enhancedMarkdown: markdownOf(note?.enhancedContent)! }
+        : {}),
+      segments: (segmentsByMeeting.get(m.id) ?? []).map((s) => ({
+        channel: s.channel,
+        speaker: s.speaker,
+        text: s.text,
+        startMs: s.startMs,
+        endMs: s.endMs,
+        ...(s.confidence !== null ? { confidence: s.confidence } : {}),
+      })),
+    };
+  });
+
+  return NextResponse.json({ allIds, changed, hasMore });
+}

--- a/packages/ai/src/local-engine.ts
+++ b/packages/ai/src/local-engine.ts
@@ -64,8 +64,30 @@ export class LocalNotesEngine implements NotesEngine {
         if (totalSize > 0) this.options.onDownloadProgress?.(downloadedSize / totalSize)
       }
     })
-    this.llama = await getLlama()
-    this.model = await this.llama.loadModel({ modelPath: this.modelPath })
+    // Staged load: the default compute layer first (Metal on mac, Vulkan on
+    // Windows when present), then CPU-only. Weak/quirky GPUs — typically
+    // laptop iGPUs under Vulkan — can fail at model-load with llama.cpp's
+    // bare "failed to load model"; the CPU binary always loads given enough
+    // RAM. build:'never' everywhere: a packaged app must never attempt a
+    // from-source build (no toolchain on user machines).
+    try {
+      this.llama = await getLlama({ build: 'never' })
+      this.model = await this.llama.loadModel({ modelPath: this.modelPath })
+    } catch (gpuErr) {
+      console.error('[local-engine] default compute layer failed, retrying CPU-only:', gpuErr)
+      try {
+        this.llama = await getLlama({ gpu: false, build: 'never' })
+        this.model = await this.llama.loadModel({ modelPath: this.modelPath })
+      } catch (cpuErr) {
+        this.llama = null
+        this.model = null
+        const detail = cpuErr instanceof Error ? cpuErr.message : String(cpuErr)
+        throw new Error(
+          `The on-device model could not be loaded (tried GPU, then CPU): ${detail}. ` +
+            'If this keeps happening, re-download the model from Settings → Notes model.'
+        )
+      }
+    }
   }
 
   async generateNotes(input: MergeInput, onToken?: (text: string) => void): Promise<MergedNotes> {

--- a/packages/ai/src/local-engine.ts
+++ b/packages/ai/src/local-engine.ts
@@ -45,6 +45,8 @@ export class LocalNotesEngine implements NotesEngine {
   private llama: Llama | null = null
   private model: LlamaModel | null = null
   private modelPath: string | null = null
+  /** GPU layer failed once (load or context) — stay on CPU from then on. */
+  private forceCpu = false
   private readonly options: LocalEngineOptions
 
   constructor(options: LocalEngineOptions) {
@@ -65,28 +67,34 @@ export class LocalNotesEngine implements NotesEngine {
       }
     })
     // Staged load: the default compute layer first (Metal on mac, Vulkan on
-    // Windows when present), then CPU-only. Weak/quirky GPUs — typically
-    // laptop iGPUs under Vulkan — can fail at model-load with llama.cpp's
-    // bare "failed to load model"; the CPU binary always loads given enough
-    // RAM. build:'never' everywhere: a packaged app must never attempt a
+    // Windows when present), then CPU-only. Shared laptop iGPUs under Vulkan
+    // fail intermittently — whether the weights or the KV cache fit depends
+    // on what else is using GPU memory at that moment — with llama.cpp's
+    // bare "failed to load model". The CPU binary always loads given enough
+    // RAM, and once the GPU misbehaves we stop trusting it (forceCpu).
+    // build:'never' everywhere: a packaged app must never attempt a
     // from-source build (no toolchain on user machines).
-    try {
-      this.llama = await getLlama({ build: 'never' })
-      this.model = await this.llama.loadModel({ modelPath: this.modelPath })
-    } catch (gpuErr) {
-      console.error('[local-engine] default compute layer failed, retrying CPU-only:', gpuErr)
+    if (!this.forceCpu) {
       try {
-        this.llama = await getLlama({ gpu: false, build: 'never' })
+        this.llama = await getLlama({ build: 'never' })
         this.model = await this.llama.loadModel({ modelPath: this.modelPath })
-      } catch (cpuErr) {
-        this.llama = null
-        this.model = null
-        const detail = cpuErr instanceof Error ? cpuErr.message : String(cpuErr)
-        throw new Error(
-          `The on-device model could not be loaded (tried GPU, then CPU): ${detail}. ` +
-            'If this keeps happening, re-download the model from Settings → Notes model.'
-        )
+        return
+      } catch (gpuErr) {
+        console.error('[local-engine] default compute layer failed, retrying CPU-only:', gpuErr)
+        this.forceCpu = true
       }
+    }
+    try {
+      this.llama = await getLlama({ gpu: false, build: 'never' })
+      this.model = await this.llama.loadModel({ modelPath: this.modelPath })
+    } catch (cpuErr) {
+      this.llama = null
+      this.model = null
+      const detail = cpuErr instanceof Error ? cpuErr.message : String(cpuErr)
+      throw new Error(
+        `The on-device model could not be loaded (tried GPU, then CPU): ${detail}. ` +
+          'If this keeps happening, re-download the model from Settings → Notes model.'
+      )
     }
   }
 
@@ -118,9 +126,24 @@ export class LocalNotesEngine implements NotesEngine {
     const { LlamaChatSession } = await loadNodeLlamaCpp()
     const started = Date.now()
 
-    const context = await this.model!.createContext({
-      contextSize: this.options.contextSize ?? 8192
-    })
+    let context: Awaited<ReturnType<LlamaModel['createContext']>>
+    try {
+      context = await this.model!.createContext({
+        contextSize: this.options.contextSize ?? 8192
+      })
+    } catch (err) {
+      if (this.forceCpu) throw err
+      // Weights fit on the GPU but the KV cache didn't — reload on CPU.
+      console.error('[local-engine] context creation failed on GPU, reloading CPU-only:', err)
+      this.forceCpu = true
+      await this.model?.dispose()
+      this.model = null
+      this.llama = null
+      await this.prepare()
+      context = await this.model!.createContext({
+        contextSize: this.options.contextSize ?? 8192
+      })
+    }
     try {
       const session = new LlamaChatSession({
         contextSequence: context.getSequence(),

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,4 +3,4 @@ export * from "./auth-schema";
 export { getDb, schema, authSchema, fullSchema, type Db, type FullSchema } from "./client";
 // Query-builder helpers re-exported so consumers don't need their own
 // drizzle-orm dependency (keeps the version single-sourced here).
-export { and, asc, desc, eq, ilike, or, sql } from "drizzle-orm";
+export { and, asc, desc, eq, gt, ilike, inArray, or, sql } from "drizzle-orm";


### PR DESCRIPTION
## What

Meetings recorded on one device now appear in the library of every device linked to the same workspace. The cloud remains the hub; each desktop pushes its changes up (as before) and now **pulls everyone else's down**.

## How

**Web** — new `GET /api/sync/pull` (same device-token auth as push):
- `?since=<updatedAt cursor>` returns changed meetings ascending, 50/page with `hasMore`
- full content per meeting: row + notes markdown + transcript segments
- the workspace's **complete id list** rides along — that's how deletions propagate with zero schema changes: a previously-synced id missing from the list was deleted somewhere

**Desktop** — SyncService runs a push→pull cycle on boot (+5s), every 5 min, on connect, and on "Sync now". Merge decisions are pure functions in `sync-pull-logic.ts` with 11 unit tests:

| situation | outcome |
|---|---|
| meeting unknown locally | import |
| identical content (echo of own push) | no-op |
| clean local + newer remote | apply remote |
| **local edits not yet pushed** | **skip — local always wins** |
| locally trashed | never resurrected |
| cloud copy vanished | soft-trash locally (restorable); spared if dirty |

Bookkeeping: the existing `pushed` hash map now means "content hash at last successful sync in either direction" — recording the hash before the import upsert keeps the push debounce from echoing pulled content straight back up. A new `meetings:changed-event` broadcast live-refreshes the Home list when a pull lands.

## Known limitations (v1)
- Quick-note kind isn't stored in the cloud, so notes import as regular meetings on other devices
- Folders and per-meeting chat history stay device-local
- Images in pulled meetings render from their cloud URLs (not re-downloaded locally)

## Verification
- `/api/sync/pull` exercised against the dev server (auth-gates with 401 as expected)
- typecheck clean across web, db, desktop; **53 tests pass** (11 new merge-rule cases); eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)