### PR TITLE
Release 0.3.5 (mac only)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "description": "Doodle Note desktop app \u2014 spawns the Swift transcription sidecar and shows its live transcript stream",
   "main": "./out/main/index.js",

--- a/apps/desktop/scripts/publish-release.mjs
+++ b/apps/desktop/scripts/publish-release.mjs
@@ -1,7 +1,7 @@
 // Upload the packaged update artifacts to the Blob-hosted feed.
 // Requires BLOB_READ_WRITE_TOKEN (repo-root .env.local has it in dev).
 import { put } from '@vercel/blob'
-import { copyFileSync, createReadStream, mkdirSync, readdirSync, statSync } from 'node:fs'
+import { copyFileSync, createReadStream, mkdirSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -30,10 +30,18 @@ if (!process.env.BLOB_READ_WRITE_TOKEN) {
 const flags = process.argv.slice(2)
 const wantMac = flags.includes('--mac') || !flags.includes('--win')
 const wantWin = flags.includes('--win') || !flags.includes('--mac')
+// Only the CURRENT version's artifacts upload — older ones are already on
+// the feed and immutable. (Re-uploading history burned ~600MB per release
+// and tripped a stream-reuse bug in the upload client's retry path.)
+const { version } = JSON.parse(
+  readFileSync(path.join(here, '..', 'package.json'), 'utf8')
+)
 const isMacArtifact = (name) =>
-  name === 'latest-mac.yml' || (name.endsWith('.zip') && name.includes('mac'))
+  name === 'latest-mac.yml' ||
+  (name.endsWith('.zip') && name.includes('mac') && name.includes(version))
 const isWinArtifact = (name) =>
-  name === 'latest.yml' || name.endsWith('.exe') || name.endsWith('.exe.blockmap')
+  name === 'latest.yml' ||
+  ((name.endsWith('.exe') || name.endsWith('.exe.blockmap')) && name.includes(version))
 const artifacts = readdirSync(releaseDir).filter(
   (name) => (wantMac && isMacArtifact(name)) || (wantWin && isWinArtifact(name))
 )

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,15 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.3.5",
+    date: "July 7, 2026",
+    highlights: [
+      "Mac: microphone picker in the meeting bar \u2014 choose any input device, switch mid-recording, and DoodleNote falls back to the default mic if your chosen one goes silent (thanks Alec!)",
+      "Mac only for now \u2014 Windows stays on 0.3.4 until the next cross-platform release",
+      "All in-app links now point at doodlenote.ai",
+    ],
+  },
+  {
     version: "0.3.4",
     date: "July 7, 2026",
     highlights: [

--- a/apps/web/app/ui.tsx
+++ b/apps/web/app/ui.tsx
@@ -5,7 +5,7 @@ import { AppleLogo, WindowsLogo } from "./logos";
 
 /** Update feed on Vercel Blob — publish-release.mjs uploads these. */
 export const DOWNLOADS = {
-  mac: "/updates/DoodleNote-0.3.4-arm64-mac.zip",
+  mac: "/updates/DoodleNote-0.3.5-arm64-mac.zip",
   win: "/updates/DoodleNote-0.3.4-setup.exe",
 };
 

--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,8 +1,8 @@
-version: 0.3.4
+version: 0.3.5
 files:
-  - url: DoodleNote-0.3.4-arm64-mac.zip
-    sha512: R22ZMHCoXlCtZDfGzkskwLIFEzFkynCSZyw4zDk8pfvxr9agZ4+FxT8HwY/4qTUj/60TgJeved1G8I0kcGg+eA==
-    size: 166926029
-path: DoodleNote-0.3.4-arm64-mac.zip
-sha512: R22ZMHCoXlCtZDfGzkskwLIFEzFkynCSZyw4zDk8pfvxr9agZ4+FxT8HwY/4qTUj/60TgJeved1G8I0kcGg+eA==
-releaseDate: '2026-07-07T20:57:55.253Z'
+  - url: DoodleNote-0.3.5-arm64-mac.zip
+    sha512: fj1/TzN7NJHjEXWgFn7Rro9BB3gcIUK23mS2QlqQPjaaYraZLM0R+cd+OC1C7bz7dhcWuce9pNE0h+GG4PA8yQ==
+    size: 167763989
+path: DoodleNote-0.3.5-arm64-mac.zip
+sha512: fj1/TzN7NJHjEXWgFn7Rro9BB3gcIUK23mS2QlqQPjaaYraZLM0R+cd+OC1C7bz7dhcWuce9pNE0h+GG4PA8yQ==
+releaseDate: '2026-07-07T23:20:27.152Z'


### PR DESCRIPTION
Version bump + changelog + mac landing link for 0.3.5 — mic input selector (Alec) + doodlenote.ai link bake. Windows intentionally stays on 0.3.4 (the feature is mac-only; feeds are separate). Merged after the mac artifact is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)