### PR TITLE
Redirect old vercel.app page links to www.doodlenote.ai

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -14,6 +14,23 @@ const nextConfig: NextConfig = {
    * build. Only used as the local dev fallback when DATABASE_URL is unset.
    */
   serverExternalPackages: ["@electric-sql/pglite"],
+  /**
+   * Old links (pre-doodlenote.ai builds, minted share links, the What's-new
+   * link in installed apps) land on the vercel.app alias — bounce PAGE
+   * routes to the branded domain. /api and /updates are excluded on
+   * purpose: installed desktop apps call them with bearer tokens, and
+   * fetch strips Authorization headers on cross-origin redirects.
+   */
+  async redirects() {
+    return [
+      {
+        source: "/:path((?!api/|updates/).*)",
+        has: [{ type: "host" as const, value: "doodle-note.vercel.app" }],
+        destination: "https://www.doodlenote.ai/:path",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Answers "the What's-new link opened a vercel URL": links baked into already-installed apps (and share links minted before the domain flip) carry the vercel.app origin. Page routes on that host now 308 to **www.doodlenote.ai**; `/api` and `/updates` are deliberately excluded (desktop clients send bearer tokens there, and fetch strips Authorization across origins — a redirect would silently break sync for existing installs).

Verified locally with Host-header spoofing: page → 308 to the branded domain; API → 401 in place; updates → 200 in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)