### PR TITLE
Landing page refresh + pricing page

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,8 +4,21 @@
     {
       "name": "web",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["--filter", "web", "dev"],
+      "runtimeArgs": [
+        "--filter",
+        "web",
+        "dev"
+      ],
       "port": 4040
+    },
+    {
+      "name": "web-alt",
+      "runtimeExecutable": "sh",
+      "runtimeArgs": [
+        "-c",
+        "NEXT_DIST_DIR=.next-preview pnpm --filter web exec next dev --port 4141"
+      ],
+      "port": 4141
     }
   ]
 }

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.next-preview/
+.next-build/

--- a/apps/web/app/logos.tsx
+++ b/apps/web/app/logos.tsx
@@ -1,0 +1,27 @@
+/** Platform marks for download buttons. Inherit color via currentColor. */
+
+export function AppleLogo({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.56-1.701" />
+    </svg>
+  );
+}
+
+export function WindowsLogo({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801" />
+    </svg>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -10,30 +10,83 @@ function Wordmark({ size = "text-lg" }: { size?: string }) {
   );
 }
 
-const FEATURES = [
-  {
-    title: "No bot in your meetings",
-    body: "DoodleNote captures mic and system audio right on your computer. Nothing joins the call, nothing announces itself — your meetings stay yours.",
-  },
-  {
-    title: "On-device transcription",
-    body: "Two-channel local transcription knows who said what: your mic is “You,” the other side is “Them.” Fast, accurate, and fully offline.",
-  },
-  {
-    title: "AI notes, locally",
-    body: "Your rough notes merge with the transcript into polished summaries using a local model downloaded in-app — or bring your own API key.",
-  },
-  {
-    title: "Calendar-aware",
-    body: "One-click Microsoft 365 sign-in shows what's coming up, counts down in your menu bar, and offers to start recording when a meeting begins.",
-  },
-];
-
 /** Update feed on Vercel Blob — publish-release.mjs uploads these. */
 const DOWNLOADS = {
   mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.3-arm64-mac.zip",
   win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.3-setup.exe",
 };
+
+const MEETING_APPS = [
+  "Zoom",
+  "Google Meet",
+  "Teams",
+  "Slack huddles",
+  "FaceTime",
+];
+
+const TIMELINE = [
+  {
+    phase: "Before",
+    title: "It knows your calendar",
+    body: "Connect Microsoft 365 or Google Calendar and DoodleNote shows what's coming up, counts down in your menu bar, and offers to take notes the moment your meeting app starts ringing.",
+  },
+  {
+    phase: "During",
+    title: "You just jot",
+    body: "Recording starts instantly and a live transcript builds in the background — your mic is “You,” the other side is “Them.” Type messy half-thoughts; that's all DoodleNote needs.",
+  },
+  {
+    phase: "After",
+    title: "Polished notes, on their own",
+    body: "When the call ends, recording stops by itself and your rough jottings merge with the transcript into clean, structured notes — summary, decisions, action items. Share them with one link.",
+  },
+];
+
+const PRIVACY_POINTS = [
+  {
+    title: "No bot joins your call",
+    body: "DoodleNote captures your mic and system audio right on your computer. Nothing announces itself, nothing sits in the participant list.",
+  },
+  {
+    title: "Transcription never leaves your device",
+    body: "Speech-to-text runs entirely on your Mac or PC. Your meeting audio is never uploaded to us — or anyone else.",
+  },
+  {
+    title: "AI notes with a local model",
+    body: "Notes are written by a local model downloaded in-app. Prefer frontier models? Bring your own API key — it's your key, your data.",
+  },
+  {
+    title: "Sync is opt-in, always",
+    body: "Out of the box, everything stays on your device. Turn on cloud sync only if you want your notes on every device — and turn it off anytime.",
+  },
+];
+
+const FEATURES = [
+  {
+    title: "Ask your meetings anything",
+    body: "Chat with one meeting or across all of them — “what did we promise the customer?” — and get grounded answers with citations back to the transcript.",
+  },
+  {
+    title: "Note templates",
+    body: "Customer discovery, 1:1, standup, interview, troubleshooting — pick a template per meeting, switch and regenerate anytime.",
+  },
+  {
+    title: "Share with a link",
+    body: "Publish a read-only page of any meeting's notes and transcript with one click. No account needed to read it.",
+  },
+  {
+    title: "Team workspaces",
+    body: "Invite your team by link and everyone sees the workspace's synced meetings — one shared memory for the whole team.",
+  },
+  {
+    title: "Full-text search",
+    body: "Search every word ever said across notes and transcripts, on your desktop and in the web library.",
+  },
+  {
+    title: "Quick notes & folders",
+    body: "Standalone notes with the same editor, images, and optional voice dump. Organize everything with folders and a recoverable trash.",
+  },
+];
 
 export default function Home() {
   return (
@@ -50,25 +103,43 @@ export default function Home() {
           />
           <Wordmark />
         </div>
-        <Link
-          href="/login"
-          className="rounded-md border border-sand bg-card px-3.5 py-1.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
-        >
-          Sign in
-        </Link>
+        <nav className="flex items-center gap-1 sm:gap-2">
+          <Link
+            href="/pricing"
+            className="rounded-md px-3 py-1.5 text-sm font-medium text-bark transition-colors hover:bg-sage-fill hover:text-ink"
+          >
+            Pricing
+          </Link>
+          <Link
+            href="/changelog"
+            className="hidden rounded-md px-3 py-1.5 text-sm font-medium text-bark transition-colors hover:bg-sage-fill hover:text-ink sm:block"
+          >
+            What&rsquo;s new
+          </Link>
+          <Link
+            href="/login"
+            className="rounded-md border border-sand bg-card px-3.5 py-1.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
+          >
+            Sign in
+          </Link>
+        </nav>
       </header>
 
       <main className="flex flex-1 flex-col">
-        <section className="mx-auto flex w-full max-w-3xl flex-col items-center px-6 pb-16 pt-20 text-center">
-          <h1 className="text-4xl font-semibold tracking-tight text-ink sm:text-5xl">
-            AI meeting notes,
+        {/* Hero */}
+        <section className="mx-auto flex w-full max-w-3xl flex-col items-center px-6 pb-14 pt-16 text-center sm:pt-20">
+          <p className="rounded-full border border-sand bg-card px-3.5 py-1 text-xs font-medium text-sage-deep">
+            Unlimited meetings, free forever
+          </p>
+          <h1 className="mt-5 text-4xl font-semibold tracking-tight text-ink sm:text-5xl">
+            AI meeting notes.
             <br />
-            <span className="text-sage-deep">without the bot.</span>
+            <span className="text-sage-deep">No bot. No cloud.</span>
           </h1>
           <p className="mt-5 max-w-xl text-lg leading-relaxed text-bark">
-            DoodleNote captures your meetings right on your Mac or PC,
-            transcribes them on-device, and turns your rough notes into
-            polished summaries with local AI. Private by default.
+            DoodleNote records right on your Mac or PC, transcribes on-device,
+            and turns your rough jottings into polished notes, action items,
+            and answers. Your meetings never leave your computer.
           </p>
           <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row">
             <a
@@ -79,43 +150,223 @@ export default function Home() {
             </a>
             <a
               href={DOWNLOADS.win}
-              className="rounded-md bg-ink px-5 py-2.5 text-sm font-medium text-cream transition-opacity hover:opacity-85"
+              className="rounded-md border border-sand bg-card px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
             >
               Download for Windows (beta)
             </a>
-            <Link
-              href="/login"
-              className="rounded-md border border-sand bg-card px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
-            >
-              Open the web dashboard
-            </Link>
           </div>
           <p className="mt-4 text-sm text-stone">
-            macOS on Apple Silicon · Windows 10/11 (64-bit). Nothing leaves
-            your device unless you opt into cloud sync.
+            Works with {MEETING_APPS.join(", ")} — any app that makes sound.
           </p>
         </section>
 
-        <section className="mx-auto w-full max-w-5xl px-6 pb-24">
-          <div className="grid gap-4 sm:grid-cols-2">
-            {FEATURES.map((f) => (
+        {/* Trust strip */}
+        <section className="mx-auto w-full max-w-5xl px-6 pb-20">
+          <div className="grid gap-px overflow-hidden rounded-xl border border-sand bg-sand sm:grid-cols-3">
+            {[
+              ["0", "bots joining your calls"],
+              ["100%", "on-device transcription"],
+              ["$0", "for unlimited meetings"],
+            ].map(([stat, label]) => (
               <div
-                key={f.title}
-                className="rounded-xl border border-sand bg-card-soft p-6"
+                key={label}
+                className="flex flex-col items-center bg-card-soft px-6 py-6 text-center"
               >
-                <h2 className="text-base font-semibold text-ink">{f.title}</h2>
-                <p className="mt-2 text-sm leading-relaxed text-bark">
-                  {f.body}
-                </p>
+                <span className="text-3xl font-semibold tracking-tight text-sage-deep">
+                  {stat}
+                </span>
+                <span className="mt-1 text-sm text-bark">{label}</span>
               </div>
             ))}
+          </div>
+        </section>
+
+        {/* Before / during / after */}
+        <section className="border-y border-sand bg-card-soft">
+          <div className="mx-auto w-full max-w-5xl px-6 py-20">
+            <h2 className="text-center text-3xl font-semibold tracking-tight text-ink">
+              Before, during, and after every meeting
+            </h2>
+            <p className="mx-auto mt-3 max-w-xl text-center text-bark">
+              DoodleNote handles the note-taking so you can actually be in the
+              conversation.
+            </p>
+            <div className="mt-12 grid gap-4 sm:grid-cols-3">
+              {TIMELINE.map((step) => (
+                <div
+                  key={step.phase}
+                  className="rounded-xl border border-sand bg-card p-6"
+                >
+                  <span className="text-xs font-semibold uppercase tracking-wider text-sage">
+                    {step.phase}
+                  </span>
+                  <h3 className="mt-2 text-base font-semibold text-ink">
+                    {step.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-relaxed text-bark">
+                    {step.body}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Privacy — the differentiator */}
+        <section className="mx-auto w-full max-w-5xl px-6 py-20">
+          <div className="grid gap-10 lg:grid-cols-[1fr_1.2fr] lg:items-center">
+            <div>
+              <h2 className="text-3xl font-semibold tracking-tight text-ink">
+                Private by design,
+                <br />
+                not by promise
+              </h2>
+              <p className="mt-4 leading-relaxed text-bark">
+                Other AI notetakers upload your meeting audio to their servers
+                and process it there. DoodleNote is built the other way around:
+                capture, transcription, and AI all run on your own computer.
+                There is nothing to leak, because nothing is sent.
+              </p>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {PRIVACY_POINTS.map((p) => (
+                <div
+                  key={p.title}
+                  className="rounded-xl border border-sand bg-card-soft p-5"
+                >
+                  <h3 className="text-sm font-semibold text-ink">{p.title}</h3>
+                  <p className="mt-1.5 text-sm leading-relaxed text-bark">
+                    {p.body}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Feature grid */}
+        <section className="border-y border-sand bg-card-soft">
+          <div className="mx-auto w-full max-w-5xl px-6 py-20">
+            <h2 className="text-center text-3xl font-semibold tracking-tight text-ink">
+              A real notepad, not just a recorder
+            </h2>
+            <div className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {FEATURES.map((f) => (
+                <div
+                  key={f.title}
+                  className="rounded-xl border border-sand bg-card p-6"
+                >
+                  <h3 className="text-base font-semibold text-ink">
+                    {f.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-relaxed text-bark">
+                    {f.body}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Pricing teaser */}
+        <section className="mx-auto w-full max-w-5xl px-6 py-20">
+          <h2 className="text-center text-3xl font-semibold tracking-tight text-ink">
+            Free forever. Pay only for sync.
+          </h2>
+          <p className="mx-auto mt-3 max-w-xl text-center text-bark">
+            Everything that runs on your device is free with no meeting caps.
+            Add Sync when you want your notes on every device.
+          </p>
+          <div className="mx-auto mt-10 grid max-w-3xl gap-4 sm:grid-cols-2">
+            <div className="rounded-xl border border-sand bg-card p-6">
+              <h3 className="text-base font-semibold text-ink">Free</h3>
+              <p className="mt-1 text-3xl font-semibold tracking-tight text-ink">
+                $0
+                <span className="text-sm font-normal text-stone"> forever</span>
+              </p>
+              <p className="mt-3 text-sm leading-relaxed text-bark">
+                Unlimited recording, on-device transcription, AI notes, chat,
+                calendars, templates, and search — all local, no account
+                required.
+              </p>
+            </div>
+            <div className="rounded-xl border-2 border-sage bg-card p-6">
+              <h3 className="text-base font-semibold text-ink">Sync</h3>
+              <p className="mt-1 text-3xl font-semibold tracking-tight text-ink">
+                $10
+                <span className="text-sm font-normal text-stone">
+                  {" "}
+                  / month
+                </span>
+              </p>
+              <p className="mt-3 text-sm leading-relaxed text-bark">
+                Everything in Free, plus your meetings on every device, the web
+                library, share links, and team workspaces.
+              </p>
+            </div>
+          </div>
+          <p className="mt-6 text-center">
+            <Link
+              href="/pricing"
+              className="text-sm font-medium text-sage-deep hover:underline"
+            >
+              Compare plans in detail →
+            </Link>
+          </p>
+        </section>
+
+        {/* Final CTA */}
+        <section className="border-t border-sand bg-card-soft">
+          <div className="mx-auto flex w-full max-w-3xl flex-col items-center px-6 py-16 text-center">
+            <Image
+              src="/mascot.png"
+              alt=""
+              width={52}
+              height={52}
+              className="rounded-xl"
+            />
+            <h2 className="mt-5 text-3xl font-semibold tracking-tight text-ink">
+              Bring DoodleNote to your next meeting
+            </h2>
+            <p className="mt-3 max-w-md text-bark">
+              Download, hit record, and see your rough jottings come back as
+              real notes.
+            </p>
+            <div className="mt-7 flex flex-col items-center gap-3 sm:flex-row">
+              <a
+                href={DOWNLOADS.mac}
+                className="rounded-md bg-ink px-5 py-2.5 text-sm font-medium text-cream transition-opacity hover:opacity-85"
+              >
+                Download for macOS
+              </a>
+              <a
+                href={DOWNLOADS.win}
+                className="rounded-md border border-sand bg-card px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
+              >
+                Download for Windows (beta)
+              </a>
+            </div>
+            <p className="mt-4 text-sm text-stone">
+              macOS on Apple Silicon · Windows 10/11 (64-bit)
+            </p>
           </div>
         </section>
       </main>
 
       <footer className="border-t border-sand">
-        <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-6 text-sm text-stone">
+        <div className="mx-auto flex w-full max-w-5xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-stone sm:flex-row">
           <Wordmark size="text-sm" />
+          <nav className="flex items-center gap-5">
+            <Link href="/pricing" className="hover:text-ink">
+              Pricing
+            </Link>
+            <Link href="/changelog" className="hover:text-ink">
+              What&rsquo;s new
+            </Link>
+            <Link href="/login" className="hover:text-ink">
+              Sign in
+            </Link>
+          </nav>
           <span>Local-first. Your meetings never leave your device.</span>
         </div>
       </footer>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { AppleLogo, WindowsLogo } from "./logos";
 
 function Wordmark({ size = "text-lg" }: { size?: string }) {
   return (
@@ -144,14 +145,16 @@ export default function Home() {
           <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row">
             <a
               href={DOWNLOADS.mac}
-              className="rounded-md bg-ink px-5 py-2.5 text-sm font-medium text-cream transition-opacity hover:opacity-85"
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-ink px-5 py-2.5 text-sm font-medium text-cream transition-opacity hover:opacity-85"
             >
+              <AppleLogo className="h-4 w-4 -mt-0.5" />
               Download for macOS
             </a>
             <a
               href={DOWNLOADS.win}
-              className="rounded-md border border-sand bg-card px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-sand bg-card px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
             >
+              <WindowsLogo className="h-3.5 w-3.5" />
               Download for Windows (beta)
             </a>
           </div>

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -1,0 +1,217 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export const metadata = { title: "Pricing — DoodleNote" };
+
+/** Update feed on Vercel Blob — publish-release.mjs uploads these. */
+const DOWNLOADS = {
+  mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.3-arm64-mac.zip",
+  win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.3-setup.exe",
+};
+
+const FREE_FEATURES = [
+  "Unlimited meetings and recording — no caps, ever",
+  "No-bot capture of mic + system audio on Mac and PC",
+  "On-device transcription — audio never leaves your computer",
+  "AI notes from a local model, or bring your own API key",
+  "Ask anything about one meeting or across all of them, with citations",
+  "Microsoft 365 and Google Calendar, meeting-start prompts",
+  "Note templates, quick notes, folders, and full-text search",
+  "Automatic updates",
+];
+
+const SYNC_FEATURES = [
+  "Everything in Free",
+  "Your meetings synced across every device, both ways",
+  "Web library — read and search your notes from any browser",
+  "Share any meeting as a read-only link",
+  "Team workspaces — invite by link, share one meeting memory",
+  "Images in notes synced and shown on shared pages",
+];
+
+const FAQ = [
+  {
+    q: "Is the free plan really free forever?",
+    a: "Yes. Recording, transcription, and AI notes all run on your own computer — they cost us nothing to provide, so we will never cap your meetings or put your own notes behind a paywall.",
+  },
+  {
+    q: "What exactly am I paying for with Sync?",
+    a: "Servers and storage. Sync keeps an encrypted-in-transit copy of your meetings in the cloud so every device you link stays up to date, powers the web library and share links, and hosts your team's shared workspace.",
+  },
+  {
+    q: "What happens if I cancel Sync?",
+    a: "Nothing dramatic. Your notes stay on your devices in full — DoodleNote is local-first, so canceling just stops the syncing. You can re-subscribe anytime and pick up where you left off.",
+  },
+  {
+    q: "Do you train AI on my meetings?",
+    a: "No. Transcription and note generation happen on your device. If you enable Sync, your data is used only to power sync, search, and sharing — never for training, never sold.",
+  },
+  {
+    q: "Do I need a ChatGPT or Claude subscription?",
+    a: "No. DoodleNote downloads a local model in-app that writes your notes for free. If you prefer a frontier model, you can plug in your own OpenAI or Anthropic API key.",
+  },
+];
+
+export default function PricingPage() {
+  return (
+    <div className="flex flex-1 flex-col bg-cream text-bark">
+      <header className="border-b border-sand bg-card-soft">
+        <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-3">
+          <Link href="/" className="flex items-center gap-2">
+            <Image
+              src="/mascot.png"
+              alt=""
+              width={26}
+              height={26}
+              className="rounded-md"
+            />
+            <span className="text-sm font-bold tracking-tight">
+              <span className="text-ink">Doodle</span>
+              <span className="text-sage">Note</span>
+            </span>
+          </Link>
+          <nav className="flex items-center gap-1 sm:gap-2">
+            <Link
+              href="/changelog"
+              className="hidden rounded-md px-3 py-1.5 text-sm font-medium text-bark transition-colors hover:bg-sage-fill hover:text-ink sm:block"
+            >
+              What&rsquo;s new
+            </Link>
+            <Link
+              href="/login"
+              className="rounded-md border border-sand bg-card px-3.5 py-1.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
+            >
+              Sign in
+            </Link>
+          </nav>
+        </div>
+      </header>
+
+      <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-6 py-14">
+        <div className="text-center">
+          <h1 className="text-4xl font-semibold tracking-tight text-ink">
+            Free forever. Pay only for sync.
+          </h1>
+          <p className="mx-auto mt-4 max-w-xl text-lg leading-relaxed text-bark">
+            Everything that runs on your device — recording, transcription, AI
+            notes — is free with no meeting caps. Sync is for when you want
+            your notes everywhere.
+          </p>
+        </div>
+
+        <div className="mx-auto mt-12 grid w-full max-w-4xl gap-5 lg:grid-cols-2">
+          {/* Free */}
+          <div className="flex flex-col rounded-2xl border border-sand bg-card p-8">
+            <h2 className="text-lg font-semibold text-ink">Free</h2>
+            <p className="mt-1 text-sm text-stone">
+              The whole notepad, on your device
+            </p>
+            <p className="mt-5 text-4xl font-semibold tracking-tight text-ink">
+              $0
+              <span className="text-base font-normal text-stone"> forever</span>
+            </p>
+            <ul className="mt-6 flex-1 space-y-2.5">
+              {FREE_FEATURES.map((item) => (
+                <li
+                  key={item}
+                  className="flex gap-2.5 text-sm leading-relaxed"
+                >
+                  <span className="mt-0.5 shrink-0 text-sage" aria-hidden="true">
+                    ✓
+                  </span>
+                  {item}
+                </li>
+              ))}
+            </ul>
+            <div className="mt-8 flex flex-col gap-2.5">
+              <a
+                href={DOWNLOADS.mac}
+                className="rounded-md bg-ink px-5 py-2.5 text-center text-sm font-medium text-cream transition-opacity hover:opacity-85"
+              >
+                Download for macOS
+              </a>
+              <a
+                href={DOWNLOADS.win}
+                className="rounded-md border border-sand bg-card px-5 py-2.5 text-center text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
+              >
+                Download for Windows (beta)
+              </a>
+            </div>
+          </div>
+
+          {/* Sync */}
+          <div className="relative flex flex-col rounded-2xl border-2 border-sage bg-card p-8">
+            <span className="absolute -top-3 right-6 rounded-full bg-sage px-3 py-0.5 text-xs font-semibold text-cream">
+              Early access
+            </span>
+            <h2 className="text-lg font-semibold text-ink">Sync</h2>
+            <p className="mt-1 text-sm text-stone">
+              Your meetings on every device
+            </p>
+            <p className="mt-5 text-4xl font-semibold tracking-tight text-ink">
+              $10
+              <span className="text-base font-normal text-stone">
+                {" "}
+                / user / month
+              </span>
+            </p>
+            <ul className="mt-6 flex-1 space-y-2.5">
+              {SYNC_FEATURES.map((item) => (
+                <li
+                  key={item}
+                  className="flex gap-2.5 text-sm leading-relaxed"
+                >
+                  <span className="mt-0.5 shrink-0 text-sage" aria-hidden="true">
+                    ✓
+                  </span>
+                  {item}
+                </li>
+              ))}
+            </ul>
+            <div className="mt-8 flex flex-col gap-2.5">
+              <Link
+                href="/login"
+                className="rounded-md bg-sage-deep px-5 py-2.5 text-center text-sm font-medium text-cream transition-opacity hover:opacity-85"
+              >
+                Get started
+              </Link>
+              <p className="text-center text-xs text-stone">
+                Free during early access — billing starts when Sync leaves
+                beta.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* FAQ */}
+        <section className="mx-auto mt-20 w-full max-w-3xl">
+          <h2 className="text-center text-2xl font-semibold tracking-tight text-ink">
+            Questions, answered
+          </h2>
+          <div className="mt-8 space-y-4">
+            {FAQ.map((item) => (
+              <div
+                key={item.q}
+                className="rounded-xl border border-sand bg-card-soft p-6"
+              >
+                <h3 className="text-sm font-semibold text-ink">{item.q}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-bark">
+                  {item.a}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </main>
+
+      <footer className="border-t border-sand">
+        <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-6 text-sm text-stone">
+          <Link href="/" className="font-semibold text-sage-deep hover:underline">
+            DoodleNote
+          </Link>
+          <span>Local-first. Your meetings never leave your device.</span>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { AppleLogo, WindowsLogo } from "../logos";
 
 export const metadata = { title: "Pricing — DoodleNote" };
 
@@ -126,14 +127,16 @@ export default function PricingPage() {
             <div className="mt-8 flex flex-col gap-2.5">
               <a
                 href={DOWNLOADS.mac}
-                className="rounded-md bg-ink px-5 py-2.5 text-center text-sm font-medium text-cream transition-opacity hover:opacity-85"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-ink px-5 py-2.5 text-center text-sm font-medium text-cream transition-opacity hover:opacity-85"
               >
+                <AppleLogo className="h-4 w-4 -mt-0.5" />
                 Download for macOS
               </a>
               <a
                 href={DOWNLOADS.win}
-                className="rounded-md border border-sand bg-card px-5 py-2.5 text-center text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-sand bg-card px-5 py-2.5 text-center text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
               >
+                <WindowsLogo className="h-3.5 w-3.5" />
                 Download for Windows (beta)
               </a>
             </div>

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -9,6 +9,8 @@ const eslintConfig = defineConfig([
   globalIgnores([
     // Default ignores of eslint-config-next:
     ".next/**",
+    ".next-preview/**",
+    ".next-build/**",
     "out/**",
     "build/**",
     "next-env.d.ts",

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  /**
+   * Next allows one dev server per dist dir; a second session (agent preview)
+   * can set NEXT_DIST_DIR to run alongside the primary `pnpm dev` server.
+   */
+  distDir: process.env.NEXT_DIST_DIR || ".next",
   /** @repo/db ships raw TypeScript — let Next transpile it. */
   transpilePackages: ["@repo/db"],
   /**


### PR DESCRIPTION
## What

Competes head-on with granola.ai's landing page using everything actually shipped in DoodleNote, and adds a `/pricing` page (Obsidian-style: free forever + one paid Sync tier).

### Landing page (`/`)
- New hero: **"AI meeting notes. No bot. No cloud."** with a free-forever badge — hits Granola where it hurts (their free tier caps at 25 meetings; their transcription is cloud-side)
- Trust strip: 0 bots / 100% on-device transcription / $0 unlimited meetings
- **Before / During / After** timeline (mirrors Granola's strongest section) built from real features: calendar prompts, instant recording, auto-stop + auto-generated notes
- **"Private by design, not by promise"** section — the core differentiator vs every cloud notetaker
- Feature grid: cited chat, templates, share links, workspaces, full-text search, quick notes
- Pricing teaser + nav/footer links to Pricing and What's new

### Pricing page (`/pricing`)
- **Free — $0 forever**: everything that runs on-device, no meeting caps
- **Sync — $10 / user / month**: cross-device sync, web library, share links, team workspaces ("Early access — free until billing lands")
- FAQ: free-forever honesty, what Sync pays for, cancellation, no training on user data, no AI subscription needed

### Dev tooling (small)
- `NEXT_DIST_DIR` env in next.config.ts lets a second dev server (agent preview) run beside the primary one; alt dist dirs gitignored + eslint-ignored; `web-alt` launch config

## Verification
- `pnpm --filter web typecheck`, `lint`, and `build` all green; `/pricing` prerenders static
- Both pages verified in a live preview (desktop viewport, no console errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)