### PR TITLE
Minimal notepad redesign across the web app

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,11 +3,10 @@
   "configurations": [
     {
       "name": "web",
-      "runtimeExecutable": "pnpm",
+      "runtimeExecutable": "sh",
       "runtimeArgs": [
-        "--filter",
-        "web",
-        "dev"
+        "-c",
+        "PATH=\"$HOME/.local/bin:$PATH\" corepack pnpm --filter web dev"
       ],
       "port": 4040
     },

--- a/apps/web/app/app/layout.tsx
+++ b/apps/web/app/app/layout.tsx
@@ -4,6 +4,7 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { auth } from "@/lib/auth";
+import { Wordmark } from "../ui";
 
 import { SignOutButton } from "./sign-out-button";
 
@@ -17,33 +18,37 @@ export default async function AppLayout({
 
   return (
     <div className="flex flex-1 flex-col bg-cream text-bark">
-      <header className="border-b border-sand bg-card-soft">
-        <div className="mx-auto flex w-full max-w-4xl items-center justify-between px-6 py-3">
-          <Link href="/app" className="flex items-center gap-2">
+      <header className="border-b border-sand">
+        <div className="mx-auto flex w-full max-w-3xl items-center justify-between px-6 py-4">
+          <Link href="/app" className="flex items-center gap-2.5">
             <Image
               src="/mascot.png"
               alt=""
-              width={26}
-              height={26}
-              className="rounded-md"
+              width={28}
+              height={28}
+              className="rounded-lg"
+              unoptimized
             />
-            <span className="text-sm font-bold tracking-tight">
-              <span className="text-ink">Doodle</span>
-              <span className="text-sage">Note</span>
-            </span>
+            <Wordmark size="text-base" />
           </Link>
-          <nav className="flex items-center gap-4 text-sm">
-            <Link href="/app" className="text-bark hover:text-ink">
+          <nav className="flex items-center gap-1 sm:gap-2">
+            <Link
+              href="/app"
+              className="rounded-md px-3 py-1.5 text-sm font-medium text-bark transition-colors hover:bg-sage-fill hover:text-ink"
+            >
               Meetings
             </Link>
-            <Link href="/app/workspaces" className="text-bark hover:text-ink">
+            <Link
+              href="/app/workspaces"
+              className="rounded-md px-3 py-1.5 text-sm font-medium text-bark transition-colors hover:bg-sage-fill hover:text-ink"
+            >
               Workspaces
             </Link>
             <SignOutButton />
           </nav>
         </div>
       </header>
-      <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col px-6 py-8">
+      <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-6 py-10">
         {children}
       </div>
     </div>

--- a/apps/web/app/app/meeting/[id]/page.tsx
+++ b/apps/web/app/app/meeting/[id]/page.tsx
@@ -1,33 +1,14 @@
 import Link from "next/link";
 import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
-import ReactMarkdown from "react-markdown";
 import { and, asc, eq, getDb, meetings, notes, transcriptSegments } from "@repo/db";
 
 import { auth } from "@/lib/auth";
 import { ensurePersonalWorkspace } from "@/lib/workspace";
+import { markdownOf, MeetingBody } from "../../../meeting-body";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-function markdownOf(content: unknown): string | null {
-  if (
-    content &&
-    typeof content === "object" &&
-    "markdown" in content &&
-    typeof (content as { markdown: unknown }).markdown === "string"
-  ) {
-    return (content as { markdown: string }).markdown;
-  }
-  return null;
-}
-
-function timestamp(ms: number): string {
-  const total = Math.max(0, Math.round(ms / 1000));
-  const m = Math.floor(total / 60);
-  const s = total % 60;
-  return `${m}:${String(s).padStart(2, "0")}`;
-}
 
 export default async function MeetingPage({
   params,
@@ -83,11 +64,11 @@ export default async function MeetingPage({
       <Link href="/app" className="text-sm text-stone hover:text-ink">
         ← All meetings
       </Link>
-      <h1 className="mt-2 text-2xl font-semibold tracking-tight text-ink">
+      <h1 className="mt-3 font-display text-3xl font-semibold tracking-tight text-ink">
         {meeting.title || "Untitled meeting"}
       </h1>
       {when && (
-        <p className="mt-1 text-sm text-stone">
+        <p className="mt-1.5 text-sm text-stone">
           {when.toLocaleDateString("en-US", {
             weekday: "long",
             month: "long",
@@ -99,40 +80,11 @@ export default async function MeetingPage({
         </p>
       )}
 
-      {(enhanced ?? raw) ? (
-        <section className="prose-notes mt-6 rounded-xl border border-sand bg-card p-6">
-          <ReactMarkdown>{enhanced ?? raw ?? ""}</ReactMarkdown>
-        </section>
-      ) : (
-        <p className="mt-6 rounded-xl border border-sand bg-card-soft p-6 text-sm text-stone">
-          No notes were synced for this meeting.
-        </p>
-      )}
-
-      {segments.length > 0 && (
-        <section className="mt-6">
-          <h2 className="text-base font-semibold text-ink">Transcript</h2>
-          <div className="mt-3 space-y-3 rounded-xl border border-sand bg-card-soft p-5">
-            {segments.map((segment) => (
-              <p key={segment.id} className="text-sm leading-relaxed">
-                <span
-                  className={
-                    segment.speaker === "You"
-                      ? "font-semibold text-sage-deep"
-                      : "font-semibold text-ink"
-                  }
-                >
-                  {segment.speaker}
-                </span>
-                <span className="ml-2 text-xs text-stone">
-                  {timestamp(segment.startMs)}
-                </span>
-                <span className="mt-0.5 block text-bark">{segment.text}</span>
-              </p>
-            ))}
-          </div>
-        </section>
-      )}
+      <MeetingBody
+        markdown={enhanced ?? raw}
+        segments={segments}
+        emptyText="No notes were synced for this meeting."
+      />
     </main>
   );
 }

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -74,39 +74,39 @@ export default async function MeetingsPage({
   return (
     <main className="flex flex-1 flex-col">
       <div className="flex items-baseline justify-between">
-        <h1 className="text-2xl font-semibold tracking-tight text-ink">
+        <h1 className="font-display text-3xl font-semibold tracking-tight text-ink">
           Meetings
         </h1>
         <span className="text-sm text-stone">{activeOrg.name}</span>
       </div>
 
-      <form method="get" className="mt-4">
+      <form method="get" className="mt-5">
         <input
           type="search"
           name="q"
           defaultValue={query}
           placeholder="Search titles, notes, and transcripts…"
-          className="w-full rounded-md border border-sand bg-card px-3 py-2 text-sm text-ink outline-none placeholder:text-stone focus:border-sage"
+          className="w-full rounded-lg border border-sand bg-card px-3 py-2 text-sm text-ink outline-none placeholder:text-stone focus:border-sage"
         />
       </form>
 
       {rows.length === 0 && query.length > 0 ? (
-        <p className="mt-8 rounded-xl border border-sand bg-card-soft p-6 text-center text-sm text-stone">
+        <p className="mt-12 text-center text-sm text-stone">
           Nothing matches &ldquo;{query}&rdquo;.
         </p>
       ) : rows.length === 0 ? (
-        <div className="mt-10 rounded-xl border border-sand bg-card-soft p-8 text-center">
-          <h2 className="text-base font-semibold text-ink">
-            No meetings synced yet
-          </h2>
-          <p className="mx-auto mt-2 max-w-md text-sm leading-relaxed text-bark">
-            Open DoodleNote on your Mac and turn on{" "}
+        <div className="mt-16 text-center">
+          <p className="font-hand text-3xl text-stone">
+            nothing jotted here yet
+          </p>
+          <p className="mx-auto mt-4 max-w-md text-sm leading-relaxed text-bark">
+            Open DoodleNote on your computer and turn on{" "}
             <strong>Settings → Sync with cloud</strong>. Your meetings,
             transcripts, and notes will appear here.
           </p>
         </div>
       ) : (
-        <ul className="mt-6 divide-y divide-sand rounded-xl border border-sand bg-card">
+        <ul className="mt-4 border-y border-sand">
           {rows.map((meeting) => {
             const when = meeting.startedAt ?? meeting.createdAt;
             const durationMin =
@@ -121,10 +121,10 @@ export default async function MeetingsPage({
                   )
                 : null;
             return (
-              <li key={meeting.id}>
+              <li key={meeting.id} className="border-b border-sand last:border-b-0">
                 <Link
                   href={`/app/meeting/${meeting.id}`}
-                  className="flex items-center justify-between gap-4 px-5 py-4 transition-colors hover:bg-sage-fill/40"
+                  className="flex items-center justify-between gap-4 px-2 py-4 transition-colors hover:bg-sage-fill/40"
                 >
                   <div className="min-w-0">
                     <p className="truncate text-sm font-medium text-ink">

--- a/apps/web/app/app/sign-out-button.tsx
+++ b/apps/web/app/app/sign-out-button.tsx
@@ -14,7 +14,7 @@ export function SignOutButton() {
         router.push("/login");
         router.refresh();
       }}
-      className="rounded-md border border-sand bg-card px-3 py-1.5 text-sm text-ink transition-colors hover:bg-sage-fill"
+      className="rounded-md border border-sand bg-card px-3.5 py-1.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
     >
       Sign out
     </button>

--- a/apps/web/app/app/workspaces/workspaces-panel.tsx
+++ b/apps/web/app/app/workspaces/workspaces-panel.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { authClient } from "@/lib/auth-client";
+import { buttonPrimary, inputClass } from "../../ui";
 
 interface Workspace {
   id: string;
@@ -97,10 +98,10 @@ export function WorkspacesPanel({
 
   return (
     <main className="flex flex-1 flex-col">
-      <h1 className="text-2xl font-semibold tracking-tight text-ink">
+      <h1 className="font-display text-3xl font-semibold tracking-tight text-ink">
         Workspaces
       </h1>
-      <p className="mt-1 text-sm text-stone">
+      <p className="mt-1.5 text-sm text-stone">
         Signed in as {userEmail}. The active workspace scopes your meetings
         and notes.
       </p>
@@ -112,17 +113,17 @@ export function WorkspacesPanel({
       )}
 
       {organizations.length === 0 ? (
-        <p className="mt-6 rounded-xl border border-dashed border-sand bg-card-soft px-4 py-6 text-center text-sm text-stone">
+        <p className="mt-10 text-center text-sm text-stone">
           No workspaces yet.
         </p>
       ) : (
-        <ul className="mt-6 divide-y divide-sand rounded-xl border border-sand bg-card">
+        <ul className="mt-6 border-y border-sand">
           {organizations.map((org) => {
             const isActive = org.id === activeOrganizationId;
             return (
               <li
                 key={org.id}
-                className="flex items-center justify-between gap-4 px-5 py-4"
+                className="flex items-center justify-between gap-4 border-b border-sand px-2 py-4 last:border-b-0"
               >
                 <div className="min-w-0">
                   <p className="truncate text-sm font-medium text-ink">
@@ -149,17 +150,19 @@ export function WorkspacesPanel({
         </ul>
       )}
 
-      <section className="mt-8">
-        <h2 className="text-base font-semibold text-ink">Members</h2>
+      <section className="mt-10">
+        <h2 className="font-display text-lg font-semibold text-ink">
+          Members
+        </h2>
         <p className="mt-1 text-sm text-stone">
           Everyone in the active workspace sees its synced meetings.
         </p>
 
-        <ul className="mt-3 divide-y divide-sand rounded-xl border border-sand bg-card">
+        <ul className="mt-4 border-y border-sand">
           {members.map((member) => (
             <li
               key={member.id}
-              className="flex items-center justify-between gap-4 px-5 py-3"
+              className="flex items-center justify-between gap-4 border-b border-sand px-2 py-3 last:border-b-0"
             >
               <span className="truncate text-sm text-ink">{member.email}</span>
               <span className="shrink-0 text-xs text-stone">{member.role}</span>
@@ -168,7 +171,7 @@ export function WorkspacesPanel({
           {invitations.map((invite) => (
             <li
               key={invite.id}
-              className="flex items-center justify-between gap-4 px-5 py-3"
+              className="flex items-center justify-between gap-4 border-b border-sand px-2 py-3 last:border-b-0"
             >
               <span className="min-w-0">
                 <span className="block truncate text-sm text-ink">
@@ -197,18 +200,18 @@ export function WorkspacesPanel({
           ))}
         </ul>
 
-        <form onSubmit={handleInvite} className="mt-3 flex items-start gap-2">
+        <form onSubmit={handleInvite} className="mt-4 flex items-start gap-2">
           <input
             type="email"
             placeholder="teammate@company.com"
             value={inviteEmail}
             onChange={(e) => setInviteEmail(e.target.value)}
-            className="flex-1 rounded-md border border-sand bg-card px-3 py-2 text-sm text-ink outline-none placeholder:text-stone focus:border-sage"
+            className={`flex-1 ${inputClass}`}
           />
           <button
             type="submit"
             disabled={invitePending || !inviteEmail.trim() || !activeOrganizationId}
-            className="rounded-md bg-ink px-3 py-2 text-sm font-medium text-cream transition-opacity hover:opacity-90 disabled:opacity-50"
+            className={buttonPrimary}
           >
             {invitePending ? "Inviting…" : "Invite"}
           </button>

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -1,5 +1,4 @@
-import Image from "next/image";
-import Link from "next/link";
+import { SiteFooter, SiteHeader } from "../ui";
 
 export const metadata = { title: "What's new — DoodleNote" };
 
@@ -114,41 +113,40 @@ const RELEASES: Array<{
 export default function ChangelogPage() {
   return (
     <div className="flex flex-1 flex-col bg-cream text-bark">
-      <header className="border-b border-sand bg-card-soft">
-        <div className="mx-auto flex w-full max-w-3xl items-center justify-between px-6 py-3">
-          <Link href="/" className="flex items-center gap-2">
-            <Image src="/mascot.png" alt="" width={26} height={26} className="rounded-md" />
-            <span className="text-sm font-bold tracking-tight">
-              <span className="text-ink">Doodle</span>
-              <span className="text-sage">Note</span>
-            </span>
-          </Link>
-          <span className="text-xs text-stone">What&rsquo;s new</span>
-        </div>
-      </header>
+      <SiteHeader />
 
-      <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-6 py-10">
-        <h1 className="text-3xl font-semibold tracking-tight text-ink">
+      <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-6 pb-24 pt-10 sm:pt-16">
+        <h1 className="font-display text-4xl font-semibold tracking-tight text-ink">
           What&rsquo;s new
         </h1>
-        <p className="mt-2 text-sm text-stone">
+        <p className="mt-3 text-sm leading-relaxed text-stone">
           Every DoodleNote release and what changed. The app updates itself —
           you&rsquo;re always on the newest version within a few hours.
         </p>
 
-        <div className="mt-10 space-y-10">
+        <div className="mt-8">
           {RELEASES.map((release) => (
-            <section key={release.version} id={`v${release.version}`}>
-              <div className="flex items-baseline gap-3">
-                <h2 className="text-xl font-semibold text-ink">
+            <section
+              key={release.version}
+              id={`v${release.version}`}
+              className="grid gap-2 border-b border-sand py-8 last:border-b-0 sm:grid-cols-[8rem_1fr] sm:gap-6"
+            >
+              <div>
+                <h2 className="font-display text-lg font-semibold text-ink">
                   v{release.version}
                 </h2>
-                <span className="text-sm text-stone">{release.date}</span>
+                <p className="mt-0.5 text-xs text-stone">{release.date}</p>
               </div>
-              <ul className="mt-3 space-y-2 rounded-xl border border-sand bg-card p-6">
+              <ul className="space-y-2.5">
                 {release.highlights.map((item) => (
-                  <li key={item} className="flex gap-2.5 text-sm leading-relaxed">
-                    <span className="mt-0.5 shrink-0 text-sage" aria-hidden="true">
+                  <li
+                    key={item}
+                    className="flex gap-2.5 text-sm leading-relaxed"
+                  >
+                    <span
+                      className="mt-0.5 shrink-0 text-sage"
+                      aria-hidden="true"
+                    >
                       •
                     </span>
                     {item}
@@ -160,14 +158,7 @@ export default function ChangelogPage() {
         </div>
       </main>
 
-      <footer className="border-t border-sand">
-        <div className="mx-auto w-full max-w-3xl px-6 py-5 text-sm text-stone">
-          <Link href="/" className="font-semibold text-sage-deep hover:underline">
-            DoodleNote
-          </Link>{" "}
-          — AI meeting notes without the bot.
-        </div>
-      </footer>
+      <SiteFooter />
     </div>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -118,6 +118,7 @@ body {
 .prose-notes h2,
 .prose-notes h3 {
   color: var(--color-ink);
+  font-family: var(--font-bricolage), sans-serif;
   font-weight: 600;
   margin: 1.1em 0 0.4em;
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -10,6 +10,8 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+  --font-display: var(--font-bricolage);
+  --font-hand: var(--font-caveat);
 }
 
 /* DoodleNote brand palette (mirrors apps/desktop main.css :root) */
@@ -53,6 +55,57 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+/* Landing page: ruled notepad paper (hero demo card). */
+.notepad-rule {
+  background-image: repeating-linear-gradient(
+    to bottom,
+    transparent 0,
+    transparent calc(2rem - 1px),
+    var(--color-sand) calc(2rem - 1px),
+    var(--color-sand) 2rem
+  );
+  background-position: 0 0.55rem;
+}
+
+/* Landing page: hand-drawn ink stroke under the headline's key phrase. */
+.doodle-stroke path {
+  stroke-dasharray: 320;
+  stroke-dashoffset: 320;
+  animation: doodle-draw 0.7s ease-out 0.35s forwards;
+}
+@keyframes doodle-draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+/* Landing page: polished side of the demo card settles in after the jot. */
+.settle-in {
+  opacity: 0;
+  animation: settle 0.5s ease-out 0.9s forwards;
+}
+@keyframes settle {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .doodle-stroke path {
+    stroke-dashoffset: 0;
+    animation: none;
+  }
+  .settle-in {
+    opacity: 1;
+    animation: none;
+  }
 }
 
 /* Markdown-rendered meeting notes (web library detail page). */

--- a/apps/web/app/invite/[id]/accept-invite.tsx
+++ b/apps/web/app/invite/[id]/accept-invite.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { authClient } from "@/lib/auth-client";
+import { buttonPrimary } from "../../ui";
 
 export function AcceptInvite({ invitationId }: { invitationId: string }) {
   const router = useRouter();
@@ -39,7 +40,7 @@ export function AcceptInvite({ invitationId }: { invitationId: string }) {
         type="button"
         disabled={pending}
         onClick={() => void accept()}
-        className="mt-4 w-full rounded-md bg-ink px-3 py-2 text-sm font-medium text-cream transition-opacity hover:opacity-90 disabled:opacity-50"
+        className={`mt-5 w-full ${buttonPrimary}`}
       >
         {pending ? "Joining…" : "Join workspace"}
       </button>

--- a/apps/web/app/invite/[id]/page.tsx
+++ b/apps/web/app/invite/[id]/page.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
@@ -36,26 +37,34 @@ export default async function InvitePage({
   }
 
   return (
-    <main className="flex flex-1 flex-col items-center justify-center bg-cream px-6 py-16">
-      <div className="w-full max-w-sm rounded-xl border border-sand bg-card p-6 text-center">
+    <main className="flex flex-1 flex-col items-center justify-center bg-cream px-6 py-16 text-bark">
+      <div className="flex w-full max-w-sm flex-col items-center rounded-2xl border border-sand bg-card p-6 text-center shadow-[0_1px_0_var(--color-sand),0_12px_32px_-20px_rgba(38,40,31,0.35)]">
+        <Image
+          src="/mascot.png"
+          alt=""
+          width={40}
+          height={40}
+          className="rounded-lg"
+          unoptimized
+        />
         {problem ? (
           <>
-            <h1 className="text-lg font-semibold text-ink">
+            <h1 className="mt-4 font-display text-lg font-semibold text-ink">
               Invitation not available
             </h1>
-            <p className="mt-2 text-sm text-bark">{problem}</p>
+            <p className="mt-2 text-sm leading-relaxed text-bark">{problem}</p>
             <p className="mt-2 text-xs text-stone">
               Signed in as {session!.user.email}
             </p>
           </>
         ) : (
           <>
-            <h1 className="text-lg font-semibold text-ink">
+            <h1 className="mt-4 font-display text-lg font-semibold text-ink">
               Join “{organizationName}”?
             </h1>
-            <p className="mt-2 text-sm text-bark">
+            <p className="mt-2 text-sm leading-relaxed text-bark">
               {inviterEmail} invited you to their DoodleNote workspace. You’ll
-            see the meetings and notes synced to it.
+              see the meetings and notes synced to it.
             </p>
             <AcceptInvite invitationId={id} />
           </>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,10 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import {
+  Bricolage_Grotesque,
+  Caveat,
+  Geist,
+  Geist_Mono,
+} from "next/font/google";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -9,6 +14,16 @@ const geistSans = Geist({
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+const bricolage = Bricolage_Grotesque({
+  variable: "--font-bricolage",
+  subsets: ["latin"],
+});
+
+const caveat = Caveat({
+  variable: "--font-caveat",
   subsets: ["latin"],
 });
 
@@ -26,7 +41,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} ${bricolage.variable} ${caveat.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col font-sans">{children}</body>
     </html>

--- a/apps/web/app/link-device/link-device-form.tsx
+++ b/apps/web/app/link-device/link-device-form.tsx
@@ -1,6 +1,25 @@
 "use client";
 
+import Image from "next/image";
 import { useState } from "react";
+
+import { buttonPrimary, inputClass } from "../ui";
+
+function DialogCard({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="w-full max-w-sm rounded-2xl border border-sand bg-card p-6 shadow-[0_1px_0_var(--color-sand),0_12px_32px_-20px_rgba(38,40,31,0.35)]">
+      <Image
+        src="/mascot.png"
+        alt=""
+        width={40}
+        height={40}
+        className="rounded-lg"
+        unoptimized
+      />
+      {children}
+    </div>
+  );
+}
 
 export function LinkDeviceForm({
   port,
@@ -46,25 +65,27 @@ export function LinkDeviceForm({
 
   if (!port) {
     return (
-      <div className="w-full max-w-sm rounded-xl border border-sand bg-card p-6 text-center">
-        <h1 className="text-lg font-semibold text-ink">Connect DoodleNote</h1>
-        <p className="mt-2 text-sm text-bark">
+      <DialogCard>
+        <h1 className="mt-4 font-display text-lg font-semibold text-ink">
+          Connect DoodleNote
+        </h1>
+        <p className="mt-2 text-sm leading-relaxed text-bark">
           This page is opened by the DoodleNote desktop app. Start the
           connection from <strong>Settings → Sync with cloud</strong> on your
-          Mac.
+          computer.
         </p>
-      </div>
+      </DialogCard>
     );
   }
 
   return (
-    <div className="w-full max-w-sm rounded-xl border border-sand bg-card p-6">
-      <h1 className="text-lg font-semibold text-ink">
-        Connect “{deviceName}”?
+    <DialogCard>
+      <h1 className="mt-4 font-display text-lg font-semibold text-ink">
+        Connect &ldquo;{deviceName}&rdquo;?
       </h1>
-      <p className="mt-2 text-sm text-bark">
-        Your Mac will sync meetings, transcripts, and notes to the workspace
-        below, signed in as <strong>{email}</strong>.
+      <p className="mt-2 text-sm leading-relaxed text-bark">
+        This computer will sync meetings, transcripts, and notes to the
+        workspace below, signed in as <strong>{email}</strong>.
       </p>
 
       {organizations.length > 1 && (
@@ -73,7 +94,7 @@ export function LinkDeviceForm({
           <select
             value={organizationId}
             onChange={(e) => setOrganizationId(e.target.value)}
-            className="mt-1 w-full rounded-md border border-sand bg-card px-3 py-2 text-sm text-ink"
+            className={`mt-1 ${inputClass}`}
           >
             {organizations.map((org) => (
               <option key={org.id} value={org.id}>
@@ -91,7 +112,7 @@ export function LinkDeviceForm({
       )}
 
       {done ? (
-        <p className="mt-4 rounded-md bg-sage-fill px-3 py-2 text-sm text-sage-deep">
+        <p className="mt-4 rounded-lg bg-sage-fill px-3 py-2 text-sm text-sage-deep">
           Connected — taking you to your meetings…
         </p>
       ) : (
@@ -99,11 +120,11 @@ export function LinkDeviceForm({
           type="button"
           disabled={pending || !organizationId}
           onClick={handleApprove}
-          className="mt-4 w-full rounded-md bg-ink px-3 py-2 text-sm font-medium text-cream transition-opacity hover:opacity-90 disabled:opacity-50"
+          className={`mt-5 w-full ${buttonPrimary}`}
         >
           {pending ? "Connecting…" : "Connect desktop app"}
         </button>
       )}
-    </div>
+    </DialogCard>
   );
 }

--- a/apps/web/app/login/login-form.tsx
+++ b/apps/web/app/login/login-form.tsx
@@ -1,15 +1,14 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { authClient } from "@/lib/auth-client";
+import { buttonPrimary, buttonSecondary, inputClass, Wordmark } from "../ui";
 
 type Mode = "sign-in" | "sign-up";
-
-const inputClasses =
-  "w-full rounded-md border border-neutral-300 bg-transparent px-3 py-2 text-sm outline-none placeholder:text-neutral-400 focus:border-neutral-500 dark:border-neutral-700 dark:placeholder:text-neutral-600 dark:focus:border-neutral-400";
 
 function MicrosoftLogo() {
   return (
@@ -58,12 +57,20 @@ export function LoginForm({
 
   return (
     <div className="w-full max-w-sm">
-      <div className="mb-8 text-center">
-        <Link href="/" className="text-xl font-bold tracking-tight">
-          <span className="text-ink">Doodle</span>
-          <span className="text-sage">Note</span>
+      <div className="mb-8 flex flex-col items-center text-center">
+        <Link href="/" className="flex flex-col items-center gap-3">
+          <Image
+            src="/mascot.png"
+            alt=""
+            width={48}
+            height={48}
+            className="rounded-xl"
+            priority
+            unoptimized
+          />
+          <Wordmark size="text-xl" />
         </Link>
-        <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
+        <p className="mt-2 text-sm text-stone">
           {mode === "sign-in"
             ? "Sign in to your workspace"
             : "Create your account"}
@@ -79,7 +86,7 @@ export function LoginForm({
             placeholder="Name"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className={inputClasses}
+            className={inputClass}
           />
         )}
         <input
@@ -89,7 +96,7 @@ export function LoginForm({
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className={inputClasses}
+          className={inputClass}
         />
         <input
           type="password"
@@ -99,20 +106,16 @@ export function LoginForm({
           placeholder="Password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className={inputClasses}
+          className={inputClass}
         />
 
         {error && (
-          <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+          <p role="alert" className="text-sm text-red-700">
             {error}
           </p>
         )}
 
-        <button
-          type="submit"
-          disabled={pending}
-          className="mt-1 rounded-md bg-neutral-900 px-3 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-900"
-        >
+        <button type="submit" disabled={pending} className={`mt-1 ${buttonPrimary}`}>
           {pending
             ? "Please wait…"
             : mode === "sign-in"
@@ -130,7 +133,7 @@ export function LoginForm({
               callbackURL: next,
             })
           }
-          className="mt-3 flex w-full items-center justify-center gap-2 rounded-md border border-neutral-300 px-3 py-2 text-sm font-medium transition-colors hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-900"
+          className={`mt-3 w-full ${buttonSecondary}`}
         >
           <MicrosoftLogo />
           Sign in with Microsoft
@@ -143,13 +146,13 @@ export function LoginForm({
           onClick={() =>
             authClient.signIn.social({ provider: "google", callbackURL: next })
           }
-          className="mt-3 w-full rounded-md border border-neutral-300 px-3 py-2 text-sm font-medium transition-colors hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-900"
+          className={`mt-3 w-full ${buttonSecondary}`}
         >
           Continue with Google
         </button>
       )}
 
-      <p className="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
+      <p className="mt-6 text-center text-sm text-stone">
         {mode === "sign-in" ? (
           <>
             No account?{" "}
@@ -159,7 +162,7 @@ export function LoginForm({
                 setMode("sign-up");
                 setError(null);
               }}
-              className="underline underline-offset-2 hover:text-neutral-900 dark:hover:text-neutral-100"
+              className="underline underline-offset-2 hover:text-ink"
             >
               Sign up
             </button>
@@ -173,7 +176,7 @@ export function LoginForm({
                 setMode("sign-in");
                 setError(null);
               }}
-              className="underline underline-offset-2 hover:text-neutral-900 dark:hover:text-neutral-100"
+              className="underline underline-offset-2 hover:text-ink"
             >
               Sign in
             </button>

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -21,7 +21,7 @@ export default async function LoginPage({
   if (session) redirect(nextPath);
 
   return (
-    <main className="flex flex-1 flex-col items-center justify-center px-6 py-16">
+    <main className="flex flex-1 flex-col items-center justify-center bg-cream px-6 py-16 text-bark">
       <LoginForm
         googleEnabled={googleEnabled()}
         microsoftEnabled={microsoftEnabled()}

--- a/apps/web/app/meeting-body.tsx
+++ b/apps/web/app/meeting-body.tsx
@@ -1,0 +1,79 @@
+import ReactMarkdown from "react-markdown";
+
+/** Notes + transcript rendering shared by the app meeting page and the public share page. */
+
+export function markdownOf(content: unknown): string | null {
+  if (
+    content &&
+    typeof content === "object" &&
+    "markdown" in content &&
+    typeof (content as { markdown: unknown }).markdown === "string"
+  ) {
+    return (content as { markdown: string }).markdown;
+  }
+  return null;
+}
+
+function timestamp(ms: number): string {
+  const total = Math.max(0, Math.round(ms / 1000));
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, "0")}`;
+}
+
+export interface TranscriptSegmentRow {
+  id: string;
+  speaker: string;
+  startMs: number;
+  text: string;
+}
+
+export function MeetingBody({
+  markdown,
+  segments,
+  emptyText,
+}: {
+  markdown: string | null;
+  segments: TranscriptSegmentRow[];
+  emptyText: string;
+}) {
+  return (
+    <>
+      {markdown ? (
+        <section className="prose-notes mt-8 rounded-2xl border border-sand bg-card px-6 py-5 shadow-[0_1px_0_var(--color-sand),0_12px_32px_-20px_rgba(38,40,31,0.35)]">
+          <ReactMarkdown>{markdown}</ReactMarkdown>
+        </section>
+      ) : (
+        <p className="mt-8 text-sm text-stone">{emptyText}</p>
+      )}
+
+      {segments.length > 0 && (
+        <section className="mt-10">
+          <h2 className="font-display text-lg font-semibold text-ink">
+            Transcript
+          </h2>
+          <div className="mt-2 border-y border-sand">
+            {segments.map((segment) => (
+              <p
+                key={segment.id}
+                className="border-b border-sand py-3 text-sm leading-relaxed last:border-b-0"
+              >
+                <span
+                  className={
+                    segment.speaker === "You"
+                      ? "font-semibold text-sage-deep"
+                      : "font-semibold text-ink"
+                  }
+                >
+                  {segment.speaker}
+                </span>
+                <span className="ml-2 text-xs text-stone">
+                  {timestamp(segment.startMs)}
+                </span>
+                <span className="mt-0.5 block text-bark">{segment.text}</span>
+              </p>
+            ))}
+          </div>
+        </section>
+      )}
+    </>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -4,7 +4,7 @@ import { AppleLogo, WindowsLogo } from "./logos";
 
 function Wordmark({ size = "text-lg" }: { size?: string }) {
   return (
-    <span className={`${size} font-bold tracking-tight`}>
+    <span className={`${size} font-display font-bold tracking-tight`}>
       <span className="text-ink">Doodle</span>
       <span className="text-sage">Note</span>
     </span>
@@ -17,82 +17,114 @@ const DOWNLOADS = {
   win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.4-setup.exe",
 };
 
-const MEETING_APPS = [
-  "Zoom",
-  "Google Meet",
-  "Teams",
-  "Slack huddles",
-  "FaceTime",
-];
-
-const TIMELINE = [
-  {
-    phase: "Before",
-    title: "It knows your calendar",
-    body: "Connect Microsoft 365 or Google Calendar and DoodleNote shows what's coming up, counts down in your menu bar, and offers to take notes the moment your meeting app starts ringing.",
-  },
-  {
-    phase: "During",
-    title: "You just jot",
-    body: "Recording starts instantly and a live transcript builds in the background — your mic is “You,” the other side is “Them.” Type messy half-thoughts; that's all DoodleNote needs.",
-  },
-  {
-    phase: "After",
-    title: "Polished notes, on their own",
-    body: "When the call ends, recording stops by itself and your rough jottings merge with the transcript into clean, structured notes — summary, decisions, action items. Share them with one link.",
-  },
-];
-
-const PRIVACY_POINTS = [
+const REASONS = [
   {
     title: "No bot joins your call",
-    body: "DoodleNote captures your mic and system audio right on your computer. Nothing announces itself, nothing sits in the participant list.",
+    body: "Nothing appears in the participant list and nobody gets a “recording started” warning about you. DoodleNote listens from your side, on your computer, in any app that makes sound.",
   },
   {
-    title: "Transcription never leaves your device",
-    body: "Speech-to-text runs entirely on your Mac or PC. Your meeting audio is never uploaded to us — or anyone else.",
+    title: "Your audio is never uploaded",
+    body: "Transcription runs entirely on your device. Meeting audio never touches our servers — or anyone else’s. There is nothing to leak, because nothing is sent.",
   },
   {
-    title: "AI notes with a local model",
-    body: "Notes are written by a local model downloaded in-app. Prefer frontier models? Bring your own API key — it's your key, your data.",
+    title: "The AI is yours",
+    body: "Notes are written by a local model you download once, in-app. Prefer a frontier model? Bring your own API key — your key, your data, no middleman.",
   },
   {
-    title: "Sync is opt-in, always",
-    body: "Out of the box, everything stays on your device. Turn on cloud sync only if you want your notes on every device — and turn it off anytime.",
+    title: "Free, without a catch",
+    body: "Unlimited meetings, transcripts, AI notes, and search on your device — no account required. Pay only if you want your notes synced across devices.",
   },
 ];
 
-const FEATURES = [
-  {
-    title: "Ask your meetings anything",
-    body: "Chat with one meeting or across all of them — “what did we promise the customer?” — and get grounded answers with citations back to the transcript.",
-  },
-  {
-    title: "Note templates",
-    body: "Customer discovery, 1:1, standup, interview, troubleshooting — pick a template per meeting, switch and regenerate anytime.",
-  },
-  {
-    title: "Share with a link",
-    body: "Publish a read-only page of any meeting's notes and transcript with one click. No account needed to read it.",
-  },
-  {
-    title: "Team workspaces",
-    body: "Invite your team by link and everyone sees the workspace's synced meetings — one shared memory for the whole team.",
-  },
-  {
-    title: "Full-text search",
-    body: "Search every word ever said across notes and transcripts, on your desktop and in the web library.",
-  },
-  {
-    title: "Quick notes & folders",
-    body: "Standalone notes with the same editor, images, and optional voice dump. Organize everything with folders and a recoverable trash.",
-  },
-];
+function DownloadButtons({ small = false }: { small?: boolean }) {
+  const pad = small ? "px-4 py-2" : "px-5 py-2.5";
+  return (
+    <div className="flex flex-col items-center gap-3 sm:flex-row">
+      <a
+        href={DOWNLOADS.mac}
+        className={`inline-flex items-center justify-center gap-2 rounded-lg bg-ink ${pad} text-sm font-medium text-cream transition-opacity hover:opacity-85 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sage-deep`}
+      >
+        <AppleLogo className="-mt-0.5 h-4 w-4" />
+        Download for macOS
+      </a>
+      <a
+        href={DOWNLOADS.win}
+        className={`inline-flex items-center justify-center gap-2 rounded-lg border border-sand bg-card ${pad} text-sm font-medium text-ink transition-colors hover:bg-sage-fill focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sage-deep`}
+      >
+        <WindowsLogo className="h-3.5 w-3.5" />
+        Windows (beta)
+      </a>
+    </div>
+  );
+}
+
+/** Hand-drawn underline for the headline's key phrase. */
+function DoodleStroke() {
+  return (
+    <svg
+      className="doodle-stroke absolute -bottom-2 left-0 h-3 w-full text-sage"
+      viewBox="0 0 300 12"
+      fill="none"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M4 8.5C42 4.5 96 3 150 5c46 1.7 92 2.5 146-1.5"
+        stroke="currentColor"
+        strokeWidth="3.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+/** The whole product in one card: messy jot in, polished notes out. */
+function NotepadDemo() {
+  return (
+    <figure className="w-full max-w-2xl overflow-hidden rounded-2xl border border-sand bg-card shadow-[0_1px_0_var(--color-sand),0_12px_32px_-20px_rgba(38,40,31,0.35)]">
+      <div className="grid sm:grid-cols-2">
+        <div className="notepad-rule border-b border-sand px-6 pb-5 pt-4 sm:border-b-0 sm:border-r">
+          <figcaption className="text-xs font-semibold uppercase tracking-wider text-stone">
+            You, mid-call
+          </figcaption>
+          <p className="mt-3 font-hand text-[1.45rem] leading-8 text-bark">
+            pricing?? john wants Q3
+            <br />
+            demo went well &mdash; latency q
+            <br />
+            they need SSO before rollout
+            <br />
+            priya = decision maker
+          </p>
+        </div>
+        <div className="settle-in px-6 pb-5 pt-4">
+          <figcaption className="text-xs font-semibold uppercase tracking-wider text-sage-deep">
+            DoodleNote, right after
+          </figcaption>
+          <div className="mt-3 space-y-3 text-sm leading-relaxed text-bark">
+            <p>
+              <strong className="text-ink">Decisions</strong>
+              <br />
+              Pricing review moves to Q3, owned by John.
+            </p>
+            <p>
+              <strong className="text-ink">Action items</strong>
+              <br />
+              Send SSO setup docs to Priya (decision maker).
+              <br />
+              Book the follow-up demo &mdash; latency question came up.
+            </p>
+          </div>
+        </div>
+      </div>
+    </figure>
+  );
+}
 
 export default function Home() {
   return (
     <div className="flex flex-1 flex-col bg-cream text-bark">
-      <header className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-5">
+      <header className="mx-auto flex w-full max-w-3xl items-center justify-between px-6 py-5">
         <div className="flex items-center gap-2.5">
           <Image
             src="/mascot.png"
@@ -101,6 +133,7 @@ export default function Home() {
             height={34}
             className="rounded-lg"
             priority
+            unoptimized
           />
           <Wordmark />
         </div>
@@ -112,12 +145,6 @@ export default function Home() {
             Pricing
           </Link>
           <Link
-            href="/changelog"
-            className="hidden rounded-md px-3 py-1.5 text-sm font-medium text-bark transition-colors hover:bg-sage-fill hover:text-ink sm:block"
-          >
-            What&rsquo;s new
-          </Link>
-          <Link
             href="/login"
             className="rounded-md border border-sand bg-card px-3.5 py-1.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
           >
@@ -126,238 +153,95 @@ export default function Home() {
         </nav>
       </header>
 
-      <main className="flex flex-1 flex-col">
+      <main className="flex flex-1 flex-col items-center px-6">
         {/* Hero */}
-        <section className="mx-auto flex w-full max-w-3xl flex-col items-center px-6 pb-14 pt-16 text-center sm:pt-20">
-          <p className="rounded-full border border-sand bg-card px-3.5 py-1 text-xs font-medium text-sage-deep">
-            Unlimited meetings, free forever
-          </p>
-          <h1 className="mt-5 text-4xl font-semibold tracking-tight text-ink sm:text-5xl">
-            AI meeting notes.
-            <br />
-            <span className="text-sage-deep">No bot. No cloud.</span>
+        <section className="flex w-full max-w-2xl flex-col items-center pb-16 pt-16 text-center sm:pt-24">
+          <h1 className="font-display text-4xl font-semibold leading-[1.12] tracking-tight text-ink sm:text-[3.4rem]">
+            Polished notes from every meeting.{" "}
+            <span className="relative inline-block whitespace-nowrap text-sage-deep">
+              Nothing
+              <DoodleStroke />
+            </span>{" "}
+            leaves your computer.
           </h1>
-          <p className="mt-5 max-w-xl text-lg leading-relaxed text-bark">
-            DoodleNote records right on your Mac or PC, transcribes on-device,
-            and turns your rough jottings into polished notes, action items,
-            and answers. Your meetings never leave your computer.
+          <p className="mt-6 max-w-xl text-lg leading-relaxed text-bark">
+            DoodleNote listens from your side of the call &mdash; no bot in the
+            room, no audio uploaded. Jot rough fragments while you talk; it
+            merges them with the on-device transcript into notes worth sharing.
           </p>
-          <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row">
-            <a
-              href={DOWNLOADS.mac}
-              className="inline-flex items-center justify-center gap-2 rounded-md bg-ink px-5 py-2.5 text-sm font-medium text-cream transition-opacity hover:opacity-85"
-            >
-              <AppleLogo className="h-4 w-4 -mt-0.5" />
-              Download for macOS
-            </a>
-            <a
-              href={DOWNLOADS.win}
-              className="inline-flex items-center justify-center gap-2 rounded-md border border-sand bg-card px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
-            >
-              <WindowsLogo className="h-3.5 w-3.5" />
-              Download for Windows (beta)
-            </a>
+          <div className="mt-9">
+            <DownloadButtons />
           </div>
           <p className="mt-4 text-sm text-stone">
-            Works with {MEETING_APPS.join(", ")} — any app that makes sound.
+            Free forever &middot; Works with any meeting app
           </p>
         </section>
 
-        {/* Trust strip */}
-        <section className="mx-auto w-full max-w-5xl px-6 pb-20">
-          <div className="grid gap-px overflow-hidden rounded-xl border border-sand bg-sand sm:grid-cols-3">
-            {[
-              ["0", "bots joining your calls"],
-              ["100%", "on-device transcription"],
-              ["$0", "for unlimited meetings"],
-            ].map(([stat, label]) => (
+        {/* The product, in one glance */}
+        <section className="flex w-full justify-center pb-24">
+          <NotepadDemo />
+        </section>
+
+        {/* Why this, and not the usual notetaker */}
+        <section className="w-full max-w-2xl pb-24">
+          <h2 className="font-display text-2xl font-semibold tracking-tight text-ink">
+            Why people switch
+          </h2>
+          <dl className="mt-2">
+            {REASONS.map((r) => (
               <div
-                key={label}
-                className="flex flex-col items-center bg-card-soft px-6 py-6 text-center"
+                key={r.title}
+                className="grid gap-1 border-b border-sand py-6 last:border-b-0 sm:grid-cols-[13rem_1fr] sm:gap-8"
               >
-                <span className="text-3xl font-semibold tracking-tight text-sage-deep">
-                  {stat}
-                </span>
-                <span className="mt-1 text-sm text-bark">{label}</span>
+                <dt className="font-display text-base font-semibold text-ink">
+                  {r.title}
+                </dt>
+                <dd className="text-[0.95rem] leading-relaxed text-bark">
+                  {r.body}
+                </dd>
               </div>
             ))}
-          </div>
-        </section>
-
-        {/* Before / during / after */}
-        <section className="border-y border-sand bg-card-soft">
-          <div className="mx-auto w-full max-w-5xl px-6 py-20">
-            <h2 className="text-center text-3xl font-semibold tracking-tight text-ink">
-              Before, during, and after every meeting
-            </h2>
-            <p className="mx-auto mt-3 max-w-xl text-center text-bark">
-              DoodleNote handles the note-taking so you can actually be in the
-              conversation.
-            </p>
-            <div className="mt-12 grid gap-4 sm:grid-cols-3">
-              {TIMELINE.map((step) => (
-                <div
-                  key={step.phase}
-                  className="rounded-xl border border-sand bg-card p-6"
-                >
-                  <span className="text-xs font-semibold uppercase tracking-wider text-sage">
-                    {step.phase}
-                  </span>
-                  <h3 className="mt-2 text-base font-semibold text-ink">
-                    {step.title}
-                  </h3>
-                  <p className="mt-2 text-sm leading-relaxed text-bark">
-                    {step.body}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Privacy — the differentiator */}
-        <section className="mx-auto w-full max-w-5xl px-6 py-20">
-          <div className="grid gap-10 lg:grid-cols-[1fr_1.2fr] lg:items-center">
-            <div>
-              <h2 className="text-3xl font-semibold tracking-tight text-ink">
-                Private by design,
-                <br />
-                not by promise
-              </h2>
-              <p className="mt-4 leading-relaxed text-bark">
-                Other AI notetakers upload your meeting audio to their servers
-                and process it there. DoodleNote is built the other way around:
-                capture, transcription, and AI all run on your own computer.
-                There is nothing to leak, because nothing is sent.
-              </p>
-            </div>
-            <div className="grid gap-4 sm:grid-cols-2">
-              {PRIVACY_POINTS.map((p) => (
-                <div
-                  key={p.title}
-                  className="rounded-xl border border-sand bg-card-soft p-5"
-                >
-                  <h3 className="text-sm font-semibold text-ink">{p.title}</h3>
-                  <p className="mt-1.5 text-sm leading-relaxed text-bark">
-                    {p.body}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Feature grid */}
-        <section className="border-y border-sand bg-card-soft">
-          <div className="mx-auto w-full max-w-5xl px-6 py-20">
-            <h2 className="text-center text-3xl font-semibold tracking-tight text-ink">
-              A real notepad, not just a recorder
-            </h2>
-            <div className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {FEATURES.map((f) => (
-                <div
-                  key={f.title}
-                  className="rounded-xl border border-sand bg-card p-6"
-                >
-                  <h3 className="text-base font-semibold text-ink">
-                    {f.title}
-                  </h3>
-                  <p className="mt-2 text-sm leading-relaxed text-bark">
-                    {f.body}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Pricing teaser */}
-        <section className="mx-auto w-full max-w-5xl px-6 py-20">
-          <h2 className="text-center text-3xl font-semibold tracking-tight text-ink">
-            Free forever. Pay only for sync.
-          </h2>
-          <p className="mx-auto mt-3 max-w-xl text-center text-bark">
-            Everything that runs on your device is free with no meeting caps.
-            Add Sync when you want your notes on every device.
-          </p>
-          <div className="mx-auto mt-10 grid max-w-3xl gap-4 sm:grid-cols-2">
-            <div className="rounded-xl border border-sand bg-card p-6">
-              <h3 className="text-base font-semibold text-ink">Free</h3>
-              <p className="mt-1 text-3xl font-semibold tracking-tight text-ink">
-                $0
-                <span className="text-sm font-normal text-stone"> forever</span>
-              </p>
-              <p className="mt-3 text-sm leading-relaxed text-bark">
-                Unlimited recording, on-device transcription, AI notes, chat,
-                calendars, templates, and search — all local, no account
-                required.
-              </p>
-            </div>
-            <div className="rounded-xl border-2 border-sage bg-card p-6">
-              <h3 className="text-base font-semibold text-ink">Sync</h3>
-              <p className="mt-1 text-3xl font-semibold tracking-tight text-ink">
-                $10
-                <span className="text-sm font-normal text-stone">
-                  {" "}
-                  / month
-                </span>
-              </p>
-              <p className="mt-3 text-sm leading-relaxed text-bark">
-                Everything in Free, plus your meetings on every device, the web
-                library, share links, and team workspaces.
-              </p>
-            </div>
-          </div>
-          <p className="mt-6 text-center">
+          </dl>
+          <p className="mt-8 text-sm text-stone">
+            Sync across devices, share links, and team workspaces are $10/month
+            when you want them.{" "}
             <Link
               href="/pricing"
-              className="text-sm font-medium text-sage-deep hover:underline"
+              className="font-medium text-sage-deep hover:underline"
             >
-              Compare plans in detail →
+              See pricing
             </Link>
           </p>
         </section>
 
         {/* Final CTA */}
-        <section className="border-t border-sand bg-card-soft">
-          <div className="mx-auto flex w-full max-w-3xl flex-col items-center px-6 py-16 text-center">
-            <Image
-              src="/mascot.png"
-              alt=""
-              width={52}
-              height={52}
-              className="rounded-xl"
-            />
-            <h2 className="mt-5 text-3xl font-semibold tracking-tight text-ink">
-              Bring DoodleNote to your next meeting
-            </h2>
-            <p className="mt-3 max-w-md text-bark">
-              Download, hit record, and see your rough jottings come back as
-              real notes.
-            </p>
-            <div className="mt-7 flex flex-col items-center gap-3 sm:flex-row">
-              <a
-                href={DOWNLOADS.mac}
-                className="rounded-md bg-ink px-5 py-2.5 text-sm font-medium text-cream transition-opacity hover:opacity-85"
-              >
-                Download for macOS
-              </a>
-              <a
-                href={DOWNLOADS.win}
-                className="rounded-md border border-sand bg-card px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
-              >
-                Download for Windows (beta)
-              </a>
-            </div>
-            <p className="mt-4 text-sm text-stone">
-              macOS on Apple Silicon · Windows 10/11 (64-bit)
-            </p>
+        <section className="flex w-full max-w-2xl flex-col items-center border-t border-sand pb-20 pt-16 text-center">
+          <Image
+            src="/mascot.png"
+            alt=""
+            width={52}
+            height={52}
+            className="rounded-xl"
+            unoptimized
+          />
+          <h2 className="mt-5 font-display text-2xl font-semibold tracking-tight text-ink">
+            Bring it to your next meeting
+          </h2>
+          <p className="mt-2 max-w-md text-bark">
+            Download, hit record, and watch your jottings come back as real
+            notes.
+          </p>
+          <div className="mt-7">
+            <DownloadButtons small />
           </div>
+          <p className="mt-4 text-sm text-stone">
+            macOS on Apple Silicon &middot; Windows 10/11 (64-bit)
+          </p>
         </section>
       </main>
 
       <footer className="border-t border-sand">
-        <div className="mx-auto flex w-full max-w-5xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-stone sm:flex-row">
+        <div className="mx-auto flex w-full max-w-3xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-stone sm:flex-row">
           <Wordmark size="text-sm" />
           <nav className="flex items-center gap-5">
             <Link href="/pricing" className="hover:text-ink">

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,21 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
-import { AppleLogo, WindowsLogo } from "./logos";
 
-function Wordmark({ size = "text-lg" }: { size?: string }) {
-  return (
-    <span className={`${size} font-display font-bold tracking-tight`}>
-      <span className="text-ink">Doodle</span>
-      <span className="text-sage">Note</span>
-    </span>
-  );
-}
-
-/** Update feed on Vercel Blob — publish-release.mjs uploads these. */
-const DOWNLOADS = {
-  mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.4-arm64-mac.zip",
-  win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.4-setup.exe",
-};
+import { DoodleStroke, DownloadButtons, SiteFooter, SiteHeader } from "./ui";
 
 const REASONS = [
   {
@@ -35,48 +21,6 @@ const REASONS = [
     body: "Unlimited meetings, transcripts, AI notes, and search on your device — no account required. Pay only if you want your notes synced across devices.",
   },
 ];
-
-function DownloadButtons({ small = false }: { small?: boolean }) {
-  const pad = small ? "px-4 py-2" : "px-5 py-2.5";
-  return (
-    <div className="flex flex-col items-center gap-3 sm:flex-row">
-      <a
-        href={DOWNLOADS.mac}
-        className={`inline-flex items-center justify-center gap-2 rounded-lg bg-ink ${pad} text-sm font-medium text-cream transition-opacity hover:opacity-85 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sage-deep`}
-      >
-        <AppleLogo className="-mt-0.5 h-4 w-4" />
-        Download for macOS
-      </a>
-      <a
-        href={DOWNLOADS.win}
-        className={`inline-flex items-center justify-center gap-2 rounded-lg border border-sand bg-card ${pad} text-sm font-medium text-ink transition-colors hover:bg-sage-fill focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sage-deep`}
-      >
-        <WindowsLogo className="h-3.5 w-3.5" />
-        Windows (beta)
-      </a>
-    </div>
-  );
-}
-
-/** Hand-drawn underline for the headline's key phrase. */
-function DoodleStroke() {
-  return (
-    <svg
-      className="doodle-stroke absolute -bottom-2 left-0 h-3 w-full text-sage"
-      viewBox="0 0 300 12"
-      fill="none"
-      preserveAspectRatio="none"
-      aria-hidden="true"
-    >
-      <path
-        d="M4 8.5C42 4.5 96 3 150 5c46 1.7 92 2.5 146-1.5"
-        stroke="currentColor"
-        strokeWidth="3.5"
-        strokeLinecap="round"
-      />
-    </svg>
-  );
-}
 
 /** The whole product in one card: messy jot in, polished notes out. */
 function NotepadDemo() {
@@ -124,34 +68,7 @@ function NotepadDemo() {
 export default function Home() {
   return (
     <div className="flex flex-1 flex-col bg-cream text-bark">
-      <header className="mx-auto flex w-full max-w-3xl items-center justify-between px-6 py-5">
-        <div className="flex items-center gap-2.5">
-          <Image
-            src="/mascot.png"
-            alt=""
-            width={34}
-            height={34}
-            className="rounded-lg"
-            priority
-            unoptimized
-          />
-          <Wordmark />
-        </div>
-        <nav className="flex items-center gap-1 sm:gap-2">
-          <Link
-            href="/pricing"
-            className="rounded-md px-3 py-1.5 text-sm font-medium text-bark transition-colors hover:bg-sage-fill hover:text-ink"
-          >
-            Pricing
-          </Link>
-          <Link
-            href="/login"
-            className="rounded-md border border-sand bg-card px-3.5 py-1.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
-          >
-            Sign in
-          </Link>
-        </nav>
-      </header>
+      <SiteHeader />
 
       <main className="flex flex-1 flex-col items-center px-6">
         {/* Hero */}
@@ -240,23 +157,7 @@ export default function Home() {
         </section>
       </main>
 
-      <footer className="border-t border-sand">
-        <div className="mx-auto flex w-full max-w-3xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-stone sm:flex-row">
-          <Wordmark size="text-sm" />
-          <nav className="flex items-center gap-5">
-            <Link href="/pricing" className="hover:text-ink">
-              Pricing
-            </Link>
-            <Link href="/changelog" className="hover:text-ink">
-              What&rsquo;s new
-            </Link>
-            <Link href="/login" className="hover:text-ink">
-              Sign in
-            </Link>
-          </nav>
-          <span>Local-first. Your meetings never leave your device.</span>
-        </div>
-      </footer>
+      <SiteFooter />
     </div>
   );
 }

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -1,14 +1,16 @@
-import Image from "next/image";
 import Link from "next/link";
-import { AppleLogo, WindowsLogo } from "../logos";
+
+import {
+  buttonPrimary,
+  DoodleStroke,
+  DownloadButtons,
+  navLinkClass,
+  navPillClass,
+  SiteFooter,
+  SiteHeader,
+} from "../ui";
 
 export const metadata = { title: "Pricing — DoodleNote" };
-
-/** Update feed on Vercel Blob — publish-release.mjs uploads these. */
-const DOWNLOADS = {
-  mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.3-arm64-mac.zip",
-  win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.3-setup.exe",
-};
 
 const FREE_FEATURES = [
   "Unlimited meetings and recording — no caps, ever",
@@ -53,168 +55,130 @@ const FAQ = [
   },
 ];
 
+function FeatureList({ items }: { items: string[] }) {
+  return (
+    <ul className="mt-4">
+      {items.map((item) => (
+        <li
+          key={item}
+          className="flex gap-3 border-b border-sand py-3 text-sm leading-relaxed text-bark last:border-b-0"
+        >
+          <span className="mt-0.5 shrink-0 text-sage" aria-hidden="true">
+            ✓
+          </span>
+          {item}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 export default function PricingPage() {
   return (
     <div className="flex flex-1 flex-col bg-cream text-bark">
-      <header className="border-b border-sand bg-card-soft">
-        <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-3">
-          <Link href="/" className="flex items-center gap-2">
-            <Image
-              src="/mascot.png"
-              alt=""
-              width={26}
-              height={26}
-              className="rounded-md"
-            />
-            <span className="text-sm font-bold tracking-tight">
-              <span className="text-ink">Doodle</span>
-              <span className="text-sage">Note</span>
-            </span>
-          </Link>
-          <nav className="flex items-center gap-1 sm:gap-2">
-            <Link
-              href="/changelog"
-              className="hidden rounded-md px-3 py-1.5 text-sm font-medium text-bark transition-colors hover:bg-sage-fill hover:text-ink sm:block"
-            >
+      <SiteHeader
+        nav={
+          <>
+            <Link href="/changelog" className={navLinkClass}>
               What&rsquo;s new
             </Link>
-            <Link
-              href="/login"
-              className="rounded-md border border-sand bg-card px-3.5 py-1.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
-            >
+            <Link href="/login" className={navPillClass}>
               Sign in
             </Link>
-          </nav>
-        </div>
-      </header>
+          </>
+        }
+      />
 
-      <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-6 py-14">
+      <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-6 pb-24 pt-10 sm:pt-16">
         <div className="text-center">
-          <h1 className="text-4xl font-semibold tracking-tight text-ink">
-            Free forever. Pay only for sync.
+          <h1 className="font-display text-4xl font-semibold tracking-tight text-ink">
+            <span className="relative inline-block whitespace-nowrap text-sage-deep">
+              Free
+              <DoodleStroke />
+            </span>{" "}
+            forever. Pay only for sync.
           </h1>
-          <p className="mx-auto mt-4 max-w-xl text-lg leading-relaxed text-bark">
+          <p className="mx-auto mt-5 max-w-xl text-lg leading-relaxed text-bark">
             Everything that runs on your device — recording, transcription, AI
             notes — is free with no meeting caps. Sync is for when you want
             your notes everywhere.
           </p>
         </div>
 
-        <div className="mx-auto mt-12 grid w-full max-w-4xl gap-5 lg:grid-cols-2">
-          {/* Free */}
-          <div className="flex flex-col rounded-2xl border border-sand bg-card p-8">
-            <h2 className="text-lg font-semibold text-ink">Free</h2>
-            <p className="mt-1 text-sm text-stone">
-              The whole notepad, on your device
+        {/* Free */}
+        <section className="mt-16">
+          <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+            <h2 className="font-display text-2xl font-semibold tracking-tight text-ink">
+              Free
+            </h2>
+            <p className="font-display text-2xl font-semibold tracking-tight text-ink">
+              $0{" "}
+              <span className="text-sm font-normal text-stone">forever</span>
             </p>
-            <p className="mt-5 text-4xl font-semibold tracking-tight text-ink">
-              $0
-              <span className="text-base font-normal text-stone"> forever</span>
-            </p>
-            <ul className="mt-6 flex-1 space-y-2.5">
-              {FREE_FEATURES.map((item) => (
-                <li
-                  key={item}
-                  className="flex gap-2.5 text-sm leading-relaxed"
-                >
-                  <span className="mt-0.5 shrink-0 text-sage" aria-hidden="true">
-                    ✓
-                  </span>
-                  {item}
-                </li>
-              ))}
-            </ul>
-            <div className="mt-8 flex flex-col gap-2.5">
-              <a
-                href={DOWNLOADS.mac}
-                className="inline-flex items-center justify-center gap-2 rounded-md bg-ink px-5 py-2.5 text-center text-sm font-medium text-cream transition-opacity hover:opacity-85"
-              >
-                <AppleLogo className="h-4 w-4 -mt-0.5" />
-                Download for macOS
-              </a>
-              <a
-                href={DOWNLOADS.win}
-                className="inline-flex items-center justify-center gap-2 rounded-md border border-sand bg-card px-5 py-2.5 text-center text-sm font-medium text-ink transition-colors hover:bg-sage-fill"
-              >
-                <WindowsLogo className="h-3.5 w-3.5" />
-                Download for Windows (beta)
-              </a>
-            </div>
           </div>
+          <p className="mt-1 text-sm text-stone">
+            The whole notepad, on your device — no account required
+          </p>
+          <FeatureList items={FREE_FEATURES} />
+          <div className="mt-7 flex justify-center sm:justify-start">
+            <DownloadButtons small />
+          </div>
+        </section>
 
-          {/* Sync */}
-          <div className="relative flex flex-col rounded-2xl border-2 border-sage bg-card p-8">
-            <span className="absolute -top-3 right-6 rounded-full bg-sage px-3 py-0.5 text-xs font-semibold text-cream">
-              Early access
-            </span>
-            <h2 className="text-lg font-semibold text-ink">Sync</h2>
-            <p className="mt-1 text-sm text-stone">
-              Your meetings on every device
-            </p>
-            <p className="mt-5 text-4xl font-semibold tracking-tight text-ink">
-              $10
-              <span className="text-base font-normal text-stone">
-                {" "}
+        {/* Sync */}
+        <section className="mt-16">
+          <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+            <h2 className="flex items-baseline gap-2.5 font-display text-2xl font-semibold tracking-tight text-ink">
+              Sync
+              <span className="rounded-full bg-sage-fill px-2.5 py-0.5 text-xs font-medium text-sage-deep">
+                Early access
+              </span>
+            </h2>
+            <p className="font-display text-2xl font-semibold tracking-tight text-ink">
+              $10{" "}
+              <span className="text-sm font-normal text-stone">
                 / user / month
               </span>
             </p>
-            <ul className="mt-6 flex-1 space-y-2.5">
-              {SYNC_FEATURES.map((item) => (
-                <li
-                  key={item}
-                  className="flex gap-2.5 text-sm leading-relaxed"
-                >
-                  <span className="mt-0.5 shrink-0 text-sage" aria-hidden="true">
-                    ✓
-                  </span>
-                  {item}
-                </li>
-              ))}
-            </ul>
-            <div className="mt-8 flex flex-col gap-2.5">
-              <Link
-                href="/login"
-                className="rounded-md bg-sage-deep px-5 py-2.5 text-center text-sm font-medium text-cream transition-opacity hover:opacity-85"
-              >
-                Get started
-              </Link>
-              <p className="text-center text-xs text-stone">
-                Free during early access — billing starts when Sync leaves
-                beta.
-              </p>
-            </div>
           </div>
-        </div>
+          <p className="mt-1 text-sm text-stone">
+            Your meetings on every device
+          </p>
+          <FeatureList items={SYNC_FEATURES} />
+          <div className="mt-7 flex flex-col items-center gap-2 sm:items-start">
+            <Link href="/login" className={buttonPrimary}>
+              Get started
+            </Link>
+            <p className="text-xs text-stone">
+              Free during early access — billing starts when Sync leaves beta.
+            </p>
+          </div>
+        </section>
 
         {/* FAQ */}
-        <section className="mx-auto mt-20 w-full max-w-3xl">
-          <h2 className="text-center text-2xl font-semibold tracking-tight text-ink">
+        <section className="mt-20">
+          <h2 className="font-display text-2xl font-semibold tracking-tight text-ink">
             Questions, answered
           </h2>
-          <div className="mt-8 space-y-4">
+          <dl className="mt-2">
             {FAQ.map((item) => (
               <div
                 key={item.q}
-                className="rounded-xl border border-sand bg-card-soft p-6"
+                className="border-b border-sand py-6 last:border-b-0"
               >
-                <h3 className="text-sm font-semibold text-ink">{item.q}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-bark">
+                <dt className="font-display text-base font-semibold text-ink">
+                  {item.q}
+                </dt>
+                <dd className="mt-2 text-sm leading-relaxed text-bark">
                   {item.a}
-                </p>
+                </dd>
               </div>
             ))}
-          </div>
+          </dl>
         </section>
       </main>
 
-      <footer className="border-t border-sand">
-        <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-6 text-sm text-stone">
-          <Link href="/" className="font-semibold text-sage-deep hover:underline">
-            DoodleNote
-          </Link>
-          <span>Local-first. Your meetings never leave your device.</span>
-        </div>
-      </footer>
+      <SiteFooter />
     </div>
   );
 }

--- a/apps/web/app/share/[token]/page.tsx
+++ b/apps/web/app/share/[token]/page.tsx
@@ -1,29 +1,13 @@
-import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import ReactMarkdown from "react-markdown";
 import { asc, eq, getDb, meetings, notes, transcriptSegments } from "@repo/db";
+
+import { markdownOf, MeetingBody } from "../../meeting-body";
+import { navPillClass, SiteHeader, Wordmark } from "../../ui";
 
 export const metadata = { title: "Shared meeting — DoodleNote" };
 
 const TOKEN_RE = /^[0-9a-f]{32}$/;
-
-function markdownOf(content: unknown): string | null {
-  if (
-    content &&
-    typeof content === "object" &&
-    "markdown" in content &&
-    typeof (content as { markdown: unknown }).markdown === "string"
-  ) {
-    return (content as { markdown: string }).markdown;
-  }
-  return null;
-}
-
-function timestamp(ms: number): string {
-  const total = Math.max(0, Math.round(ms / 1000));
-  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, "0")}`;
-}
 
 /** Public, read-only view of a shared meeting. No auth — the token is the key. */
 export default async function SharePage({
@@ -62,25 +46,23 @@ export default async function SharePage({
 
   return (
     <div className="flex flex-1 flex-col bg-cream text-bark">
-      <header className="border-b border-sand bg-card-soft">
-        <div className="mx-auto flex w-full max-w-3xl items-center justify-between px-6 py-3">
-          <Link href="/" className="flex items-center gap-2">
-            <Image src="/mascot.png" alt="" width={26} height={26} className="rounded-md" />
-            <span className="text-sm font-bold tracking-tight">
-              <span className="text-ink">Doodle</span>
-              <span className="text-sage">Note</span>
-            </span>
+      <SiteHeader
+        nav={
+          <Link href="/" className={navPillClass}>
+            Get DoodleNote
           </Link>
-          <span className="text-xs text-stone">Shared meeting notes</span>
-        </div>
-      </header>
+        }
+      />
 
-      <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-6 py-8">
-        <h1 className="text-2xl font-semibold tracking-tight text-ink">
+      <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-6 pb-20 pt-6">
+        <p className="text-xs font-semibold uppercase tracking-wider text-stone">
+          Shared meeting notes
+        </p>
+        <h1 className="mt-2 font-display text-3xl font-semibold tracking-tight text-ink">
           {meeting.title || "Untitled meeting"}
         </h1>
         {when && (
-          <p className="mt-1 text-sm text-stone">
+          <p className="mt-1.5 text-sm text-stone">
             {when.toLocaleDateString("en-US", {
               weekday: "long",
               month: "long",
@@ -90,47 +72,23 @@ export default async function SharePage({
           </p>
         )}
 
-        {(enhanced ?? raw) ? (
-          <section className="prose-notes mt-6 rounded-xl border border-sand bg-card p-6">
-            <ReactMarkdown>{enhanced ?? raw ?? ""}</ReactMarkdown>
-          </section>
-        ) : (
-          <p className="mt-6 rounded-xl border border-sand bg-card-soft p-6 text-sm text-stone">
-            No notes on this meeting yet.
-          </p>
-        )}
-
-        {segments.length > 0 && (
-          <section className="mt-6">
-            <h2 className="text-base font-semibold text-ink">Transcript</h2>
-            <div className="mt-3 space-y-3 rounded-xl border border-sand bg-card-soft p-5">
-              {segments.map((segment) => (
-                <p key={segment.id} className="text-sm leading-relaxed">
-                  <span
-                    className={
-                      segment.speaker === "You"
-                        ? "font-semibold text-sage-deep"
-                        : "font-semibold text-ink"
-                    }
-                  >
-                    {segment.speaker}
-                  </span>
-                  <span className="ml-2 text-xs text-stone">{timestamp(segment.startMs)}</span>
-                  <span className="mt-0.5 block text-bark">{segment.text}</span>
-                </p>
-              ))}
-            </div>
-          </section>
-        )}
+        <MeetingBody
+          markdown={enhanced ?? raw}
+          segments={segments}
+          emptyText="No notes on this meeting yet."
+        />
       </main>
 
       <footer className="border-t border-sand">
-        <div className="mx-auto w-full max-w-3xl px-6 py-5 text-sm text-stone">
-          Notes taken with{" "}
-          <Link href="/" className="font-semibold text-sage-deep hover:underline">
-            DoodleNote
-          </Link>{" "}
-          — AI meeting notes without the bot.
+        <div className="mx-auto flex w-full max-w-2xl items-center justify-between gap-3 px-6 py-6 text-sm text-stone">
+          <span>
+            Notes taken with{" "}
+            <Link href="/" className="font-medium text-sage-deep hover:underline">
+              DoodleNote
+            </Link>{" "}
+            — AI meeting notes without the bot.
+          </span>
+          <Wordmark size="text-sm" />
         </div>
       </footer>
     </div>

--- a/apps/web/app/ui.tsx
+++ b/apps/web/app/ui.tsx
@@ -1,0 +1,131 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { AppleLogo, WindowsLogo } from "./logos";
+
+/** Update feed on Vercel Blob — publish-release.mjs uploads these. */
+export const DOWNLOADS = {
+  mac: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.4-arm64-mac.zip",
+  win: "https://z4d0oe5bcxlyzvar.public.blob.vercel-storage.com/updates/DoodleNote-0.3.4-setup.exe",
+};
+
+/* Shared control styles — keep every page speaking the same visual language. */
+export const inputClass =
+  "w-full rounded-lg border border-sand bg-card px-3 py-2 text-sm text-ink outline-none placeholder:text-stone focus:border-sage";
+
+export const buttonPrimary =
+  "inline-flex items-center justify-center gap-2 rounded-lg bg-ink px-4 py-2 text-sm font-medium text-cream transition-opacity hover:opacity-85 disabled:opacity-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sage-deep";
+
+export const buttonSecondary =
+  "inline-flex items-center justify-center gap-2 rounded-lg border border-sand bg-card px-4 py-2 text-sm font-medium text-ink transition-colors hover:bg-sage-fill disabled:opacity-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sage-deep";
+
+export const navLinkClass =
+  "rounded-md px-3 py-1.5 text-sm font-medium text-bark transition-colors hover:bg-sage-fill hover:text-ink";
+
+export const navPillClass =
+  "rounded-md border border-sand bg-card px-3.5 py-1.5 text-sm font-medium text-ink transition-colors hover:bg-sage-fill";
+
+export function Wordmark({ size = "text-lg" }: { size?: string }) {
+  return (
+    <span className={`${size} font-display font-bold tracking-tight`}>
+      <span className="text-ink">Doodle</span>
+      <span className="text-sage">Note</span>
+    </span>
+  );
+}
+
+/** Marketing-page header. Pass `nav` to swap the right side per page. */
+export function SiteHeader({ nav }: { nav?: React.ReactNode }) {
+  return (
+    <header className="mx-auto flex w-full max-w-3xl items-center justify-between px-6 py-5">
+      <Link href="/" className="flex items-center gap-2.5">
+        <Image
+          src="/mascot.png"
+          alt=""
+          width={34}
+          height={34}
+          className="rounded-lg"
+          priority
+          unoptimized
+        />
+        <Wordmark />
+      </Link>
+      <nav className="flex items-center gap-1 sm:gap-2">
+        {nav ?? (
+          <>
+            <Link href="/pricing" className={navLinkClass}>
+              Pricing
+            </Link>
+            <Link href="/login" className={navPillClass}>
+              Sign in
+            </Link>
+          </>
+        )}
+      </nav>
+    </header>
+  );
+}
+
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-sand">
+      <div className="mx-auto flex w-full max-w-3xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-stone sm:flex-row">
+        <Wordmark size="text-sm" />
+        <nav className="flex items-center gap-5">
+          <Link href="/pricing" className="hover:text-ink">
+            Pricing
+          </Link>
+          <Link href="/changelog" className="hover:text-ink">
+            What&rsquo;s new
+          </Link>
+          <Link href="/login" className="hover:text-ink">
+            Sign in
+          </Link>
+        </nav>
+        <span>Local-first. Your meetings never leave your device.</span>
+      </div>
+    </footer>
+  );
+}
+
+export function DownloadButtons({ small = false }: { small?: boolean }) {
+  const pad = small ? "px-4 py-2" : "px-5 py-2.5";
+  return (
+    <div className="flex flex-col items-center gap-3 sm:flex-row">
+      <a
+        href={DOWNLOADS.mac}
+        className={`inline-flex items-center justify-center gap-2 rounded-lg bg-ink ${pad} text-sm font-medium text-cream transition-opacity hover:opacity-85 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sage-deep`}
+      >
+        <AppleLogo className="-mt-0.5 h-4 w-4" />
+        Download for macOS
+      </a>
+      <a
+        href={DOWNLOADS.win}
+        className={`inline-flex items-center justify-center gap-2 rounded-lg border border-sand bg-card ${pad} text-sm font-medium text-ink transition-colors hover:bg-sage-fill focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sage-deep`}
+      >
+        <WindowsLogo className="h-3.5 w-3.5" />
+        Windows (beta)
+      </a>
+    </div>
+  );
+}
+
+/** Hand-drawn ink stroke under a headline's key word. */
+export function DoodleStroke() {
+  return (
+    <svg
+      className="doodle-stroke absolute -bottom-2 left-0 h-3 w-full text-sage"
+      viewBox="0 0 300 12"
+      fill="none"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M4 8.5C42 4.5 96 3 150 5c46 1.7 92 2.5 146-1.5"
+        stroke="currentColor"
+        strokeWidth="3.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
Redesigns the entire web front end around a minimal notepad design language.

- Landing page: single quiet column — hero with hand-drawn underline, jot-to-notes demo card, ruled differentiator list, one CTA
- Pricing and changelog: ruled single-column layouts, FAQ rows, timeline with margin dates
- Login, link-device, invite: brand-styled forms and mascot dialog cards (replaces pre-brand neutral styling)
- App dashboard, meeting detail, workspaces, share page: ruled lists, Bricolage display headings, handwritten empty state
- New shared modules ui.tsx (site chrome, buttons, inputs) and meeting-body.tsx (notes + transcript shared by app and share pages)
- Fixes pricing page pointing at stale 0.3.3 download links

Typecheck, lint, and production build all pass; every page verified in light/dark and mobile. Approved by Alec and Sean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)