### PR TITLE
iOS: link accounts via Safari + doodlenote:// callback

### DIFF
--- a/apps/ios/DoodleNote/DoodleNoteApp.swift
+++ b/apps/ios/DoodleNote/DoodleNoteApp.swift
@@ -19,10 +19,15 @@ struct DoodleNoteApp: App {
 
     var body: some Scene {
         WindowGroup {
-            if hasOnboarded {
-                HomeView()
-            } else {
-                WelcomeView { hasOnboarded = true }
+            Group {
+                if hasOnboarded {
+                    HomeView()
+                } else {
+                    WelcomeView { hasOnboarded = true }
+                }
+            }
+            .onOpenURL { url in
+                SyncEngine.shared.handleCallback(url)
             }
         }
         .modelContainer(container)

--- a/apps/ios/DoodleNote/Info.plist
+++ b/apps/ios/DoodleNote/Info.plist
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>DoodleNote</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.doodlenote.ios</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>doodlenote</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>DoodleNote shows your upcoming meetings so you can start notes with one tap. Calendar data stays on your phone.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>DoodleNote records your meetings so it can transcribe them on this device. Audio never leaves your phone.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>DoodleNote transcribes your meetings entirely on this device.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/apps/ios/DoodleNote/Sync/SyncEngine.swift
+++ b/apps/ios/DoodleNote/Sync/SyncEngine.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftData
 import SwiftUI
 import CryptoKit
-import AuthenticationServices
+import UIKit
 
 /// Orchestrates cloud sync: device linking, push of locally-changed meetings,
 /// pull of remote changes, and deletion reconciliation. Mirrors the desktop
@@ -50,8 +50,17 @@ final class SyncEngine: NSObject {
 
     // MARK: Device linking
 
-    /// Opens the web approval flow. The link-device page redirects back to
-    /// doodlenote://link?token=dnsy_...&email=...&workspace=... on approval.
+    /// True while we've handed off to Safari and are waiting for the
+    /// doodlenote://link callback.
+    private(set) var isLinking = false
+    private var linkTimeoutTask: Task<Void, Never>?
+
+    /// Opens the account/approval flow in the real Safari app — same pattern
+    /// as desktop (system browser + callback). The /link-device page redirects
+    /// to doodlenote://link?token=dnsy_...&email=...&workspace=... on
+    /// approval, which lands in handleCallback via onOpenURL. Using Safari
+    /// instead of an in-app sheet keeps the user's existing web sessions and
+    /// avoids embedded-browser quirks.
     func link() async {
         lastError = nil
         var components = URLComponents(
@@ -62,25 +71,39 @@ final class SyncEngine: NSObject {
             URLQueryItem(name: "scheme", value: "doodlenote"),
             URLQueryItem(name: "name", value: UIDevice.current.name),
         ]
+        guard let url = components.url else { return }
 
-        do {
-            let callback = try await startWebAuth(url: components.url!)
-            let items = URLComponents(url: callback, resolvingAgainstBaseURL: false)?.queryItems ?? []
-            func item(_ name: String) -> String? { items.first { $0.name == name }?.value }
+        isLinking = true
+        await UIApplication.shared.open(url)
 
-            guard let token = item("token"), token.hasPrefix("dnsy_") else {
-                lastError = "Linking failed: no token returned."
-                return
-            }
-            Keychain.save(key: .syncToken, value: token)
-            linkedEmail = item("email")
-            workspaceName = item("workspace")
-            pullCursor = nil
-        } catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin {
-            // User dismissed the sheet — not an error.
-        } catch {
-            lastError = "Linking failed: \(error.localizedDescription)"
+        // Give the user 5 minutes to finish in Safari (matches desktop).
+        linkTimeoutTask?.cancel()
+        linkTimeoutTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(300))
+            guard let self, !Task.isCancelled, self.isLinking else { return }
+            self.isLinking = false
         }
+    }
+
+    /// Callback from Safari (doodlenote://link?token=...). Wired in
+    /// DoodleNoteApp via onOpenURL; safe to receive even on cold launch.
+    func handleCallback(_ url: URL) {
+        guard url.scheme == "doodlenote", url.host == "link" else { return }
+        linkTimeoutTask?.cancel()
+        isLinking = false
+
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        func item(_ name: String) -> String? { items.first { $0.name == name }?.value }
+
+        guard let token = item("token"), token.hasPrefix("dnsy_") else {
+            lastError = "Linking failed: no token returned."
+            return
+        }
+        Keychain.save(key: .syncToken, value: token)
+        linkedEmail = item("email")
+        workspaceName = item("workspace")
+        pullCursor = nil
+        lastError = nil
     }
 
     func unlink() {
@@ -89,26 +112,9 @@ final class SyncEngine: NSObject {
         workspaceName = nil
         pullCursor = nil
         pendingDeletes = []
+        pendingFolderDeletes = []
         lastError = nil
         lastSyncedAt = nil
-    }
-
-    private func startWebAuth(url: URL) async throws -> URL {
-        try await withCheckedThrowingContinuation { continuation in
-            let session = ASWebAuthenticationSession(
-                url: url,
-                callback: .customScheme("doodlenote")
-            ) { callbackURL, error in
-                if let callbackURL {
-                    continuation.resume(returning: callbackURL)
-                } else {
-                    continuation.resume(throwing: error ?? URLError(.cancelled))
-                }
-            }
-            session.presentationContextProvider = self
-            session.prefersEphemeralWebBrowserSession = false
-            session.start()
-        }
     }
 
     // MARK: Deletion queue
@@ -380,15 +386,6 @@ final class SyncEngine: NSObject {
     }
 }
 
-extension SyncEngine: ASWebAuthenticationPresentationContextProviding {
-    nonisolated func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        MainActor.assumeIsolated {
-            UIApplication.shared.connectedScenes
-                .compactMap { ($0 as? UIWindowScene)?.keyWindow }
-                .first ?? ASPresentationAnchor()
-        }
-    }
-}
 
 private extension Array {
     func chunked(into size: Int) -> [[Element]] {

--- a/apps/ios/DoodleNote/Views/SyncSettingsSection.swift
+++ b/apps/ios/DoodleNote/Views/SyncSettingsSection.swift
@@ -34,8 +34,20 @@ struct SyncSettingsSection: View {
                 Button {
                     Task { await sync.link() }
                 } label: {
-                    Label("Link to your DoodleNote account", systemImage: "icloud")
+                    HStack {
+                        Label(
+                            sync.isLinking
+                                ? "Finish signing in with Safari…"
+                                : "Link to your DoodleNote account",
+                            systemImage: "icloud"
+                        )
+                        if sync.isLinking {
+                            Spacer()
+                            ProgressView()
+                        }
+                    }
                 }
+                .disabled(sync.isLinking)
             }
         } header: {
             Text("Cloud sync")

--- a/apps/ios/DoodleNote/Views/WelcomeView.swift
+++ b/apps/ios/DoodleNote/Views/WelcomeView.swift
@@ -6,7 +6,6 @@ struct WelcomeView: View {
     var onDone: () -> Void
 
     @State private var sync = SyncEngine.shared
-    @State private var linking = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -46,16 +45,13 @@ struct WelcomeView: View {
                 }
 
                 Button {
-                    linking = true
-                    Task {
-                        await sync.link()
-                        linking = false
-                        if sync.isLinked { onDone() }
-                    }
+                    Task { await sync.link() }
                 } label: {
                     HStack {
-                        if linking { ProgressView().tint(Color.ink) }
-                        Text("Sign in & sync my meetings")
+                        if sync.isLinking { ProgressView().tint(Color.ink) }
+                        Text(sync.isLinking
+                            ? "Finish signing in with Safari…"
+                            : "Sign in & sync my meetings")
                     }
                     .font(.headline)
                     .frame(maxWidth: .infinity)
@@ -64,7 +60,10 @@ struct WelcomeView: View {
                     .overlay(RoundedRectangle(cornerRadius: 14).stroke(Color.sand))
                     .foregroundStyle(Color.ink)
                 }
-                .disabled(linking)
+                .disabled(sync.isLinking)
+                .onChange(of: sync.isLinked) { _, linked in
+                    if linked { onDone() }
+                }
 
                 if let error = sync.lastError {
                     Text(error)

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -49,6 +49,21 @@ targets:
         product: FluidAudio
       - package: TwilioVoice
         product: TwilioVoice
+    info:
+      path: DoodleNote/Info.plist
+      properties:
+        CFBundleDisplayName: DoodleNote
+        UILaunchScreen: {}
+        UISupportedInterfaceOrientations: [UIInterfaceOrientationPortrait]
+        NSMicrophoneUsageDescription: DoodleNote records your meetings so it can transcribe them on this device. Audio never leaves your phone.
+        NSSpeechRecognitionUsageDescription: DoodleNote transcribes your meetings entirely on this device.
+        NSCalendarsFullAccessUsageDescription: DoodleNote shows your upcoming meetings so you can start notes with one tap. Calendar data stays on your phone.
+        UIBackgroundModes: [audio]
+        # Account-link callback: Safari hands the sync token back via
+        # doodlenote://link?token=...
+        CFBundleURLTypes:
+          - CFBundleURLName: com.doodlenote.ios
+            CFBundleURLSchemes: [doodlenote]
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.doodlenote.ios
@@ -59,12 +74,4 @@ targets:
         CODE_SIGN_STYLE: Automatic
         TARGETED_DEVICE_FAMILY: "1"
         SWIFT_VERSION: "6.0"
-        GENERATE_INFOPLIST_FILE: true
-        INFOPLIST_KEY_CFBundleDisplayName: DoodleNote
-        INFOPLIST_KEY_UILaunchScreen_Generation: true
-        INFOPLIST_KEY_UISupportedInterfaceOrientations: UIInterfaceOrientationPortrait
-        INFOPLIST_KEY_NSMicrophoneUsageDescription: DoodleNote records your meetings so it can transcribe them on this device. Audio never leaves your phone.
-        INFOPLIST_KEY_NSSpeechRecognitionUsageDescription: DoodleNote transcribes your meetings entirely on this device.
-        INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription: DoodleNote shows your upcoming meetings so you can start notes with one tap. Calendar data stays on your phone.
-        INFOPLIST_KEY_UIBackgroundModes: audio
         SWIFT_EMIT_LOC_STRINGS: false


### PR DESCRIPTION
Replaces the in-app ASWebAuthenticationSession sheet with the desktop pattern: open `/link-device` in the real Safari app and receive the sync token via the `doodlenote://` URL scheme.

Why: the embedded sheet turned any sign-in failure into a silently dead button (what Sean hit in the simulator), and it isolates users from their existing doodlenote.ai / Microsoft sessions. Real Safari has neither problem.

- `doodlenote` scheme registered via a proper generated Info.plist (`CFBundleURLTypes`)
- `onOpenURL` → `SyncEngine.handleCallback`, cold-launch safe, 5-minute timeout, "Finish signing in with Safari…" pending states on Welcome + Settings
- No web changes needed — the `?scheme=doodlenote` redirect support is already deployed

Verified in the simulator: firing `doodlenote://link?token=…` shows the system "Open in DoodleNote?" prompt and routes into the app. iOS build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)