### PR TITLE
Mic input selector + AVCaptureSession mic capture (macOS)

### DIFF
--- a/apps/desktop/src/main/engine-process.ts
+++ b/apps/desktop/src/main/engine-process.ts
@@ -4,6 +4,7 @@ import type { Readable, Writable } from 'node:stream'
 import type {
   EngineCommand,
   EngineEvent,
+  EngineInputDevice,
   EngineSidecarEvent,
   EngineStartOptions
 } from '../shared/engine-events'
@@ -143,6 +144,89 @@ export class EngineProcess {
     }
   }
 
+  /**
+   * Audio input devices, for the renderer's mic picker. Runs the cheap
+   * `engine devices` command (no models, no permissions, returns instantly);
+   * resolves [] on any failure so the picker just hides.
+   */
+  listInputDevices(): Promise<EngineInputDevice[]> {
+    return new Promise((resolve) => {
+      if (!existsSync(this.binaryPath)) {
+        resolve([])
+        return
+      }
+      let child: ReturnType<typeof spawn>
+      try {
+        child = spawn(this.binaryPath, ['devices'], { stdio: ['ignore', 'pipe', 'ignore'] })
+      } catch {
+        resolve([])
+        return
+      }
+      let out = ''
+      let settled = false
+      const finish = (devices: EngineInputDevice[]): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        resolve(devices)
+      }
+      const timeout = setTimeout(() => {
+        child.kill('SIGKILL')
+        finish([])
+      }, 5_000)
+      child.stdout?.setEncoding('utf8')
+      child.stdout?.on('data', (chunk: string) => {
+        out += chunk
+      })
+      child.on('error', () => finish([]))
+      child.on('close', () => {
+        for (const line of out.split('\n')) {
+          try {
+            const parsed = JSON.parse(line) as {
+              event?: string
+              inputs?: Array<{ uid?: string; name?: string; default?: boolean }>
+            }
+            if (parsed.event === 'devices' && Array.isArray(parsed.inputs)) {
+              finish(
+                parsed.inputs
+                  .filter((d) => typeof d.uid === 'string' && typeof d.name === 'string')
+                  .map((d) => ({
+                    uid: d.uid as string,
+                    name: d.name as string,
+                    isDefault: d.default === true
+                  }))
+              )
+              return
+            }
+          } catch {
+            // Not the devices line — keep scanning.
+          }
+        }
+        finish([])
+      })
+    })
+  }
+
+  /**
+   * Point the mic channel at a different input device. Applies live when a
+   * session is running (serve or classic spawn — both parse stdin commands);
+   * otherwise it's a no-op and the next start's opts carry the choice.
+   */
+  setInputDevice(uid: string | null): void {
+    const command = { cmd: 'set-input', uid: uid ?? '' }
+    if (this.serveSessionActive) {
+      this.serveWrite(command)
+      return
+    }
+    const child = this.child
+    if (!child) return
+    try {
+      child.stdin.write(`${JSON.stringify(command)}\n`)
+    } catch {
+      // Session is tearing down — the next start picks up the new device.
+    }
+  }
+
   get running(): boolean {
     return this.child !== null || this.serveSessionActive
   }
