### PR TITLE
Release 0.3.3

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "description": "Doodle Note desktop app \u2014 spawns the Swift transcription sidecar and shows its live transcript stream",
   "main": "./out/main/index.js",

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -10,6 +10,14 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.3.3",
+    date: "July 7, 2026",
+    highlights: [
+      "Two-way sync: meetings recorded on one computer now appear on every device linked to your workspace — deletions travel too (to Trash, always recoverable)",
+      "Fixed: \u201cfailed to load the model\u201d on Windows — note generation now falls back to CPU automatically when the GPU can\u2019t fit the model",
+    ],
+  },
+  {
     version: "0.3.2",
     date: "July 7, 2026",
     highlights: [

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -31,8 +31,8 @@ const FEATURES = [
 
 /** Update feed on Vercel Blob — publish-release.mjs uploads these. */
 const DOWNLOADS = {
-  mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.2-arm64-mac.zip",
-  win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.2-setup.exe",
+  mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.3-arm64-mac.zip",
+  win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.3-setup.exe",
 };
 
 export default function Home() {


### PR DESCRIPTION
Version bump + changelog + landing links for 0.3.3 (two-way sync, local-model CPU fallback). Merged after both platform artifacts are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)