### PR TITLE
doodlenote.ai domain sweep + rebuilt mac 0.3.4 manifest

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -76,4 +76,4 @@ npmRebuild: false
 # (403 Security Checkpoint) which electron-updater cannot pass.
 publish:
   provider: generic
-  url: https://doodle-note.vercel.app/updates
+  url: https://www.doodlenote.ai/updates

--- a/apps/desktop/src/main/sync-service.ts
+++ b/apps/desktop/src/main/sync-service.ts
@@ -28,7 +28,7 @@ import {
 } from './sync-pull-logic'
 
 /** Cloud base URL; override with DOODLE_SYNC_URL for local web-dev testing. */
-const DEFAULT_BASE_URL = 'https://doodle-note.vercel.app'
+const DEFAULT_BASE_URL = 'https://www.doodlenote.ai'
 
 const LINK_TIMEOUT_MS = 5 * 60_000
 const PUSH_DEBOUNCE_MS = 5_000

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -495,7 +495,7 @@ export default function ModelsView({
               type="button"
               className="settings-version"
               title="See what changed in each version"
-              onClick={() => window.open('https://doodle-note.vercel.app/changelog')}
+              onClick={() => window.open('https://www.doodlenote.ai/changelog')}
             >
               v{detect.appVersion} · What&rsquo;s new
             </button>

--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,8 +1,8 @@
-version: 0.3.3
+version: 0.3.4
 files:
-  - url: DoodleNote-0.3.3-arm64-mac.zip
-    sha512: sK33hkJrsKne2QtzphHs+XUaTWkItXuzRgAK0wAeUYIdbhH80E0UmwVGeVibHL/0qmy9P+UkTZFp2+rBMqZagA==
-    size: 166922877
-path: DoodleNote-0.3.3-arm64-mac.zip
-sha512: sK33hkJrsKne2QtzphHs+XUaTWkItXuzRgAK0wAeUYIdbhH80E0UmwVGeVibHL/0qmy9P+UkTZFp2+rBMqZagA==
-releaseDate: '2026-07-07T18:26:56.015Z'
+  - url: DoodleNote-0.3.4-arm64-mac.zip
+    sha512: R22ZMHCoXlCtZDfGzkskwLIFEzFkynCSZyw4zDk8pfvxr9agZ4+FxT8HwY/4qTUj/60TgJeved1G8I0kcGg+eA==
+    size: 166926029
+path: DoodleNote-0.3.4-arm64-mac.zip
+sha512: R22ZMHCoXlCtZDfGzkskwLIFEzFkynCSZyw4zDk8pfvxr9agZ4+FxT8HwY/4qTUj/60TgJeved1G8I0kcGg+eA==
+releaseDate: '2026-07-07T20:57:55.253Z'


### PR DESCRIPTION
1. **Mac 0.3.4 manifest** for the domain feed — the rebuilt, successfully-notarized mac build is on Blob; this serves its manifest from www.doodlenote.ai/updates (merging this = macs can update to 0.3.4 via the resilient feed).
2. **Domain sweep**: desktop cloud base URL (share links, device link, transcript footers), the Settings changelog link, and the electron-updater feed URL all move to **https://www.doodlenote.ai** (canonical — apex 308s to www). Takes effect in the next desktop build; existing installs keep working via the vercel.app alias, which Vercel maintains indefinitely.

NOT included (sequenced separately to avoid breaking sign-in): the BETTER_AUTH_URL env flip — that happens after the Microsoft/Google OAuth redirect URIs for the new domain are registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)