@@ -155,7 +239,11 @@ export class EngineProcess {
     if (command === 'live' && this.serveReady && this.serveChild && !this.serveSessionActive) {
       this.serveSessionActive = true
       this.emit({ event: 'started', command, filePath, binaryPath: this.binaryPath })
-      const ok = this.serveWrite({ cmd: 'start', source: opts.source ?? 'both' })
+      const ok = this.serveWrite({
+        cmd: 'start',
+        source: opts.source ?? 'both',
+        inputDevice: opts.inputDevice ?? ''
+      })
       if (ok) return
       this.serveSessionActive = false // fall through to the classic spawn
     }
@@ -188,6 +276,7 @@ export class EngineProcess {
     if (command === 'live') {
       args.push('--source', opts.source ?? 'both')
       args.push('--exit-on-stdin-close')
+      if (opts.inputDevice) args.push('--input-device', opts.inputDevice)
       if (typeof opts.seconds === 'number' && opts.seconds > 0) {
         args.push('--seconds', String(opts.seconds))
       }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -38,9 +38,12 @@ import {
   ENGINE_AUDIO_CHANNEL,
   ENGINE_CAPTURE_ERROR_CHANNEL,
   ENGINE_EVENT_CHANNEL,
+  ENGINE_LIST_DEVICES_CHANNEL,
+  ENGINE_SET_INPUT_CHANNEL,
   ENGINE_START_CHANNEL,
   ENGINE_STOP_CHANNEL,
   type EngineEvent,
+  type EngineInputDevice,
   type EngineStartRequest
 } from '../shared/engine-events'
 
@@ -291,6 +294,17 @@ app.whenReady().then(() => {
   ipcMain.on(ENGINE_STOP_CHANNEL, () => {
     engine.stop()
     micWatcher.setSuppressed(false)
+  })
+
+  // Mic input picker: device list + (mid-session) switching. macOS engine
+  // only — Windows captures in the renderer, which owns device choice there.
+  ipcMain.handle(ENGINE_LIST_DEVICES_CHANNEL, (): Promise<EngineInputDevice[]> => {
+    return engine instanceof EngineProcess ? engine.listInputDevices() : Promise.resolve([])
+  })
+  ipcMain.on(ENGINE_SET_INPUT_CHANNEL, (_event, uid: unknown) => {
+    if (engine instanceof EngineProcess) {
+      engine.setInputDevice(typeof uid === 'string' && uid.length > 0 ? uid : null)
+    }
   })
 
   // Meetings store first: NotesService reads it to gather cross-meeting

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -4,12 +4,15 @@ import {
   ENGINE_CAPTURE_CONTROL_CHANNEL,
   ENGINE_CAPTURE_ERROR_CHANNEL,
   ENGINE_EVENT_CHANNEL,
+  ENGINE_LIST_DEVICES_CHANNEL,
+  ENGINE_SET_INPUT_CHANNEL,
   ENGINE_START_CHANNEL,
   ENGINE_STOP_CHANNEL,
   type EngineCaptureControl,
   type EngineApi,
   type EngineCommand,
   type EngineEvent,
+  type EngineInputDevice,
   type EngineStartOptions,
   type EngineStartRequest
 } from '../shared/engine-events'
@@ -132,6 +135,14 @@ const engineApi: EngineApi = {
 
   stop(): void {
     ipcRenderer.send(ENGINE_STOP_CHANNEL)
+  },
+
+  listInputDevices(): Promise<EngineInputDevice[]> {
+    return ipcRenderer.invoke(ENGINE_LIST_DEVICES_CHANNEL) as Promise<EngineInputDevice[]>
+  },
+
+  setInputDevice(uid: string | null): void {
+    ipcRenderer.send(ENGINE_SET_INPUT_CHANNEL, uid)
   },
 
   onEvent(cb: (event: EngineEvent) => void): () => void {

--- a/apps/desktop/src/renderer/src/MeetingView.tsx
+++ b/apps/desktop/src/renderer/src/MeetingView.tsx
@@ -4,7 +4,12 @@ import StarterKit from '@tiptap/starter-kit'
 import Image from '@tiptap/extension-image'
 import { TaskItem, TaskList } from '@tiptap/extension-list'
 import { Placeholder } from '@tiptap/extensions'
-import type { EngineChannel, EngineEvent, TranscriptSegment } from '../../shared/engine-events'
+import type {
+  EngineChannel,
+  EngineEvent,
+  EngineInputDevice,
+  TranscriptSegment
+} from '../../shared/engine-events'
 import type { FolderRecord } from '../../shared/folders-api'
 import type { MeetingChatEntry, MeetingRecord } from '../../shared/meetings-api'
 import type {
@@ -134,6 +139,23 @@ type EnhanceStatus = 'idle' | 'running' | 'error'
 
 const CHANNEL_SPEAKERS: Record<EngineChannel, string> = { mic: 'You', system: 'Them' }
 
+/** Remembered mic choice ('' = system default input). */
+const INPUT_DEVICE_STORAGE_KEY = 'doodle.inputDeviceUid'
+
+function MicIcon(): React.JSX.Element {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <rect x="9" y="3" width="6" height="11" rx="3" stroke="currentColor" strokeWidth="2" />
+      <path
+        d="M5 11a7 7 0 0 0 14 0M12 18v3"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
 /** Canned question behind the "✉ Write follow up email" chip. */
 const FOLLOW_UP_EMAIL_QUESTION =
   'Write a concise, ready-to-send follow-up email for this meeting: brief recap, decisions made, and action items with owners.'
@@ -200,6 +222,10 @@ export default function MeetingView({
   const [folders, setFolders] = useState<FolderRecord[]>([])
   const [folderId, setFolderId] = useState<string | null>(null)
   const [folderPickerOpen, setFolderPickerOpen] = useState(false)
+  const [inputDevices, setInputDevices] = useState<EngineInputDevice[]>([])
+  const [inputDeviceUid, setInputDeviceUid] = useState<string>(
+    () => window.localStorage.getItem(INPUT_DEVICE_STORAGE_KEY) ?? ''
+  )
 
   const roughMarkdownRef = useRef('')
   const titleValueRef = useRef('')
@@ -567,13 +593,43 @@ export default function MeetingView({
 
   /* ---- actions ---- */
 
+  // Mic picker: [] where unsupported (Windows), which hides the control.
+  // Refreshed when the picker gains focus so plugging in a mic just works.
+  const refreshInputDevices = useCallback(async (): Promise<void> => {
+    try {
+      setInputDevices(await window.engine.listInputDevices())
+    } catch {
+      setInputDevices([])
+    }
+  }, [])
+
+  useEffect(() => {
+    void refreshInputDevices()
+  }, [refreshInputDevices])
+
+  const changeInputDevice = (uid: string): void => {
+    setInputDeviceUid(uid)
+    if (uid) window.localStorage.setItem(INPUT_DEVICE_STORAGE_KEY, uid)
+    else window.localStorage.removeItem(INPUT_DEVICE_STORAGE_KEY)
+    // Mid-recording the engine swaps the capture under the live session.
+    if (ACTIVE_PHASES.includes(stateRef.current.phase)) {
+      window.engine.setInputDevice(uid || null)
+    }
+  }
+
   const startRecording = (): void => {
     if (capturing) return
     if (startedAtRef.current === null) {
       startedAtRef.current = new Date().toISOString()
       persist({ startedAt: startedAtRef.current })
     }
-    window.engine.start('live', undefined, { source: 'both' })
+    // Only pin a remembered device that still exists — a stale UID (unplugged
+    // since last time) records from the system default instead.
+    const pinned =
+      inputDeviceUid && inputDevices.some((d) => d.uid === inputDeviceUid)
+        ? inputDeviceUid
+        : undefined
+    window.engine.start('live', undefined, { source: 'both', inputDevice: pinned })
   }
 
   const stopRecording = (): void => window.engine.stop()
@@ -1220,6 +1276,35 @@ export default function MeetingView({
             </>
           )}
         </div>
+
+        {inputDevices.length > 0 && (
+          <label className="mic-pill" title="Microphone input">
+            <MicIcon />
+            <select
+              className="mic-select"
+              aria-label="Microphone input"
+              value={
+                inputDeviceUid && inputDevices.some((d) => d.uid === inputDeviceUid)
+                  ? inputDeviceUid
+                  : ''
+              }
+              onChange={(e) => changeInputDevice(e.target.value)}
+              onFocus={() => void refreshInputDevices()}
+            >
+              <option value="">
+                Default{(() => {
+                  const def = inputDevices.find((d) => d.isDefault)
+                  return def ? ` — ${def.name}` : ''
+                })()}
+              </option>
+              {inputDevices.map((device) => (
+                <option key={device.uid} value={device.uid}>
+                  {device.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
 
         <form
           className="ask-bar"

--- a/apps/desktop/src/renderer/src/MeetingView.tsx
+++ b/apps/desktop/src/renderer/src/MeetingView.tsx
@@ -604,8 +604,17 @@ export default function MeetingView({
   }, [])
 
   useEffect(() => {
-    void refreshInputDevices()
-  }, [refreshInputDevices])
+    let cancelled = false
+    window.engine
+      .listInputDevices()
+      .then((devices) => {
+        if (!cancelled) setInputDevices(devices)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const changeInputDevice = (uid: string): void => {
     setInputDeviceUid(uid)

--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -1406,6 +1406,38 @@ button.fp-row:hover {
   box-shadow: var(--shadow-pill);
 }
 
+.mic-pill {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 8px 12px;
+  box-shadow: var(--shadow-pill);
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.mic-pill:hover {
+  color: var(--ink);
+}
+
+.mic-select {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--ink);
+  font-size: 12px;
+  max-width: 150px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+  outline: none;
+}
+
 .record-btn {
   display: flex;
   align-items: center;

--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -1414,7 +1414,9 @@ button.fp-row:hover {
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 999px;
-  padding: 8px 12px;
+  /* Same height as .rec-pill and .ask-bar — the three sit on one row. */
+  min-height: 46px;
+  padding: 5px 14px;
   box-shadow: var(--shadow-pill);
   color: var(--muted);
   cursor: pointer;

--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -1402,6 +1402,9 @@ button.fp-row:hover {
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 999px;
+  /* Hold the idle height while recording too — the timer/stop controls are
+     shorter than the record button, and the bar's pills sit on one row. */
+  min-height: 46px;
   padding: 5px 6px;
   box-shadow: var(--shadow-pill);
 }

--- a/apps/desktop/src/shared/engine-events.ts
+++ b/apps/desktop/src/shared/engine-events.ts
@@ -21,6 +21,18 @@ export interface EngineCaptureControl {
 export const ENGINE_EVENT_CHANNEL = 'engine:event'
 export const ENGINE_START_CHANNEL = 'engine:start'
 export const ENGINE_STOP_CHANNEL = 'engine:stop'
+/** renderer → main (invoke): list audio input devices (macOS engine). */
+export const ENGINE_LIST_DEVICES_CHANNEL = 'engine:list-devices'
+/** renderer → main: switch the mic channel's input device (mid-session too). */
+export const ENGINE_SET_INPUT_CHANNEL = 'engine:set-input'
+
+/** One selectable audio input device (macOS: CoreAudio UID + name). */
+export interface EngineInputDevice {
+  uid: string
+  name: string
+  /** True for the current system default input. */
+  isDefault: boolean
+}
 
 export type EngineCommand = 'stream' | 'transcribe' | 'live'
 
@@ -35,6 +47,8 @@ export interface EngineStartOptions {
   source?: 'mic' | 'system' | 'both'
   /** live only: auto-stop after N seconds (dev/testing) */
   seconds?: number
+  /** live only (macOS): CoreAudio UID of the mic to record from; omit = system default. */
+  inputDevice?: string
 }
 
 export interface EngineStartRequest {
@@ -203,6 +217,10 @@ export interface EngineApi {
   start(command: EngineCommand, filePath?: string, opts?: EngineStartOptions): void
   stop(): void
   onEvent(cb: (event: EngineEvent) => void): () => void
+  /** Audio input devices for the mic picker; [] where unsupported (Windows). */
+  listInputDevices(): Promise<EngineInputDevice[]>
+  /** Switch the mic input; applies live when a session is recording. null = system default. */
+  setInputDevice(uid: string | null): void
   /** Windows capture bridge (no-ops on macOS). */
   onCaptureControl(cb: (control: EngineCaptureControl) => void): () => void
   sendAudio(channel: string, samples: Float32Array): void

--- a/engine/README.md
+++ b/engine/README.md
@@ -26,12 +26,24 @@ engine stream --file meeting.wav [--realtime]
     Feeds a file through the live streaming engine (Parakeet Unified) in
     0.25s chunks — same code path as live capture. Emits growing partials.
 
-engine live [--source mic|system|both] [--seconds N] [--aec off]
+engine live [--source mic|system|both] [--seconds N] [--aec off] [--input-device <uid>]
     Live two-channel capture + transcription:
       mic    → "You"   (AVAudioEngine input tap)
       system → "Them"  (ScreenCaptureKit system audio — the other side of the call)
     Runs until --seconds or SIGINT/SIGTERM. Speaker separation between you and
     the far side comes from the capture topology, not diarization.
+
+    --input-device pins the mic channel to a CoreAudio device UID (from
+    `engine devices`); omitted = system default input. A pinned device that
+    fails to start or delivers no audio falls back to the default rather than
+    recording silence. With --exit-on-stdin-close, stdin lines are commands:
+    {"cmd":"set-input","uid":"…"} switches the mic mid-session ("" = default),
+    {"cmd":"stop"} ends the session. The serve mode accepts the same
+    "inputDevice" on start and the same "set-input" command.
+
+engine devices
+    Lists audio input devices as one NDJSON event and exits immediately:
+    {"event":"devices","inputs":[{"uid":"…","name":"MacBook Pro Microphone","default":true},…]}
 
     Echo isolation: when the call plays through speakers, the mic physically
     hears the far side. Apple's Voice Processing I/O (the FaceTime echo

--- a/engine/Sources/engine/AudioDevices.swift
+++ b/engine/Sources/engine/AudioDevices.swift
@@ -1,0 +1,158 @@
+import CoreAudio
+import Foundation
+
+/// CoreAudio input-device enumeration and UID resolution. The mic channel
+/// records from the system default input unless a session pins a device UID
+/// (`--input-device` / the serve `start`/`set-input` commands).
+enum AudioInputDevices {
+    struct Device {
+        let id: AudioDeviceID
+        let uid: String
+        let name: String
+        let isDefault: Bool
+    }
+
+    static func list() -> [Device] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size: UInt32 = 0
+        guard
+            AudioObjectGetPropertyDataSize(
+                AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size) == noErr,
+            size > 0
+        else { return [] }
+        var ids = [AudioDeviceID](repeating: 0, count: Int(size) / MemoryLayout<AudioDeviceID>.size)
+        guard
+            AudioObjectGetPropertyData(
+                AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &ids) == noErr
+        else { return [] }
+
+        let defaultID = defaultInputDeviceID()
+        return ids.compactMap { id in
+            guard inputChannelCount(id) > 0 else { return nil }
+            guard let uid = stringProperty(id, selector: kAudioDevicePropertyDeviceUID) else { return nil }
+            let name = stringProperty(id, selector: kAudioObjectPropertyName) ?? uid
+            return Device(id: id, uid: uid, name: name, isDefault: id == defaultID)
+        }
+    }
+
+    static func deviceID(forUID uid: String) -> AudioDeviceID? {
+        list().first { $0.uid == uid }?.id
+    }
+
+    static func defaultInputDeviceID() -> AudioDeviceID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var id = AudioDeviceID(0)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &id)
+        guard status == noErr, id != 0 else { return nil }
+        return id
+    }
+
+    private static func inputChannelCount(_ id: AudioDeviceID) -> Int {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(id, &address, 0, nil, &size) == noErr, size > 0 else {
+            return 0
+        }
+        let raw = UnsafeMutableRawPointer.allocate(
+            byteCount: Int(size), alignment: MemoryLayout<AudioBufferList>.alignment)
+        defer { raw.deallocate() }
+        guard AudioObjectGetPropertyData(id, &address, 0, nil, &size, raw) == noErr else { return 0 }
+        let buffers = UnsafeMutableAudioBufferListPointer(
+            raw.assumingMemoryBound(to: AudioBufferList.self))
+        return buffers.reduce(0) { $0 + Int($1.mNumberChannels) }
+    }
+
+    private static func stringProperty(
+        _ id: AudioDeviceID, selector: AudioObjectPropertySelector
+    ) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var value: Unmanaged<CFString>?
+        var size = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        let status = withUnsafeMutablePointer(to: &value) { pointer in
+            AudioObjectGetPropertyData(id, &address, 0, nil, &size, pointer)
+        }
+        guard status == noErr, let cf = value?.takeRetainedValue() else { return nil }
+        return cf as String
+    }
+}
+
+/// `engine devices` — list audio input devices as one NDJSON event and exit.
+/// No models, no permissions, returns in milliseconds; hosts call it to
+/// populate their input-device picker.
+enum DevicesCommand {
+    static func run() {
+        let inputs = AudioInputDevices.list().map { device in
+            ["uid": device.uid, "name": device.name, "default": device.isDefault] as [String: Any]
+        }
+        Events.emit(["event": "devices", "inputs": inputs])
+    }
+}
+
+/// Live mic-switch bridge: the active session registers a handler; stdin
+/// command loops (`live` and `serve`) invoke it when the host asks to move
+/// the mic channel to a different input device mid-recording.
+final class MicController: @unchecked Sendable {
+    static let shared = MicController()
+
+    private let lock = NSLock()
+    private var handler: ((String?) -> Void)?
+
+    /// Session start passes its switch closure; session end passes nil.
+    func register(_ newHandler: ((String?) -> Void)?) {
+        lock.lock()
+        handler = newHandler
+        lock.unlock()
+    }
+
+    /// nil / empty UID = system default input.
+    func switchInput(toUID uid: String?) {
+        lock.lock()
+        let current = handler
+        lock.unlock()
+        guard let current else {
+            Events.log("set-input ignored: no active session")
+            return
+        }
+        let normalized = (uid?.isEmpty ?? true) ? nil : uid
+        current(normalized)
+    }
+}
+
+/// Thread-safe holder for the session's current MicCapture — the watchdog and
+/// the mid-session switch handler both replace it.
+final class MicCaptureBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var capture: MicCapture?
+
+    func swap(_ next: MicCapture?) -> MicCapture? {
+        lock.lock()
+        defer { lock.unlock() }
+        let previous = capture
+        capture = next
+        return previous
+    }
+
+    func current() -> MicCapture? {
+        lock.lock()
+        defer { lock.unlock() }
+        return capture
+    }
+}

--- a/engine/Sources/engine/EngineMain.swift
+++ b/engine/Sources/engine/EngineMain.swift
@@ -26,6 +26,8 @@ struct EngineMain {
                 MicMonitorCommand.run()
             case "serve":
                 try await ServeCommand.run(options)
+            case "devices":
+                DevicesCommand.run()
             case "info":
                 Commands.info()
             default:

--- a/engine/Sources/engine/LiveCommand.swift
+++ b/engine/Sources/engine/LiveCommand.swift
@@ -1,4 +1,6 @@
 import AVFoundation
+import AudioToolbox
+import CoreAudio
 import CoreMedia
 import FluidAudio
 import Foundation
@@ -27,12 +29,21 @@ enum LiveCommand {
         // Opt-in parent-death watchdog: hosts that spawn us with a live stdin
         // pipe pass this flag; when the pipe closes (host crashed/restarted),
         // stop gracefully instead of recording forever as an orphan. Opt-in
-        // because a /dev/null stdin reads EOF immediately.
+        // because a /dev/null stdin reads EOF immediately. Lines that arrive
+        // before EOF are commands: {"cmd":"set-input","uid":…} switches the
+        // mic device mid-session; {"cmd":"stop"} ends the session.
         if options.flags.contains("exit-on-stdin-close") {
             Thread {
+                var buffer = Data()
                 while true {
-                    let data = FileHandle.standardInput.availableData
-                    if data.isEmpty { break }  // EOF — host is gone
+                    let chunk = FileHandle.standardInput.availableData
+                    if chunk.isEmpty { break }  // EOF — host is gone
+                    buffer.append(chunk)
+                    while let newline = buffer.firstIndex(of: 0x0A) {
+                        let lineData = buffer.subdata(in: buffer.startIndex..<newline)
+                        buffer.removeSubrange(buffer.startIndex...newline)
+                        LiveCommand.handleStdinCommand(lineData)
+                    }
                 }
                 Events.log("stdin closed — host process gone; finishing session")
                 StopController.shared.stop()
@@ -43,10 +54,26 @@ enum LiveCommand {
             source: options.values["source"] ?? "both",
             aec: options.values["aec"] == "on",
             seconds: options.values["seconds"].flatMap(Double.init),
+            inputDevice: options.values["input-device"],
             micManager: nil,
             systemManager: nil,
             stopper: stopper
         )
+    }
+
+    private static func handleStdinCommand(_ lineData: Data) {
+        guard
+            let object = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+            let cmd = object["cmd"] as? String
+        else { return }
+        switch cmd {
+        case "set-input":
+            MicController.shared.switchInput(toUID: object["uid"] as? String)
+        case "stop":
+            StopController.shared.stop()
+        default:
+            Events.log("live: unknown stdin command \(cmd)")
+        }
     }
 }
 
@@ -59,6 +86,7 @@ enum LiveSession {
         source: String,
         aec: Bool,
         seconds: Double?,
+        inputDevice: String? = nil,
         micManager: StreamingUnifiedAsrManager?,
         systemManager: StreamingUnifiedAsrManager?,
         stopper: Stopper
@@ -78,7 +106,7 @@ enum LiveSession {
         if wantMic { micPipeline = ChannelPipeline(channel: "mic", manager: micManager) }
         if wantSystem { systemPipeline = ChannelPipeline(channel: "system", manager: systemManager) }
 
-        var micCapture: MicCapture?
+        let micBox = MicCaptureBox()
         var systemCapture: SystemAudioCapture?
 
         if let pipeline = systemPipeline {
@@ -104,10 +132,50 @@ enum LiveSession {
             // initialize on some setups, and its teardown/retry can leave the
             // fallback mic silently dead. Cross-channel transcript dedup
             // handles speaker echo, so reliability wins by default.
-            micCapture = MicCapture(into: pipeline, enableAEC: aec)
+            _ = micBox.swap(MicCapture(into: pipeline, enableAEC: aec, deviceUID: inputDevice))
+
+            // Host-driven mid-session mic switch ({"cmd":"set-input"} on stdin):
+            // swap the capture under the same pipeline; the transcript keeps
+            // flowing and the session never restarts.
+            MicController.shared.register { uid in
+                let old = micBox.swap(nil)
+                old?.stop()
+                let next = MicCapture(into: pipeline, enableAEC: false, deviceUID: uid)
+                do {
+                    try next.start()
+                    _ = micBox.swap(next)
+                    Events.emit([
+                        "event": "status", "stage": "input_switched", "channel": "mic",
+                        "device": uid ?? "default",
+                    ])
+                } catch {
+                    Events.emit([
+                        "event": "error", "channel": "mic",
+                        "message":
+                            "Could not switch to that microphone (\(error)). Recording continues on the previous input.",
+                    ])
+                    // Best effort: bring the previous device back so the mic
+                    // channel doesn't go silent because a switch failed.
+                    let revert = MicCapture(into: pipeline, enableAEC: false, deviceUID: old?.deviceUID)
+                    if (try? revert.start()) != nil { _ = micBox.swap(revert) }
+                }
+            }
         }
 
-        try micCapture?.start()
+        // A pinned device that fails to start (unplugged since it was chosen)
+        // must not kill the session — fall back to the system default input.
+        if let capture = micBox.current(), let pipeline = micPipeline {
+            do {
+                try capture.start()
+            } catch where inputDevice != nil {
+                Events.log("pinned input failed to start (\(error)) — using the default input")
+                Events.emit(["event": "status", "stage": "input_default_fallback", "channel": "mic"])
+                micBox.swap(nil)?.stop()
+                let fallback = MicCapture(into: pipeline, enableAEC: false, deviceUID: nil)
+                try fallback.start()
+                _ = micBox.swap(fallback)
+            }
+        }
         try await systemCapture?.start()
 
         // Capturing now — tell the host immediately (bars animate, timer runs).
@@ -117,19 +185,20 @@ enum LiveSession {
 
         // Dead-capture watchdog: a live mic delivers buffers continuously even
         // in silence, so zero buffers means the capture is dead — restart it
-        // once, then say so loudly. A fake recording session is the worst bug
-        // a meeting app can have.
+        // once (same device), then once more on the system default if a pinned
+        // device stays silent, then say so loudly. A fake recording session is
+        // the worst bug a meeting app can have.
         if wantMic, let pipeline = micPipeline {
-            let originalCapture = micCapture
             Task {
                 try? await Task.sleep(nanoseconds: 3_000_000_000)
                 guard !pipeline.hasProducedAudio else { return }
                 Events.log("mic produced no audio after 3s — restarting capture")
                 Events.emit(["event": "status", "stage": "mic_restarting", "channel": "mic"])
-                originalCapture?.stop()
-                let retry = MicCapture(into: pipeline, enableAEC: false)
+                micBox.swap(nil)?.stop()
+                let retry = MicCapture(into: pipeline, enableAEC: false, deviceUID: inputDevice)
                 do {
                     try retry.start()
+                    _ = micBox.swap(retry)
                 } catch {
                     Events.emit([
                         "event": "error", "channel": "mic",
@@ -139,13 +208,24 @@ enum LiveSession {
                     return
                 }
                 try? await Task.sleep(nanoseconds: 3_000_000_000)
-                if !pipeline.hasProducedAudio {
-                    Events.emit([
-                        "event": "error", "channel": "mic",
-                        "message": "Microphone is not delivering audio — check System Settings → "
-                            + "Sound → Input, then stop and re-record.",
-                    ])
+                guard !pipeline.hasProducedAudio else { return }
+                // A pinned device that never delivers gets one more chance on
+                // the system default — silently recording nothing loses the
+                // meeting; a device change mid-meeting does not.
+                if inputDevice != nil {
+                    Events.log("pinned input silent after restart — falling back to the default input")
+                    Events.emit(["event": "status", "stage": "input_default_fallback", "channel": "mic"])
+                    micBox.swap(nil)?.stop()
+                    let fallback = MicCapture(into: pipeline, enableAEC: false, deviceUID: nil)
+                    if (try? fallback.start()) != nil { _ = micBox.swap(fallback) }
+                    try? await Task.sleep(nanoseconds: 3_000_000_000)
+                    guard !pipeline.hasProducedAudio else { return }
                 }
+                Events.emit([
+                    "event": "error", "channel": "mic",
+                    "message": "Microphone is not delivering audio — check System Settings → "
+                        + "Sound → Input, then stop and re-record.",
+                ])
             }
         }
 
@@ -161,7 +241,8 @@ enum LiveSession {
         await stopper.wait(timeoutSeconds: seconds)
         Events.emit(["event": "status", "stage": "finishing"])
 
-        micCapture?.stop()
+        MicController.shared.register(nil)
+        micBox.swap(nil)?.stop()
         await systemCapture?.stop()
         await micPipeline?.finish()
         await systemPipeline?.finish()
@@ -273,24 +354,37 @@ final class ChannelPipeline {
 
 // MARK: - Microphone capture
 
-final class MicCapture {
+final class MicCapture: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate {
     private var engine = AVAudioEngine()
     private let pipeline: ChannelPipeline
     private let enableAEC: Bool
+    /// CoreAudio device UID to record from; nil = system default input.
+    let deviceUID: String?
 
-    init(into pipeline: ChannelPipeline, enableAEC: Bool) {
+    /* Non-AEC path: AVCaptureSession — the API built for explicit device
+       selection. AVAudioEngine's input node fundamentally tracks the system
+       default device; pinning it via AUAudioUnit.setDeviceID reports the right
+       format but never delivers buffers (and re-starts fail with -10868). */
+    private var captureSession: AVCaptureSession?
+    private let captureQueue = DispatchQueue(label: "engine.mic-audio")
+    private let converter = AudioConverter()
+
+    init(into pipeline: ChannelPipeline, enableAEC: Bool, deviceUID: String? = nil) {
         self.pipeline = pipeline
         self.enableAEC = enableAEC
+        self.deviceUID = deviceUID
+        super.init()
     }
 
     func start() throws {
         // Acoustic echo cancellation (Apple's Voice Processing I/O — the FaceTime
         // AEC) subtracts whatever the Mac plays through its speakers from the mic
-        // signal. If it fails for any reason, capture must survive: fall back to
-        // the raw mic (far-side bleed returns, but the meeting is still recorded).
+        // signal. It rides AVAudioEngine and therefore the system default input;
+        // if it fails for any reason, capture must survive: fall back to the raw
+        // mic (far-side bleed returns, but the meeting is still recorded).
         if enableAEC {
             do {
-                try startEngine(withAEC: true)
+                try startEngineWithAEC()
                 Events.emit(["event": "status", "stage": "aec_enabled", "channel": "mic"])
                 return
             } catch {
@@ -305,33 +399,86 @@ final class MicCapture {
             }
         }
         do {
-            try startEngine(withAEC: false)
+            try startCaptureSession()
         } catch {
             throw EngineError.internalError(
-                "Microphone capture failed even without echo cancellation "
+                "Microphone capture failed "
                     + "(check the input device in System Settings → Sound): \(error)"
             )
         }
     }
 
-    private func startEngine(withAEC aec: Bool) throws {
-        let input = engine.inputNode
-        if aec {
-            // macOS requires the SAME voice-processing mode on BOTH I/O nodes of
-            // an engine — enabling only the input side fails at kAUInitialize.
-            try input.setVoiceProcessingEnabled(true)
-            try engine.outputNode.setVoiceProcessingEnabled(true)
-            if #available(macOS 14.0, *) {
-                // Don't let voice processing lower the meeting audio the user is hearing.
-                input.voiceProcessingOtherAudioDuckingConfiguration =
-                    AVAudioVoiceProcessingOtherAudioDuckingConfiguration(
-                        enableAdvancedDucking: false,
-                        duckingLevel: .min
-                    )
+    private func startCaptureSession() throws {
+        let device: AVCaptureDevice?
+        if let uid = deviceUID {
+            // AVCaptureDevice uniqueID == CoreAudio device UID on macOS.
+            device = AVCaptureDevice(uniqueID: uid)
+            guard device != nil else {
+                throw EngineError.internalError("input device not found: \(uid)")
             }
-            // VPIO is a full-duplex unit; give the engine a live-but-silent output pair.
-            engine.mainMixerNode.outputVolume = 0
+        } else {
+            device = AVCaptureDevice.default(for: .audio)
         }
+        guard let device else {
+            throw EngineError.internalError("no microphone input available")
+        }
+        Events.log("mic capture starting: device=\(device.localizedName) [\(device.uniqueID)]")
+
+        let session = AVCaptureSession()
+        let input = try AVCaptureDeviceInput(device: device)
+        guard session.canAddInput(input) else {
+            throw EngineError.internalError("cannot capture from \(device.localizedName)")
+        }
+        session.addInput(input)
+
+        let output = AVCaptureAudioDataOutput()
+        // Deliver what the ASR managers eat directly: 16kHz mono float PCM —
+        // the same shape the ScreenCaptureKit system channel is configured for.
+        output.audioSettings = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: AudioSupport.sampleRate,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsFloatKey: true,
+            AVLinearPCMIsNonInterleaved: false,
+        ]
+        output.setSampleBufferDelegate(self, queue: captureQueue)
+        guard session.canAddOutput(output) else {
+            throw EngineError.internalError("cannot read audio from \(device.localizedName)")
+        }
+        session.addOutput(output)
+
+        session.startRunning()
+        captureSession = session
+    }
+
+    func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        // extractAVAudioPCMBuffer allocates a fresh buffer — safe to queue as-is.
+        if let pcm = try? converter.extractAVAudioPCMBuffer(from: sampleBuffer) {
+            pipeline.ingest(pcm)
+        }
+    }
+
+    private func startEngineWithAEC() throws {
+        let input = engine.inputNode
+        // macOS requires the SAME voice-processing mode on BOTH I/O nodes of
+        // an engine — enabling only the input side fails at kAUInitialize.
+        try input.setVoiceProcessingEnabled(true)
+        try engine.outputNode.setVoiceProcessingEnabled(true)
+        if #available(macOS 14.0, *) {
+            // Don't let voice processing lower the meeting audio the user is hearing.
+            input.voiceProcessingOtherAudioDuckingConfiguration =
+                AVAudioVoiceProcessingOtherAudioDuckingConfiguration(
+                    enableAdvancedDucking: false,
+                    duckingLevel: .min
+                )
+        }
+        // VPIO is a full-duplex unit; give the engine a live-but-silent output pair.
+        engine.mainMixerNode.outputVolume = 0
 
         // Query the format AFTER voice-processing setup — it changes the I/O format.
         let format = input.outputFormat(forBus: 0)
@@ -349,8 +496,14 @@ final class MicCapture {
     }
 
     func stop() {
-        engine.inputNode.removeTap(onBus: 0)
-        engine.stop()
+        if let session = captureSession {
+            session.stopRunning()
+            captureSession = nil
+        }
+        if enableAEC {
+            engine.inputNode.removeTap(onBus: 0)
+            engine.stop()
+        }
     }
 }
 

--- a/engine/Sources/engine/ServeCommand.swift
+++ b/engine/Sources/engine/ServeCommand.swift
@@ -42,12 +42,14 @@ enum ServeCommand {
                 let stopper = Stopper()
                 let source = object["source"] as? String ?? "both"
                 let aec = (object["aec"] as? String) == "on"
+                let inputDevice = (object["inputDevice"] as? String).flatMap { $0.isEmpty ? nil : $0 }
                 let started = box.begin(stopper) {
                     do {
                         try await LiveSession.run(
                             source: source,
                             aec: aec,
                             seconds: nil,
+                            inputDevice: inputDevice,
                             micManager: micManager,
                             systemManager: systemManager,
                             stopper: stopper
@@ -65,6 +67,9 @@ enum ServeCommand {
                 }
             case "stop":
                 box.stop()
+            case "set-input":
+                // Mid-session mic switch; ignored (with a log) when idle.
+                MicController.shared.switchInput(toUID: object["uid"] as? String)
             default:
                 Events.log("serve: unknown command \(cmd)")
             }


### PR DESCRIPTION
Alec's mic-selector patch (from `alec-dev`), reviewed and prod-readied — merged with current main plus one lint fix.

## What it adds
- **Mic picker pill** in the meeting bottom bar (macOS only — hides itself on Windows where the renderer owns capture): choose any input device, remembered across sessions, refreshed on focus so newly-plugged mics appear.
- **Mid-recording switching**: changing the mic swaps the capture under the live session — transcript keeps flowing, no restart.
- **Engine `devices` command**: instant CoreAudio input enumeration as NDJSON.
- **AVCaptureSession mic capture** (non-AEC path): the API built for device selection; AVAudioEngine fundamentally tracks the system default (pinning reports the right format but never delivers buffers). Output configured to 16k mono float directly.

## Review findings (all positive or fixed)
- Dead-mic watchdog **preserved and strengthened**: silent pinned device → retry same device → fall back to system default → loud error. Unplugged remembered devices are guarded in the renderer AND the engine.
- Mid-session switch reverts to the previous device on failure; stdin command loop keeps the parent-death EOF watchdog intact.
- IPC follows house conventions (channel consts, typed API, `instanceof EngineProcess` platform gate).
- One fix applied: initial device fetch rewritten to the `.then` effect pattern (strict react-hooks rule flagged the original).

## Verification (real hardware)
- `engine devices` → correct 4-device list with default flagged
- 4s live session with `--input-device BuiltInMicrophoneDevice` → permission → capture → **real speech transcribed** → clean finish
- Swift release build clean; desktop typecheck clean; 61 tests pass; no new lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)