### PR TITLE
Release 0.3.4

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "description": "Doodle Note desktop app \u2014 spawns the Swift transcription sidecar and shows its live transcript stream",
   "main": "./out/main/index.js",

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -10,6 +10,16 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.3.4",
+    date: "July 7, 2026",
+    highlights: [
+      "Folders sync: your Spaces, and which folder each meeting is in, now travel to every linked device — folder deletions move meetings back to My notes everywhere",
+      "Windows: brand-new full-bleed sage icon — no more black edges on the desktop or taskbar",
+      "Fixed: the \u201cquit unexpectedly\u201d dialog when installing an update on Mac",
+      "Developer console moved out of the sidebar into Settings \u2192 General \u2192 Troubleshooting",
+    ],
+  },
+  {
     version: "0.3.3",
     date: "July 7, 2026",
     highlights: [

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -13,8 +13,8 @@ function Wordmark({ size = "text-lg" }: { size?: string }) {
 
 /** Update feed on Vercel Blob — publish-release.mjs uploads these. */
 const DOWNLOADS = {
-  mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.3-arm64-mac.zip",
-  win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.3-setup.exe",
+  mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.4-arm64-mac.zip",
+  win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.4-setup.exe",
 };
 
 const MEETING_APPS = [


### PR DESCRIPTION
Version bump + changelog + landing links for 0.3.4 (folder sync, full-bleed Windows icon, update-quit crash fix, dev console → Settings). Neon migration 0004 already applied. Merged after both platform artifacts are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)