### PR TITLE
Restore linux to supportedArchitectures (Vercel deploy failure)

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -22,6 +22,7 @@ mac:
   # cross-builds work; each platform ships only its own.
   files:
     - "!**/node_modules/@node-llama-cpp/win-*/**"
+    - "!**/node_modules/@node-llama-cpp/linux-*/**"
     - "!**/node_modules/@node-llama-cpp/mac-x64/**"
     - "!**/node_modules/sherpa-onnx-*/**"
   target:
@@ -57,10 +58,12 @@ win:
   # local note generation); CUDA variants add >500MB for little test value.
   files:
     - "!**/node_modules/@node-llama-cpp/mac-*/**"
+    - "!**/node_modules/@node-llama-cpp/linux-*/**"
     - "!**/node_modules/@node-llama-cpp/win-arm64/**"
     - "!**/node_modules/@node-llama-cpp/win-x64-cuda/**"
     - "!**/node_modules/@node-llama-cpp/win-x64-cuda-ext/**"
     - "!**/node_modules/sherpa-onnx-darwin-*/**"
+    - "!**/node_modules/sherpa-onnx-linux-*/**"
   # Unsigned for now (no Authenticode cert) — SmartScreen will warn on
   # install; testers click "More info → Run anyway".
 nsis:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,11 +14,14 @@ ignoredBuiltDependencies:
 
 # Cross-building the Windows app from macOS: pnpm must also install the
 # win32-x64 platform binaries (sherpa-onnx, node-llama-cpp) so
-# electron-builder can bundle them.
+# electron-builder can bundle them. linux stays in the list for Vercel's
+# build machines — omitting it starved them of platform binaries
+# (lightningcss.linux-x64-gnu) and broke web deploys.
 supportedArchitectures:
   os:
     - darwin
     - win32
+    - linux
   cpu:
     - arm64
     - x64


### PR DESCRIPTION
The PR #30 production deploy failed: `Cannot find module '../lightningcss.linux-x64-gnu.node'`. Root cause: `supportedArchitectures` (added for Windows cross-builds) **replaces** pnpm's current-platform detection — listing only darwin+win32 made Vercel's Linux build machines skip Linux platform binaries. Earlier deploys survived on build cache; this one missed.

Fix: linux back in the os list, and both desktop installer configs exclude the (now locally installed) `@node-llama-cpp/linux-*` / `sherpa-onnx-linux-*` packages so installers don't grow.

Merging this redeploys prod, which also carries: the BETTER_AUTH_URL → doodlenote.ai flip, the mac 0.3.4 manifest for the domain feed, and the domain sweep — all stuck behind the failed deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)