### PR TITLE
Folder sync: spaces and meeting assignments travel with two-way sync

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,8 +4,21 @@
     {
       "name": "web",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["--filter", "web", "dev"],
+      "runtimeArgs": [
+        "--filter",
+        "web",
+        "dev"
+      ],
       "port": 4040
+    },
+    {
+      "name": "web-alt",
+      "runtimeExecutable": "sh",
+      "runtimeArgs": [
+        "-c",
+        "NEXT_DIST_DIR=.next-preview pnpm --filter web exec next dev --port 4141"
+      ],
+      "port": 4141
     }
   ]
 }

--- a/apps/desktop/src/main/folders-service.ts
+++ b/apps/desktop/src/main/folders-service.ts
@@ -19,6 +19,9 @@ const MAX_NAME_LENGTH = 80
  * "My notes" (folderId: null) — meetings themselves are never deleted here.
  */
 export class FoldersService {
+  /** Post-write hook (cloud sync). `deletedId` set on folder deletion. */
+  onDidWrite: ((change: { deletedId?: string }) => void) | null = null
+
   constructor(
     private readonly file: string,
     private readonly meetings: MeetingsService
@@ -49,6 +52,7 @@ export class FoldersService {
       createdAt: new Date().toISOString()
     }
     this.save([...this.list(), folder])
+    this.onDidWrite?.({})
     return folder
   }
 
@@ -58,11 +62,13 @@ export class FoldersService {
     if (!folder) return null
     folder.name = cleanName(name)
     this.save(folders)
+    this.onDidWrite?.({})
     return folder
   }
 
   delete(id: string): void {
     this.save(this.list().filter((f) => f.id !== id))
+    this.onDidWrite?.({ deletedId: id })
     // Sweep the meetings dir: anything filed here moves back to "My notes".
     // (Runs even if the folder was already gone, so orphans self-heal.)
     for (const meeting of this.meetings.list()) {
@@ -70,6 +76,23 @@ export class FoldersService {
         this.meetings.upsert({ id: meeting.id, folderId: null })
       }
     }
+  }
+
+  /** Cloud pull: create or rename with a fixed id, keeping createdAt. */
+  upsertRemote(record: FolderRecord): void {
+    const folders = this.list()
+    const existing = folders.find((f) => f.id === record.id)
+    if (existing) {
+      if (existing.name === record.name) return
+      existing.name = cleanName(record.name)
+      this.save(folders)
+    } else {
+      this.save([
+        ...folders,
+        { id: record.id, name: cleanName(record.name), createdAt: record.createdAt }
+      ])
+    }
+    this.onDidWrite?.({})
   }
 
   private save(folders: FolderRecord[]): void {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -365,9 +365,15 @@ app.whenReady().then(() => {
   })
 
   // Cloud sync: opt-in one-way push of meetings/notes to the web dashboard.
-  const syncService = new SyncService(app.getPath('userData'), meetingsService, broadcast)
+  const syncService = new SyncService(
+    app.getPath('userData'),
+    meetingsService,
+    foldersService,
+    broadcast
+  )
   syncService.registerIpc()
   meetingsService.onDidWrite = (change) => syncService.onMeetingsChanged(change.deletedId)
+  foldersService.onDidWrite = (change) => syncService.onFoldersChanged(change.deletedId)
 
   // Image attachments for the notes editor (doodle-media:// protocol).
   const mediaService = new MediaService(join(app.getPath('userData'), 'attachments'))

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -342,7 +342,7 @@ app.whenReady().then(() => {
   })
   // macOS: engine micmon (CoreAudio). Windows: ConsentStore registry poll.
   if (process.platform === 'darwin' || process.platform === 'win32') micWatcher.start()
-  initAutoUpdater(broadcast)
+  initAutoUpdater(broadcast, () => notesService?.dispose() ?? Promise.resolve())
 
   // node-llama-cpp's async workers SIGABRT if they complete during Electron's
   // teardown (ThrowAsJavaScriptException on a dead env → ggml terminate) —

--- a/apps/desktop/src/main/sync-pull-logic.test.ts
+++ b/apps/desktop/src/main/sync-pull-logic.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { decidePullAction, shouldTrashLocally } from './sync-pull-logic'
+import {
+  decideFolderPull,
+  decidePullAction,
+  shouldRemoveFolderLocally,
+  shouldTrashLocally
+} from './sync-pull-logic'
 
 describe('decidePullAction', () => {
   it('imports meetings that do not exist locally', () => {
@@ -139,6 +144,91 @@ describe('shouldTrashLocally', () => {
         localTrashed: false,
         localDirty: false
       }),
+      false
+    )
+  })
+})
+
+describe('decideFolderPull', () => {
+  it('creates folders that do not exist locally', () => {
+    assert.equal(
+      decideFolderPull({
+        localExists: false,
+        localName: null,
+        syncedName: null,
+        remoteName: 'Clients'
+      }),
+      'create'
+    )
+  })
+
+  it('skips identical names', () => {
+    assert.equal(
+      decideFolderPull({
+        localExists: true,
+        localName: 'Clients',
+        syncedName: 'Clients',
+        remoteName: 'Clients'
+      }),
+      'skip'
+    )
+  })
+
+  it('applies a remote rename to a clean local folder', () => {
+    assert.equal(
+      decideFolderPull({
+        localExists: true,
+        localName: 'Clients',
+        syncedName: 'Clients',
+        remoteName: 'Customers'
+      }),
+      'rename'
+    )
+  })
+
+  it('never overwrites an unsynced local rename', () => {
+    assert.equal(
+      decideFolderPull({
+        localExists: true,
+        localName: 'My Clients',
+        syncedName: 'Clients',
+        remoteName: 'Customers'
+      }),
+      'skip'
+    )
+  })
+
+  it('never renames folders with no sync history', () => {
+    assert.equal(
+      decideFolderPull({
+        localExists: true,
+        localName: 'Local Only',
+        syncedName: null,
+        remoteName: 'Remote'
+      }),
+      'skip'
+    )
+  })
+})
+
+describe('shouldRemoveFolderLocally', () => {
+  it('removes synced folders that vanished from the cloud', () => {
+    assert.equal(
+      shouldRemoveFolderLocally({ wasSynced: true, presentInCloud: false, localDirty: false }),
+      true
+    )
+  })
+
+  it('leaves never-synced folders alone', () => {
+    assert.equal(
+      shouldRemoveFolderLocally({ wasSynced: false, presentInCloud: false, localDirty: false }),
+      false
+    )
+  })
+
+  it('spares folders with a rename pending push', () => {
+    assert.equal(
+      shouldRemoveFolderLocally({ wasSynced: true, presentInCloud: false, localDirty: true }),
       false
     )
   })

--- a/apps/desktop/src/main/sync-pull-logic.ts
+++ b/apps/desktop/src/main/sync-pull-logic.ts
@@ -54,3 +54,36 @@ export interface DeleteDecisionInput {
 export function shouldTrashLocally(input: DeleteDecisionInput): boolean {
   return input.wasSynced && !input.presentInCloud && !input.localTrashed && !input.localDirty
 }
+
+/* ---- folders ---- */
+
+export type FolderPullAction = 'create' | 'rename' | 'skip'
+
+export interface FolderPullInput {
+  localExists: boolean
+  /** Current local name, null when absent. */
+  localName: string | null
+  /** Name recorded at the folder's last successful sync, if any. */
+  syncedName: string | null
+  remoteName: string
+}
+
+/** Same discipline as meetings: an unsynced local rename outranks remote. */
+export function decideFolderPull(input: FolderPullInput): FolderPullAction {
+  if (!input.localExists) return 'create'
+  if (input.localName === input.remoteName) return 'skip'
+  if (input.syncedName === null || input.localName !== input.syncedName) return 'skip'
+  return 'rename'
+}
+
+export interface FolderDeleteInput {
+  wasSynced: boolean
+  presentInCloud: boolean
+  /** Local name differs from the last-synced name (rename pending push). */
+  localDirty: boolean
+}
+
+/** Remove locally when the cloud copy vanished — unless a rename is pending. */
+export function shouldRemoveFolderLocally(input: FolderDeleteInput): boolean {
+  return input.wasSynced && !input.presentInCloud && !input.localDirty
+}

--- a/apps/desktop/src/main/sync-service.ts
+++ b/apps/desktop/src/main/sync-service.ts
@@ -17,8 +17,15 @@ import {
   type ShareResult,
   type SyncStatus
 } from '../shared/sync-api'
+import type { FolderRecord } from '../shared/folders-api'
+import type { FoldersService } from './folders-service'
 import type { MeetingsService } from './meetings-service'
-import { decidePullAction, shouldTrashLocally } from './sync-pull-logic'
+import {
+  decideFolderPull,
+  decidePullAction,
+  shouldRemoveFolderLocally,
+  shouldTrashLocally
+} from './sync-pull-logic'
 
 /** Cloud base URL; override with DOODLE_SYNC_URL for local web-dev testing. */
 const DEFAULT_BASE_URL = 'https://doodle-note.vercel.app'
@@ -41,6 +48,10 @@ interface SyncConfig {
   pushed: Record<string, string>
   /** updatedAt high-water mark of the last pull. */
   pullCursor?: string
+  /** folderId → name at last successful sync (either direction). */
+  syncedFolders: Record<string, string>
+  /** Local folders deleted whose cloud copy still needs removing. */
+  pendingFolderDeletes: string[]
   /** attachment file name → public blob URL (uploaded once, reused). */
   mediaUrls: Record<string, string>
   /** Local meetings deleted/trashed whose cloud copy still needs removing. */
@@ -71,6 +82,7 @@ export class SyncService {
   constructor(
     userDataDir: string,
     private readonly meetings: MeetingsService,
+    private readonly folders: FoldersService,
     private readonly broadcast: (channel: string, payload: unknown) => void
   ) {
     this.configPath = join(userDataDir, 'sync.json')
@@ -106,6 +118,24 @@ export class SyncService {
   private async syncCycle(): Promise<void> {
     await this.pushAll()
     await this.pullAll()
+  }
+
+  /** FoldersService calls this after every write; deletes pass deletedId. */
+  onFoldersChanged(deletedId?: string): void {
+    if (deletedId && this.config.syncedFolders[deletedId]) {
+      this.config.pendingFolderDeletes = [
+        ...new Set([...this.config.pendingFolderDeletes, deletedId])
+      ]
+      delete this.config.syncedFolders[deletedId]
+      this.writeConfig()
+    }
+    if (!this.config.enabled || !this.token()) return
+    if (this.debounceTimer) clearTimeout(this.debounceTimer)
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null
+      void this.pushAll()
+    }, PUSH_DEBOUNCE_MS)
+    this.debounceTimer.unref?.()
   }
 
   /** MeetingsService calls this after every write; deletes pass deletedId. */
@@ -227,7 +257,9 @@ export class SyncService {
       enabled: false,
       pushed: {},
       mediaUrls: {},
-      pendingDeletes: []
+      pendingDeletes: [],
+      syncedFolders: {},
+      pendingFolderDeletes: []
     }
     this.writeConfig()
     this.lastError = undefined
@@ -250,9 +282,7 @@ export class SyncService {
   async share(meetingId: string): Promise<ShareResult> {
     const token = this.token()
     if (!token) return { error: 'Connect cloud sync in Settings first' }
-    const record = this.meetings
-      .readAll()
-      .find((r) => r.id === meetingId && !r.trashedAt)
+    const record = this.meetings.readAll().find((r) => r.id === meetingId && !r.trashedAt)
     if (!record) return { error: 'Meeting not found' }
 
     try {
@@ -311,17 +341,42 @@ export class SyncService {
 
     try {
       // Deletions first so restores (delete then re-create) settle correctly.
-      if (this.config.pendingDeletes.length > 0) {
+      if (this.config.pendingDeletes.length > 0 || this.config.pendingFolderDeletes.length > 0) {
         const response = await fetch(`${this.baseUrl}/api/sync/push`, {
           method: 'DELETE',
           headers: {
             Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify({ ids: this.config.pendingDeletes })
+          body: JSON.stringify({
+            ids: this.config.pendingDeletes,
+            folderIds: this.config.pendingFolderDeletes
+          })
         })
         if (response.ok) {
           this.config.pendingDeletes = []
+          this.config.pendingFolderDeletes = []
+          this.writeConfig()
+        }
+      }
+
+      // Folders next — meetings below may reference them server-side.
+      const dirtyFolders = this.folders
+        .list()
+        .filter((f) => this.config.syncedFolders[f.id] !== f.name)
+      if (dirtyFolders.length > 0) {
+        const response = await fetch(`${this.baseUrl}/api/sync/push`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            folders: dirtyFolders.map((f) => ({ id: f.id, name: f.name, createdAt: f.createdAt }))
+          })
+        })
+        if (response.ok) {
+          for (const f of dirtyFolders) this.config.syncedFolders[f.id] = f.name
           this.writeConfig()
         }
       }
@@ -367,6 +422,65 @@ export class SyncService {
 
   /* ---- pulling ---- */
 
+  /** Create/rename local folders from the cloud list. True when changed. */
+  private applyRemoteFolders(
+    remote: Array<{ id?: unknown; name?: unknown; createdAt?: unknown }>
+  ): boolean {
+    let changed = false
+    const locals = new Map(this.folders.list().map((f) => [f.id, f]))
+    for (const item of remote) {
+      const id = String(item.id ?? '')
+      const name = typeof item.name === 'string' ? item.name.trim() : ''
+      if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) continue
+      if (name.length === 0) continue
+      const local = locals.get(id)
+      const action = decideFolderPull({
+        localExists: local !== undefined,
+        localName: local?.name ?? null,
+        syncedName: this.config.syncedFolders[id] ?? null,
+        remoteName: name
+      })
+      if (action === 'skip') {
+        if (local && local.name === name) this.config.syncedFolders[id] = name
+        continue
+      }
+      this.config.syncedFolders[id] = name
+      this.writeConfig()
+      const record: FolderRecord = {
+        id,
+        name,
+        createdAt:
+          local?.createdAt ??
+          (typeof item.createdAt === 'string' ? item.createdAt : new Date().toISOString())
+      }
+      this.folders.upsertRemote(record)
+      changed = true
+    }
+    return changed
+  }
+
+  /** Remove local folders whose cloud copy vanished (rename-safe). */
+  private applyCloudFolderDeletions(remote: Array<{ id?: unknown }>): boolean {
+    const cloudIds = new Set(remote.map((f) => String(f.id ?? '')))
+    let changed = false
+    for (const local of this.folders.list()) {
+      const syncedName = this.config.syncedFolders[local.id]
+      const remove = shouldRemoveFolderLocally({
+        wasSynced: syncedName !== undefined,
+        presentInCloud: cloudIds.has(local.id),
+        localDirty: syncedName !== undefined && local.name !== syncedName
+      })
+      if (!remove) continue
+      // Drop the bookkeeping first so the delete hook doesn't echo a
+      // redundant cloud DELETE for a folder the cloud already removed.
+      delete this.config.syncedFolders[local.id]
+      this.writeConfig()
+      this.folders.delete(local.id) // sweeps member meetings to My notes
+      changed = true
+    }
+    return changed
+  }
+
   /**
    * Cursor-based pull of meetings changed on other devices, applied under
    * the rules in sync-pull-logic.ts. The full cloud id list rides along so
@@ -382,6 +496,7 @@ export class SyncService {
     try {
       let cursor = this.config.pullCursor ?? ''
       let cloudIds: Set<string> | null = null
+      let cloudFolders: Array<{ id?: unknown; name?: unknown }> | null = null
       for (let page = 0; page < MAX_PULL_PAGES; page++) {
         const response = await fetch(
           `${this.baseUrl}/api/sync/pull?since=${encodeURIComponent(cursor)}`,
@@ -390,10 +505,16 @@ export class SyncService {
         if (!response.ok) throw new Error(`Pull failed (HTTP ${response.status})`)
         const body = (await response.json()) as {
           allIds?: unknown
+          folders?: Array<{ id?: unknown; name?: unknown; createdAt?: unknown }>
           changed?: RemoteMeeting[]
           hasMore?: boolean
         }
         cloudIds = new Set(Array.isArray(body.allIds) ? body.allIds.map(String) : [])
+        // Folders first — meetings in this page may point at them.
+        if (Array.isArray(body.folders)) {
+          cloudFolders = body.folders
+          if (this.applyRemoteFolders(body.folders)) storeChanged = true
+        }
         for (const remote of Array.isArray(body.changed) ? body.changed : []) {
           if (this.applyRemote(remote)) storeChanged = true
           if (typeof remote.updatedAt === 'string' && remote.updatedAt > cursor) {
@@ -404,6 +525,9 @@ export class SyncService {
       }
       if (cloudIds) {
         if (this.applyCloudDeletions(cloudIds)) storeChanged = true
+      }
+      if (cloudFolders) {
+        if (this.applyCloudFolderDeletions(cloudFolders)) storeChanged = true
       }
       this.config.pullCursor = cursor
       this.config.lastSyncAt = new Date().toISOString()
@@ -466,8 +590,7 @@ export class SyncService {
     const incoming: MeetingRecord = {
       id,
       title: typeof remote.title === 'string' ? remote.title : '',
-      createdAt:
-        typeof remote.createdAt === 'string' ? remote.createdAt : new Date().toISOString(),
+      createdAt: typeof remote.createdAt === 'string' ? remote.createdAt : new Date().toISOString(),
       ...(typeof remote.startedAt === 'string' ? { startedAt: remote.startedAt } : {}),
       ...(typeof remote.endedAt === 'string' ? { endedAt: remote.endedAt } : {}),
       ...(typeof remote.calendarEventId === 'string'
@@ -477,6 +600,8 @@ export class SyncService {
       ...(typeof remote.enhancedMarkdown === 'string'
         ? { enhancedMarkdown: remote.enhancedMarkdown }
         : {}),
+      // null (not absence) so applying clears a stale local assignment.
+      folderId: typeof remote.folderId === 'string' ? remote.folderId : null,
       segments,
       echoSuppressed: 0
     }
@@ -583,15 +708,32 @@ export class SyncService {
         ...(typeof raw.email === 'string' ? { email: raw.email } : {}),
         ...(typeof raw.workspaceName === 'string' ? { workspaceName: raw.workspaceName } : {}),
         ...(typeof raw.lastSyncAt === 'string' ? { lastSyncAt: raw.lastSyncAt } : {}),
-        pushed: raw.pushed && typeof raw.pushed === 'object' ? (raw.pushed as Record<string, string>) : {},
+        pushed:
+          raw.pushed && typeof raw.pushed === 'object'
+            ? (raw.pushed as Record<string, string>)
+            : {},
         mediaUrls:
           raw.mediaUrls && typeof raw.mediaUrls === 'object'
             ? (raw.mediaUrls as Record<string, string>)
             : {},
-        pendingDeletes: Array.isArray(raw.pendingDeletes) ? raw.pendingDeletes.map(String) : []
+        pendingDeletes: Array.isArray(raw.pendingDeletes) ? raw.pendingDeletes.map(String) : [],
+        syncedFolders:
+          raw.syncedFolders && typeof raw.syncedFolders === 'object'
+            ? (raw.syncedFolders as Record<string, string>)
+            : {},
+        pendingFolderDeletes: Array.isArray(raw.pendingFolderDeletes)
+          ? raw.pendingFolderDeletes.map(String)
+          : []
       }
     } catch {
-      return { enabled: false, pushed: {}, mediaUrls: {}, pendingDeletes: [] }
+      return {
+        enabled: false,
+        pushed: {},
+        mediaUrls: {},
+        pendingDeletes: [],
+        syncedFolders: {},
+        pendingFolderDeletes: []
+      }
     }
   }
 
@@ -612,6 +754,7 @@ interface RemoteMeeting {
   startedAt?: unknown
   endedAt?: unknown
   calendarEventId?: unknown
+  folderId?: unknown
   rawNotesMarkdown?: unknown
   enhancedMarkdown?: unknown
   segments?: Array<{
@@ -646,6 +789,7 @@ function contentHash(record: MeetingRecord, mediaUrls: Record<string, string>): 
     startedAt: record.startedAt ?? null,
     endedAt: record.endedAt ?? null,
     calendarEventId: record.calendarEventId ?? null,
+    folderId: record.folderId ?? null,
     rawNotesMarkdown: rewriteMedia(record.rawNotesMarkdown, mediaUrls),
     enhancedMarkdown: record.enhancedMarkdown
       ? rewriteMedia(record.enhancedMarkdown, mediaUrls)
@@ -663,6 +807,7 @@ function toPushMeeting(record: MeetingRecord, mediaUrls: Record<string, string>)
     ...(record.startedAt ? { startedAt: record.startedAt } : {}),
     ...(record.endedAt ? { endedAt: record.endedAt } : {}),
     ...(record.calendarEventId ? { calendarEventId: record.calendarEventId } : {}),
+    ...(record.folderId ? { folderId: record.folderId } : {}),
     ...(record.rawNotesMarkdown
       ? { rawNotesMarkdown: rewriteMedia(record.rawNotesMarkdown, mediaUrls) }
       : {}),

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -35,10 +35,31 @@ export function isQuittingForUpdate(): boolean {
  * user-driven "Check for updates" in Settings with live status and a
  * Restart-to-update button.
  */
-export function initAutoUpdater(broadcast: (channel: string, payload: unknown) => void): void {
+export function initAutoUpdater(
+  broadcast: (channel: string, payload: unknown) => void,
+  /** Awaited before quitAndInstall — unload native addons that crash on a
+   *  normal teardown (the llama addon SIGABRTs if a model is loaded). */
+  beforeInstall?: () => Promise<void>
+): void {
   const setState = (patch: Partial<UpdateState>): void => {
     state = { ...state, ...patch }
     broadcast(UPDATE_STATE_EVENT_CHANNEL, state)
+  }
+
+  const installNow = async (): Promise<void> => {
+    quittingForUpdate = true
+    // The update quit must be a NORMAL quit (the installer takes over after
+    // it), so the hard-exit workaround doesn't protect this path — unload
+    // the model first, bounded so a hung dispose can't block the update.
+    try {
+      await Promise.race([
+        beforeInstall?.(),
+        new Promise((resolve) => setTimeout(resolve, 3_000))
+      ])
+    } catch {
+      // install regardless
+    }
+    autoUpdater.quitAndInstall()
   }
 
   ipcMain.handle(UPDATE_GET_STATE_CHANNEL, () => state)
@@ -53,8 +74,7 @@ export function initAutoUpdater(broadcast: (channel: string, payload: unknown) =
   })
   ipcMain.handle(UPDATE_INSTALL_CHANNEL, () => {
     if (state.status !== 'downloaded') return
-    quittingForUpdate = true
-    autoUpdater.quitAndInstall()
+    void installNow()
   })
 
   if (!app.isPackaged) return
@@ -79,8 +99,7 @@ export function initAutoUpdater(broadcast: (channel: string, payload: unknown) =
         body: 'Click to restart and update now.'
       })
       notification.on('click', () => {
-        quittingForUpdate = true
-        autoUpdater.quitAndInstall()
+        void installNow()
       })
       notification.show()
     } catch {

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.next-preview/
+.next-build/

--- a/apps/web/app/api/sync/pull/route.ts
+++ b/apps/web/app/api/sync/pull/route.ts
@@ -3,6 +3,7 @@ import {
   and,
   asc,
   eq,
+  folders,
   getDb,
   gt,
   inArray,
@@ -47,6 +48,17 @@ export async function GET(request: Request) {
     .where(eq(meetings.organizationId, device.organizationId));
   const allIds = idRows.map((r) => r.id);
 
+  // Folders are few — the full list ships every pull (renames + deletions).
+  const folderRows = await db
+    .select()
+    .from(folders)
+    .where(eq(folders.organizationId, device.organizationId));
+  const allFolders = folderRows.map((f) => ({
+    id: f.id,
+    name: f.name,
+    createdAt: (f.createdAt ?? new Date()).toISOString(),
+  }));
+
   const changedRows = await db
     .select()
     .from(meetings)
@@ -90,6 +102,7 @@ export async function GET(request: Request) {
       ...(m.startedAt ? { startedAt: m.startedAt.toISOString() } : {}),
       ...(m.endedAt ? { endedAt: m.endedAt.toISOString() } : {}),
       ...(m.calendarEventId ? { calendarEventId: m.calendarEventId } : {}),
+      ...(m.folderId ? { folderId: m.folderId } : {}),
       rawNotesMarkdown: markdownOf(note?.rawContent) ?? "",
       ...(markdownOf(note?.enhancedContent)
         ? { enhancedMarkdown: markdownOf(note?.enhancedContent)! }
@@ -105,5 +118,5 @@ export async function GET(request: Request) {
     };
   });
 
-  return NextResponse.json({ allIds, changed, hasMore });
+  return NextResponse.json({ allIds, folders: allFolders, changed, hasMore });
 }

--- a/apps/web/app/api/sync/push/route.ts
+++ b/apps/web/app/api/sync/push/route.ts
@@ -1,5 +1,14 @@
 import { NextResponse } from "next/server";
-import { and, eq, getDb, meetings, notes, transcriptSegments } from "@repo/db";
+import {
+  and,
+  eq,
+  folders,
+  getDb,
+  inArray,
+  meetings,
+  notes,
+  transcriptSegments,
+} from "@repo/db";
 
 import { authenticateSyncRequest } from "@/lib/sync-auth";
 
@@ -22,9 +31,16 @@ interface PushMeeting {
   startedAt?: string;
   endedAt?: string;
   calendarEventId?: string;
+  folderId?: string;
   rawNotesMarkdown?: string;
   enhancedMarkdown?: string;
   segments: PushSegment[];
+}
+
+interface PushFolder {
+  id: string;
+  name: string;
+  createdAt?: string;
 }
 
 function toDate(value: unknown): Date | null {
@@ -50,7 +66,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid sync token" }, { status: 401 });
   }
 
-  let body: { meetings?: unknown };
+  let body: { meetings?: unknown; folders?: unknown };
   try {
     body = await request.json();
   } catch {
@@ -59,7 +75,10 @@ export async function POST(request: Request) {
   const items = Array.isArray(body.meetings)
     ? (body.meetings as PushMeeting[])
     : [];
-  if (items.length === 0 || items.length > 20) {
+  const folderItems = Array.isArray(body.folders)
+    ? (body.folders as PushFolder[]).slice(0, 100)
+    : [];
+  if (items.length + folderItems.length === 0 || items.length > 20) {
     return NextResponse.json(
       { error: "Expected 1-20 meetings per push" },
       { status: 400 },
@@ -68,6 +87,45 @@ export async function POST(request: Request) {
 
   const db = getDb();
   const results: Array<{ id: string; ok: boolean; error?: string }> = [];
+
+  // Folders first — meetings in this batch may point at them.
+  for (const item of folderItems) {
+    const id = String(item.id ?? "");
+    if (!UUID_RE.test(id) || typeof item.name !== "string" || !item.name.trim()) {
+      continue; // malformed folder — meetings degrade to unfiled
+    }
+    const existing = await db
+      .select({ organizationId: folders.organizationId })
+      .from(folders)
+      .where(eq(folders.id, id))
+      .limit(1);
+    if (existing[0] && existing[0].organizationId !== device.organizationId) {
+      continue; // id owned by another workspace
+    }
+    const row = {
+      organizationId: device.organizationId,
+      name: item.name.trim().slice(0, 80),
+      createdAt: toDate(item.createdAt) ?? new Date(),
+      updatedAt: new Date(),
+    };
+    await db
+      .insert(folders)
+      .values({ id, ...row })
+      .onConflictDoUpdate({
+        target: folders.id,
+        set: { name: row.name, updatedAt: row.updatedAt },
+      });
+  }
+
+  // Folder assignments must reference folders this workspace owns.
+  const ownFolderIds = new Set(
+    (
+      await db
+        .select({ id: folders.id })
+        .from(folders)
+        .where(eq(folders.organizationId, device.organizationId))
+    ).map((r) => r.id),
+  );
 
   for (const item of items) {
     const id = String(item.id ?? "");
@@ -103,6 +161,10 @@ export async function POST(request: Request) {
             : null,
         startedAt: toDate(item.startedAt),
         endedAt: toDate(item.endedAt),
+        folderId:
+          typeof item.folderId === "string" && ownFolderIds.has(item.folderId)
+            ? item.folderId
+            : null,
         createdAt,
         updatedAt: new Date(),
       };
@@ -166,13 +228,17 @@ export async function DELETE(request: Request) {
   if (!device) {
     return NextResponse.json({ error: "Invalid sync token" }, { status: 401 });
   }
-  let body: { ids?: unknown };
+  let body: { ids?: unknown; folderIds?: unknown };
   try {
     body = await request.json();
   } catch {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
   const ids = (Array.isArray(body.ids) ? body.ids : [])
+    .map(String)
+    .filter((id) => UUID_RE.test(id))
+    .slice(0, 100);
+  const folderIds = (Array.isArray(body.folderIds) ? body.folderIds : [])
     .map(String)
     .filter((id) => UUID_RE.test(id))
     .slice(0, 100);
@@ -185,5 +251,16 @@ export async function DELETE(request: Request) {
         and(eq(meetings.id, id), eq(meetings.organizationId, device.organizationId)),
       );
   }
-  return NextResponse.json({ ok: true, deleted: ids.length });
+  if (folderIds.length > 0) {
+    // FK is ON DELETE SET NULL — meetings inside fall back to unfiled.
+    await db
+      .delete(folders)
+      .where(
+        and(
+          inArray(folders.id, folderIds),
+          eq(folders.organizationId, device.organizationId),
+        ),
+      );
+  }
+  return NextResponse.json({ ok: true, deleted: ids.length + folderIds.length });
 }

--- a/apps/web/app/logos.tsx
+++ b/apps/web/app/logos.tsx
@@ -1,0 +1,27 @@
+/** Platform marks for download buttons. Inherit color via currentColor. */
+
+export function AppleLogo({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.56-1.701" />
+    </svg>
+  );
+}
+
+export function WindowsLogo({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801" />
+    </svg>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -10,30 +10,83 @@ function Wordmark({ size = "text-lg" }: { size?: string }) {
   );
 }
 
-const FEATURES = [
-  {
-    title: "No bot in your meetings",
-    body: "DoodleNote captures mic and system audio right on your computer. Nothing joins the call, nothing announces itself — your meetings stay yours.",
-  },
-  {
-    title: "On-device transcription",
-    body: "Two-channel local transcription knows who said what: your mic is “You,” the other side is “Them.” Fast, accurate, and fully offline.",
-  },
-  {
-    title: "AI notes, locally",
-    body: "Your rough notes merge with the transcript into polished summaries using a local model downloaded in-app — or bring your own API key.",
-  },
-  {
-    title: "Calendar-aware",
-    body: "One-click Microsoft 365 sign-in shows what's coming up, counts down in your menu bar, and offers to start recording when a meeting begins.",
-  },
-];
-
 /** Update feed on Vercel Blob — publish-release.mjs uploads these. */
 const DOWNLOADS = {
   mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.3-arm64-mac.zip",
   win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.3-setup.exe",
 };
+
+const MEETING_APPS = [
+  "Zoom",
+  "Google Meet",
+  "Teams",
+  "Slack huddles",
+  "FaceTime",
+];
+
+const TIMELINE = [
+  {
+    phase: "Before",
+    title: "It knows your calendar",
+    body: "Connect Microsoft 365 or Google Calendar and DoodleNote shows what's coming up, counts down in your menu bar, and offers to take notes the moment your meeting app starts ringing.",
+  },
+  {
+    phase: "During",
+    title: "You just jot",
+    body: "Recording starts instantly and a live transcript builds in the background — your mic is “You,” the other side is “Them.” Type messy half-thoughts; that's all DoodleNote needs.",
+  },
+  {
+    phase: "After",
+    title: "Polished notes, on their own",
+    body: "When the call ends, recording stops by itself and your rough jottings merge with the transcript into clean, structured notes — summary, decisions, action items. Share them with one link.",
+  },
+];
+
+const PRIVACY_POINTS = [
+  {
+    title: "No bot joins your call",
+    body: "DoodleNote captures your mic and system audio right on your computer. Nothing announces itself, nothing sits in the participant list.",
+  },
+  {
+    title: "Transcription never leaves your device",
+    body: "Speech-to-text runs entirely on your Mac or PC. Your meeting audio is never uploaded to us — or anyone else.",
+  },
+  {
+    title: "AI notes with a local model",
+    body: "Notes are written by a local model downloaded in-app. Prefer frontier models? Bring your own API key — it's your key, your data.",
+  },
+  {
+    title: "Sync is opt-in, always",
+    body: "Out of the box, everything stays on your device. Turn on cloud sync only if you want your notes on every device — and turn it off anytime.",
+  },
+];
+
+const FEATURES = [
+  {
+    title: "Ask your meetings anything",
+    body: "Chat with one meeting or across all of them — “what did we promise the customer?” — and get grounded answers with citations back to the transcript.",
+  },
+  {
+    title: "Note templates",
+    body: "Customer discovery, 1:1, standup, interview, troubleshooting — pick a template per meeting, switch and regenerate anytime.",
+  },
+  {
+    title: "Share with a link",
+    body: "Publish a read-only page of any meeting's notes and transcript with one click. No account needed to read it.",
+  },
+  {
+    title: "Team workspaces",
+    body: "Invite your team by link and everyone sees the workspace's synced meetings — one shared memory for the whole team.",
+  },
+  {
+    title: "Full-text search",
+    body: "Search every word ever said across notes and transcripts, on your desktop and in the web library.",
+  },
+  {
+    title: "Quick notes & folders",
+    body: "Standalone notes with the same editor, images, and optional voice dump. Organize everything with folders and a recoverable trash.",
+  },
+];
 
 export default function Home() {
   return (
@@ -50,25 +103,43 @@ export default function Home() {
           />
           <Wordmark />
         </div>
-        <Link
-          href="/login"
-          className="rounded-md border border-sand bg-card px-3.5 py-1.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
-        >
-          Sign in
-        </Link>
+        <nav className="flex items-center gap-1 sm:gap-2">
+          <Link
+            href="/pricing"
+            className="rounded-md px-3 py-1.5 text-sm font-medium text-bark transition-colors hover:bg-sage-fill hover:text-ink"
+          >
+            Pricing
+          </Link>
+          <Link
+            href="/changelog"
+            className="hidden rounded-md px-3 py-1.5 text-sm font-medium text-bark transition-colors hover:bg-sage-fill hover:text-ink sm:block"
+          >
+            What&rsquo;s new
+          </Link>
+          <Link
+            href="/login"
+            className="rounded-md border border-sand bg-card px-3.5 py-1.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
+          >
+            Sign in
+          </Link>
+        </nav>
       </header>
 
       <main className="flex flex-1 flex-col">
-        <section className="mx-auto flex w-full max-w-3xl flex-col items-center px-6 pb-16 pt-20 text-center">
-          <h1 className="text-4xl font-semibold tracking-tight text-ink sm:text-5xl">
-            AI meeting notes,
+        {/* Hero */}
+        <section className="mx-auto flex w-full max-w-3xl flex-col items-center px-6 pb-14 pt-16 text-center sm:pt-20">
+          <p className="rounded-full border border-sand bg-card px-3.5 py-1 text-xs font-medium text-sage-deep">
+            Unlimited meetings, free forever
+          </p>
+          <h1 className="mt-5 text-4xl font-semibold tracking-tight text-ink sm:text-5xl">
+            AI meeting notes.
             <br />
-            <span className="text-sage-deep">without the bot.</span>
+            <span className="text-sage-deep">No bot. No cloud.</span>
           </h1>
           <p className="mt-5 max-w-xl text-lg leading-relaxed text-bark">
-            DoodleNote captures your meetings right on your Mac or PC,
-            transcribes them on-device, and turns your rough notes into
-            polished summaries with local AI. Private by default.
+            DoodleNote records right on your Mac or PC, transcribes on-device,
+            and turns your rough jottings into polished notes, action items,
+            and answers. Your meetings never leave your computer.
           </p>
           <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row">
             <a
@@ -79,43 +150,223 @@ export default function Home() {
             </a>
             <a
               href={DOWNLOADS.win}
-              className="rounded-md bg-ink px-5 py-2.5 text-sm font-medium text-cream transition-opacity hover:opacity-85"
+              className="rounded-md border border-sand bg-card px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
             >
               Download for Windows (beta)
             </a>
-            <Link
-              href="/login"
-              className="rounded-md border border-sand bg-card px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
-            >
-              Open the web dashboard
-            </Link>
           </div>
           <p className="mt-4 text-sm text-stone">
-            macOS on Apple Silicon · Windows 10/11 (64-bit). Nothing leaves
-            your device unless you opt into cloud sync.
+            Works with {MEETING_APPS.join(", ")} — any app that makes sound.
           </p>
         </section>
 
-        <section className="mx-auto w-full max-w-5xl px-6 pb-24">
-          <div className="grid gap-4 sm:grid-cols-2">
-            {FEATURES.map((f) => (
+        {/* Trust strip */}
+        <section className="mx-auto w-full max-w-5xl px-6 pb-20">
+          <div className="grid gap-px overflow-hidden rounded-xl border border-sand bg-sand sm:grid-cols-3">
+            {[
+              ["0", "bots joining your calls"],
+              ["100%", "on-device transcription"],
+              ["$0", "for unlimited meetings"],
+            ].map(([stat, label]) => (
               <div
-                key={f.title}
-                className="rounded-xl border border-sand bg-card-soft p-6"
+                key={label}
+                className="flex flex-col items-center bg-card-soft px-6 py-6 text-center"
               >
-                <h2 className="text-base font-semibold text-ink">{f.title}</h2>
-                <p className="mt-2 text-sm leading-relaxed text-bark">
-                  {f.body}
-                </p>
+                <span className="text-3xl font-semibold tracking-tight text-sage-deep">
+                  {stat}
+                </span>
+                <span className="mt-1 text-sm text-bark">{label}</span>
               </div>
             ))}
+          </div>
+        </section>
+
+        {/* Before / during / after */}
+        <section className="border-y border-sand bg-card-soft">
+          <div className="mx-auto w-full max-w-5xl px-6 py-20">
+            <h2 className="text-center text-3xl font-semibold tracking-tight text-ink">
+              Before, during, and after every meeting
+            </h2>
+            <p className="mx-auto mt-3 max-w-xl text-center text-bark">
+              DoodleNote handles the note-taking so you can actually be in the
+              conversation.
+            </p>
+            <div className="mt-12 grid gap-4 sm:grid-cols-3">
+              {TIMELINE.map((step) => (
+                <div
+                  key={step.phase}
+                  className="rounded-xl border border-sand bg-card p-6"
+                >
+                  <span className="text-xs font-semibold uppercase tracking-wider text-sage">
+                    {step.phase}
+                  </span>
+                  <h3 className="mt-2 text-base font-semibold text-ink">
+                    {step.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-relaxed text-bark">
+                    {step.body}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Privacy — the differentiator */}
+        <section className="mx-auto w-full max-w-5xl px-6 py-20">
+          <div className="grid gap-10 lg:grid-cols-[1fr_1.2fr] lg:items-center">
+            <div>
+              <h2 className="text-3xl font-semibold tracking-tight text-ink">
+                Private by design,
+                <br />
+                not by promise
+              </h2>
+              <p className="mt-4 leading-relaxed text-bark">
+                Other AI notetakers upload your meeting audio to their servers
+                and process it there. DoodleNote is built the other way around:
+                capture, transcription, and AI all run on your own computer.
+                There is nothing to leak, because nothing is sent.
+              </p>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {PRIVACY_POINTS.map((p) => (
+                <div
+                  key={p.title}
+                  className="rounded-xl border border-sand bg-card-soft p-5"
+                >
+                  <h3 className="text-sm font-semibold text-ink">{p.title}</h3>
+                  <p className="mt-1.5 text-sm leading-relaxed text-bark">
+                    {p.body}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Feature grid */}
+        <section className="border-y border-sand bg-card-soft">
+          <div className="mx-auto w-full max-w-5xl px-6 py-20">
+            <h2 className="text-center text-3xl font-semibold tracking-tight text-ink">
+              A real notepad, not just a recorder
+            </h2>
+            <div className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {FEATURES.map((f) => (
+                <div
+                  key={f.title}
+                  className="rounded-xl border border-sand bg-card p-6"
+                >
+                  <h3 className="text-base font-semibold text-ink">
+                    {f.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-relaxed text-bark">
+                    {f.body}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Pricing teaser */}
+        <section className="mx-auto w-full max-w-5xl px-6 py-20">
+          <h2 className="text-center text-3xl font-semibold tracking-tight text-ink">
+            Free forever. Pay only for sync.
+          </h2>
+          <p className="mx-auto mt-3 max-w-xl text-center text-bark">
+            Everything that runs on your device is free with no meeting caps.
+            Add Sync when you want your notes on every device.
+          </p>
+          <div className="mx-auto mt-10 grid max-w-3xl gap-4 sm:grid-cols-2">
+            <div className="rounded-xl border border-sand bg-card p-6">
+              <h3 className="text-base font-semibold text-ink">Free</h3>
+              <p className="mt-1 text-3xl font-semibold tracking-tight text-ink">
+                $0
+                <span className="text-sm font-normal text-stone"> forever</span>
+              </p>
+              <p className="mt-3 text-sm leading-relaxed text-bark">
+                Unlimited recording, on-device transcription, AI notes, chat,
+                calendars, templates, and search — all local, no account
+                required.
+              </p>
+            </div>
+            <div className="rounded-xl border-2 border-sage bg-card p-6">
+              <h3 className="text-base font-semibold text-ink">Sync</h3>
+              <p className="mt-1 text-3xl font-semibold tracking-tight text-ink">
+                $10
+                <span className="text-sm font-normal text-stone">
+                  {" "}
+                  / month
+                </span>
+              </p>
+              <p className="mt-3 text-sm leading-relaxed text-bark">
+                Everything in Free, plus your meetings on every device, the web
+                library, share links, and team workspaces.
+              </p>
+            </div>
+          </div>
+          <p className="mt-6 text-center">
+            <Link
+              href="/pricing"
+              className="text-sm font-medium text-sage-deep hover:underline"
+            >
+              Compare plans in detail →
+            </Link>
+          </p>
+        </section>
+
+        {/* Final CTA */}
+        <section className="border-t border-sand bg-card-soft">
+          <div className="mx-auto flex w-full max-w-3xl flex-col items-center px-6 py-16 text-center">
+            <Image
+              src="/mascot.png"
+              alt=""
+              width={52}
+              height={52}
+              className="rounded-xl"
+            />
+            <h2 className="mt-5 text-3xl font-semibold tracking-tight text-ink">
+              Bring DoodleNote to your next meeting
+            </h2>
+            <p className="mt-3 max-w-md text-bark">
+              Download, hit record, and see your rough jottings come back as
+              real notes.
+            </p>
+            <div className="mt-7 flex flex-col items-center gap-3 sm:flex-row">
+              <a
+                href={DOWNLOADS.mac}
+                className="rounded-md bg-ink px-5 py-2.5 text-sm font-medium text-cream transition-opacity hover:opacity-85"
+              >
+                Download for macOS
+              </a>
+              <a
+                href={DOWNLOADS.win}
+                className="rounded-md border border-sand bg-card px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
+              >
+                Download for Windows (beta)
+              </a>
+            </div>
+            <p className="mt-4 text-sm text-stone">
+              macOS on Apple Silicon · Windows 10/11 (64-bit)
+            </p>
           </div>
         </section>
       </main>
 
       <footer className="border-t border-sand">
-        <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-6 text-sm text-stone">
+        <div className="mx-auto flex w-full max-w-5xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-stone sm:flex-row">
           <Wordmark size="text-sm" />
+          <nav className="flex items-center gap-5">
+            <Link href="/pricing" className="hover:text-ink">
+              Pricing
+            </Link>
+            <Link href="/changelog" className="hover:text-ink">
+              What&rsquo;s new
+            </Link>
+            <Link href="/login" className="hover:text-ink">
+              Sign in
+            </Link>
+          </nav>
           <span>Local-first. Your meetings never leave your device.</span>
         </div>
       </footer>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { AppleLogo, WindowsLogo } from "./logos";
 
 function Wordmark({ size = "text-lg" }: { size?: string }) {
   return (
@@ -144,14 +145,16 @@ export default function Home() {
           <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row">
             <a
               href={DOWNLOADS.mac}
-              className="rounded-md bg-ink px-5 py-2.5 text-sm font-medium text-cream transition-opacity hover:opacity-85"
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-ink px-5 py-2.5 text-sm font-medium text-cream transition-opacity hover:opacity-85"
             >
+              <AppleLogo className="h-4 w-4 -mt-0.5" />
               Download for macOS
             </a>
             <a
               href={DOWNLOADS.win}
-              className="rounded-md border border-sand bg-card px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-sand bg-card px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
             >
+              <WindowsLogo className="h-3.5 w-3.5" />
               Download for Windows (beta)
             </a>
           </div>

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -1,0 +1,217 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export const metadata = { title: "Pricing — DoodleNote" };
+
+/** Update feed on Vercel Blob — publish-release.mjs uploads these. */
+const DOWNLOADS = {
+  mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.3-arm64-mac.zip",
+  win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.3-setup.exe",
+};
+
+const FREE_FEATURES = [
+  "Unlimited meetings and recording — no caps, ever",
+  "No-bot capture of mic + system audio on Mac and PC",
+  "On-device transcription — audio never leaves your computer",
+  "AI notes from a local model, or bring your own API key",
+  "Ask anything about one meeting or across all of them, with citations",
+  "Microsoft 365 and Google Calendar, meeting-start prompts",
+  "Note templates, quick notes, folders, and full-text search",
+  "Automatic updates",
+];
+
+const SYNC_FEATURES = [
+  "Everything in Free",
+  "Your meetings synced across every device, both ways",
+  "Web library — read and search your notes from any browser",
+  "Share any meeting as a read-only link",
+  "Team workspaces — invite by link, share one meeting memory",
+  "Images in notes synced and shown on shared pages",
+];
+
+const FAQ = [
+  {
+    q: "Is the free plan really free forever?",
+    a: "Yes. Recording, transcription, and AI notes all run on your own computer — they cost us nothing to provide, so we will never cap your meetings or put your own notes behind a paywall.",
+  },
+  {
+    q: "What exactly am I paying for with Sync?",
+    a: "Servers and storage. Sync keeps an encrypted-in-transit copy of your meetings in the cloud so every device you link stays up to date, powers the web library and share links, and hosts your team's shared workspace.",
+  },
+  {
+    q: "What happens if I cancel Sync?",
+    a: "Nothing dramatic. Your notes stay on your devices in full — DoodleNote is local-first, so canceling just stops the syncing. You can re-subscribe anytime and pick up where you left off.",
+  },
+  {
+    q: "Do you train AI on my meetings?",
+    a: "No. Transcription and note generation happen on your device. If you enable Sync, your data is used only to power sync, search, and sharing — never for training, never sold.",
+  },
+  {
+    q: "Do I need a ChatGPT or Claude subscription?",
+    a: "No. DoodleNote downloads a local model in-app that writes your notes for free. If you prefer a frontier model, you can plug in your own OpenAI or Anthropic API key.",
+  },
+];
+
+export default function PricingPage() {
+  return (
+    <div className="flex flex-1 flex-col bg-cream text-bark">
+      <header className="border-b border-sand bg-card-soft">
+        <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-3">
+          <Link href="/" className="flex items-center gap-2">
+            <Image
+              src="/mascot.png"
+              alt=""
+              width={26}
+              height={26}
+              className="rounded-md"
+            />
+            <span className="text-sm font-bold tracking-tight">
+              <span className="text-ink">Doodle</span>
+              <span className="text-sage">Note</span>
+            </span>
+          </Link>
+          <nav className="flex items-center gap-1 sm:gap-2">
+            <Link
+              href="/changelog"
+              className="hidden rounded-md px-3 py-1.5 text-sm font-medium text-bark transition-colors hover:bg-sage-fill hover:text-ink sm:block"
+            >
+              What&rsquo;s new
+            </Link>
+            <Link
+              href="/login"
+              className="rounded-md border border-sand bg-card px-3.5 py-1.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
+            >
+              Sign in
+            </Link>
+          </nav>
+        </div>
+      </header>
+
+      <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-6 py-14">
+        <div className="text-center">
+          <h1 className="text-4xl font-semibold tracking-tight text-ink">
+            Free forever. Pay only for sync.
+          </h1>
+          <p className="mx-auto mt-4 max-w-xl text-lg leading-relaxed text-bark">
+            Everything that runs on your device — recording, transcription, AI
+            notes — is free with no meeting caps. Sync is for when you want
+            your notes everywhere.
+          </p>
+        </div>
+
+        <div className="mx-auto mt-12 grid w-full max-w-4xl gap-5 lg:grid-cols-2">
+          {/* Free */}
+          <div className="flex flex-col rounded-2xl border border-sand bg-card p-8">
+            <h2 className="text-lg font-semibold text-ink">Free</h2>
+            <p className="mt-1 text-sm text-stone">
+              The whole notepad, on your device
+            </p>
+            <p className="mt-5 text-4xl font-semibold tracking-tight text-ink">
+              $0
+              <span className="text-base font-normal text-stone"> forever</span>
+            </p>
+            <ul className="mt-6 flex-1 space-y-2.5">
+              {FREE_FEATURES.map((item) => (
+                <li
+                  key={item}
+                  className="flex gap-2.5 text-sm leading-relaxed"
+                >
+                  <span className="mt-0.5 shrink-0 text-sage" aria-hidden="true">
+                    ✓
+                  </span>
+                  {item}
+                </li>
+              ))}
+            </ul>
+            <div className="mt-8 flex flex-col gap-2.5">
+              <a
+                href={DOWNLOADS.mac}
+                className="rounded-md bg-ink px-5 py-2.5 text-center text-sm font-medium text-cream transition-opacity hover:opacity-85"
+              >
+                Download for macOS
+              </a>
+              <a
+                href={DOWNLOADS.win}
+                className="rounded-md border border-sand bg-card px-5 py-2.5 text-center text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
+              >
+                Download for Windows (beta)
+              </a>
+            </div>
+          </div>
+
+          {/* Sync */}
+          <div className="relative flex flex-col rounded-2xl border-2 border-sage bg-card p-8">
+            <span className="absolute -top-3 right-6 rounded-full bg-sage px-3 py-0.5 text-xs font-semibold text-cream">
+              Early access
+            </span>
+            <h2 className="text-lg font-semibold text-ink">Sync</h2>
+            <p className="mt-1 text-sm text-stone">
+              Your meetings on every device
+            </p>
+            <p className="mt-5 text-4xl font-semibold tracking-tight text-ink">
+              $10
+              <span className="text-base font-normal text-stone">
+                {" "}
+                / user / month
+              </span>
+            </p>
+            <ul className="mt-6 flex-1 space-y-2.5">
+              {SYNC_FEATURES.map((item) => (
+                <li
+                  key={item}
+                  className="flex gap-2.5 text-sm leading-relaxed"
+                >
+                  <span className="mt-0.5 shrink-0 text-sage" aria-hidden="true">
+                    ✓
+                  </span>
+                  {item}
+                </li>
+              ))}
+            </ul>
+            <div className="mt-8 flex flex-col gap-2.5">
+              <Link
+                href="/login"
+                className="rounded-md bg-sage-deep px-5 py-2.5 text-center text-sm font-medium text-cream transition-opacity hover:opacity-85"
+              >
+                Get started
+              </Link>
+              <p className="text-center text-xs text-stone">
+                Free during early access — billing starts when Sync leaves
+                beta.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* FAQ */}
+        <section className="mx-auto mt-20 w-full max-w-3xl">
+          <h2 className="text-center text-2xl font-semibold tracking-tight text-ink">
+            Questions, answered
+          </h2>
+          <div className="mt-8 space-y-4">
+            {FAQ.map((item) => (
+              <div
+                key={item.q}
+                className="rounded-xl border border-sand bg-card-soft p-6"
+              >
+                <h3 className="text-sm font-semibold text-ink">{item.q}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-bark">
+                  {item.a}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </main>
+
+      <footer className="border-t border-sand">
+        <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-6 text-sm text-stone">
+          <Link href="/" className="font-semibold text-sage-deep hover:underline">
+            DoodleNote
+          </Link>
+          <span>Local-first. Your meetings never leave your device.</span>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { AppleLogo, WindowsLogo } from "../logos";
 
 export const metadata = { title: "Pricing — DoodleNote" };
 
@@ -126,14 +127,16 @@ export default function PricingPage() {
             <div className="mt-8 flex flex-col gap-2.5">
               <a
                 href={DOWNLOADS.mac}
-                className="rounded-md bg-ink px-5 py-2.5 text-center text-sm font-medium text-cream transition-opacity hover:opacity-85"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-ink px-5 py-2.5 text-center text-sm font-medium text-cream transition-opacity hover:opacity-85"
               >
+                <AppleLogo className="h-4 w-4 -mt-0.5" />
                 Download for macOS
               </a>
               <a
                 href={DOWNLOADS.win}
-                className="rounded-md border border-sand bg-card px-5 py-2.5 text-center text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
+                className="inline-flex items-center justify-center gap-2 rounded-md border border-sand bg-card px-5 py-2.5 text-center text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
               >
+                <WindowsLogo className="h-3.5 w-3.5" />
                 Download for Windows (beta)
               </a>
             </div>

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -9,6 +9,8 @@ const eslintConfig = defineConfig([
   globalIgnores([
     // Default ignores of eslint-config-next:
     ".next/**",
+    ".next-preview/**",
+    ".next-build/**",
     "out/**",
     "build/**",
     "next-env.d.ts",

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  /**
+   * Next allows one dev server per dist dir; a second session (agent preview)
+   * can set NEXT_DIST_DIR to run alongside the primary `pnpm dev` server.
+   */
+  distDir: process.env.NEXT_DIST_DIR || ".next",
   /** @repo/db ships raw TypeScript — let Next transpile it. */
   transpilePackages: ["@repo/db"],
   /**

--- a/packages/db/drizzle/0004_gigantic_the_hand.sql
+++ b/packages/db/drizzle/0004_gigantic_the_hand.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "folders" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"name" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "meetings" ADD COLUMN "folder_id" uuid;--> statement-breakpoint
+ALTER TABLE "folders" ADD CONSTRAINT "folders_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "folders_organization_id_idx" ON "folders" USING btree ("organization_id");--> statement-breakpoint
+ALTER TABLE "meetings" ADD CONSTRAINT "meetings_folder_id_folders_id_fk" FOREIGN KEY ("folder_id") REFERENCES "public"."folders"("id") ON DELETE set null ON UPDATE no action;

--- a/packages/db/drizzle/meta/0004_snapshot.json
+++ b/packages/db/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1160 @@
+{
+  "id": "9d867004-23ee-47ec-bc86-ec20f76588f1",
+  "prevId": "ff14d15d-1309-4ea8-a39c-3e122cc16e4f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.folders": {
+      "name": "folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "folders_organization_id_idx": {
+          "name": "folders_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "folders_organization_id_organization_id_fk": {
+          "name": "folders_organization_id_organization_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetings": {
+      "name": "meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled meeting'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetings_organization_id_idx": {
+          "name": "meetings_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetings_organization_id_organization_id_fk": {
+          "name": "meetings_organization_id_organization_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_folder_id_folders_id_fk": {
+          "name": "meetings_folder_id_folders_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meetings_share_token_unique": {
+          "name": "meetings_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notes": {
+      "name": "notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_content": {
+          "name": "raw_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enhanced_content": {
+          "name": "enhanced_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notes_meeting_id_meetings_id_fk": {
+          "name": "notes_meeting_id_meetings_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notes_meeting_id_unique": {
+          "name": "notes_meeting_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meeting_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_devices": {
+      "name": "sync_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Desktop'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_devices_user_id_idx": {
+          "name": "sync_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_devices_user_id_user_id_fk": {
+          "name": "sync_devices_user_id_user_id_fk",
+          "tableFrom": "sync_devices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_devices_organization_id_organization_id_fk": {
+          "name": "sync_devices_organization_id_organization_id_fk",
+          "tableFrom": "sync_devices",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sync_devices_token_hash_unique": {
+          "name": "sync_devices_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcript_segments": {
+      "name": "transcript_segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker": {
+          "name": "speaker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcript_segments_meeting_id_idx": {
+          "name": "transcript_segments_meeting_id_idx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transcript_segments_meeting_id_meetings_id_fk": {
+          "name": "transcript_segments_meeting_id_meetings_id_fk",
+          "tableFrom": "transcript_segments",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1783370735905,
       "tag": "0003_slow_anthem",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1783449744306,
+      "tag": "0004_gigantic_the_hand",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -1,0 +1,24 @@
+/** Apply drizzle/ migrations to the DATABASE_URL Neon instance. */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { neon } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-http";
+import { migrate } from "drizzle-orm/neon-http/migrator";
+
+if (!process.env.DATABASE_URL) {
+  const envLocal = readFileSync(
+    join(__dirname, "..", "..", "..", ".env.local"),
+    "utf8",
+  );
+  const m = envLocal.match(/^DATABASE_URL="?([^"\n]+)"?$/m);
+  if (m) process.env.DATABASE_URL = m[1];
+}
+if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL not set");
+
+const db = drizzle(neon(process.env.DATABASE_URL));
+migrate(db, { migrationsFolder: join(__dirname, "..", "drizzle") })
+  .then(() => console.log("migrations applied"))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -1,13 +1,15 @@
 /** Apply drizzle/ migrations to the DATABASE_URL Neon instance. */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+
+const here = import.meta.dirname;
 import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 import { migrate } from "drizzle-orm/neon-http/migrator";
 
 if (!process.env.DATABASE_URL) {
   const envLocal = readFileSync(
-    join(__dirname, "..", "..", "..", ".env.local"),
+    join(here, "..", "..", "..", ".env.local"),
     "utf8",
   );
   const m = envLocal.match(/^DATABASE_URL="?([^"\n]+)"?$/m);
@@ -16,7 +18,7 @@ if (!process.env.DATABASE_URL) {
 if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL not set");
 
 const db = drizzle(neon(process.env.DATABASE_URL));
-migrate(db, { migrationsFolder: join(__dirname, "..", "drizzle") })
+migrate(db, { migrationsFolder: join(here, "..", "drizzle") })
   .then(() => console.log("migrations applied"))
   .catch((err) => {
     console.error(err);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -11,6 +11,21 @@ import {
 
 import { organization, user } from "./auth-schema";
 
+export const folders = pgTable(
+  "folders",
+  {
+    /** Desktop-minted UUID — the same id on every device and in the cloud. */
+    id: uuid("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => [index("folders_organization_id_idx").on(table.organizationId)],
+);
+
 export const meetings = pgTable(
   "meetings",
   {
@@ -24,6 +39,10 @@ export const meetings = pgTable(
       .notNull()
       .default("complete"),
     calendarEventId: text("calendar_event_id"),
+    /** Optional folder assignment; folder deletion moves meetings out. */
+    folderId: uuid("folder_id").references(() => folders.id, {
+      onDelete: "set null",
+    }),
     /** Public share-link token; null = not shared. */
     shareToken: text("share_token").unique(),
     startedAt: timestamp("started_at", { withTimezone: true }),


### PR DESCRIPTION
## What

Folders (Spaces) and which folder each meeting lives in now sync across devices, completing what #20 started. Create a folder on the Mac, file meetings into it — the Windows laptop gets the folder and the filing.

## How

**Schema (migration 0004, additive):** `folders` table (uuid PK — local folder ids are already UUIDs, so cloud and local share the id space; org-scoped) + `meetings.folder_id` with `ON DELETE SET NULL`, which mirrors the desktop behavior where deleting a folder moves its meetings back to My notes.

**Push:** dirty folders (tracked as `syncedFolders` id→name in sync.json) go up before meetings; each meeting carries `folderId` (validated server-side against the workspace's own folders); folder deletions ride the existing DELETE. `folderId` joins the meeting contentHash, so a meeting moved between folders syncs like any other edit.

**Pull:** the full folder list ships with every pull (folders are few) — that one list propagates creates, renames, AND deletions. Applied folders-first so meeting assignments always land on existing folders.

**Conflict rules** — same discipline as meetings, pure + tested (8 new cases, 61 total):
- an unsynced local rename outranks a remote rename
- cloud-vanished folders are removed locally only when clean; their meetings sweep to My notes
- folders with no sync history are never touched

## One-time effect
Adding `folderId` to the content hash makes every meeting look dirty once after updating — a single full re-push per device, idempotent and harmless.

## Deploy note
**Migration 0004 must be applied to Neon before/with the merge** (`npx tsx packages/db/scripts/migrate.ts` — new script, reads DATABASE_URL from root .env.local). It's blocked behind explicit authorization in this session; it runs as part of the release step.

Gates: typecheck clean (web, db, desktop), 61 tests pass, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)