### PR TITLE
Move Developer console entry into Settings → Troubleshooting

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -528,9 +528,6 @@ function App(): React.JSX.Element {
               </span>{' '}
               Settings
             </button>
-            <button type="button" className="dev-link" onClick={() => setView('dev')}>
-              Developer
-            </button>
           </div>
         </aside>
 
@@ -555,6 +552,7 @@ function App(): React.JSX.Element {
               active={view === 'settings'}
               jump={settingsJump}
               onShowTour={() => setTourOpen(true)}
+              onOpenDevConsole={() => setView('dev')}
             />
           </div>
           <div className={view === 'dev' ? 'content-slot' : 'content-slot hidden'}>

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -145,12 +145,14 @@ const SETTINGS_NAV: Array<{ key: SettingsSection; icon: React.JSX.Element; label
 export default function ModelsView({
   active,
   jump,
-  onShowTour
+  onShowTour,
+  onOpenDevConsole
 }: {
   active: boolean
   /** External deep-link into a section (n bumps to re-trigger). */
   jump?: { section: SettingsSection; n: number } | null
   onShowTour?: () => void
+  onOpenDevConsole?: () => void
 }): React.JSX.Element {
   const [section, setSection] = useState<SettingsSection>('general')
 
@@ -943,6 +945,23 @@ export default function ModelsView({
                     )}
                   </div>
                 )}
+              </section>
+
+              <section className="keys-section">
+                <h3>Troubleshooting</h3>
+                <div className="cal-subcard">
+                  <div className="cal-row">
+                    <span className="cal-row-main">
+                      <span className="cal-row-label">Developer console</span>
+                      <span className="cal-row-sub">
+                        Raw engine controls and event logs — handy when reporting a bug.
+                      </span>
+                    </span>
+                    <button type="button" className="pill-btn" onClick={() => onOpenDevConsole?.()}>
+                      Open
+                    </button>
+                  </div>
+                </div>
               </section>
             </>
           )}


### PR DESCRIPTION
The always-visible sidebar "Developer" link is gone. Settings → General now ends with a **Troubleshooting** card — "Developer console: raw engine controls and event logs — handy when reporting a bug" with an Open button. Same view, same functionality, just discoverable-when-needed instead of front-and-center.

Gates: typecheck clean, 53 tests pass, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)