### PR TITLE
Fix INVALID_CALLBACK_URL for device names with spaces + Google logo

### DIFF
--- a/apps/web/app/link-device/page.tsx
+++ b/apps/web/app/link-device/page.tsx
@@ -29,9 +29,15 @@ export default async function LinkDevicePage({
   const requestHeaders = await headers();
   const session = await auth.api.getSession({ headers: requestHeaders });
   if (!session) {
-    const query = new URLSearchParams({
-      next: `/link-device?port=${port ?? ""}&scheme=${scheme ?? ""}&name=${name ?? ""}`,
+    // Encode the inner params individually — a device name with spaces
+    // ("iPhone 17 Pro") otherwise lands raw in the login form's callbackURL,
+    // which Better Auth rejects with INVALID_CALLBACK_URL.
+    const inner = new URLSearchParams({
+      port: port ?? "",
+      scheme: scheme ?? "",
+      name: name ?? "",
     });
+    const query = new URLSearchParams({ next: `/link-device?${inner}` });
     redirect(`/login?${query}`);
   }
 

--- a/apps/web/app/login/login-form.tsx
+++ b/apps/web/app/login/login-form.tsx
@@ -10,6 +10,29 @@ import { buttonPrimary, buttonSecondary, inputClass, Wordmark } from "../ui";
 
 type Mode = "sign-in" | "sign-up";
 
+function GoogleLogo() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 48 48" aria-hidden="true">
+      <path
+        fill="#EA4335"
+        d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+      />
+      <path
+        fill="#4285F4"
+        d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+      />
+      <path
+        fill="#34A853"
+        d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+      />
+    </svg>
+  );
+}
+
 function MicrosoftLogo() {
   return (
     <svg width="16" height="16" viewBox="0 0 21 21" aria-hidden="true">
@@ -170,6 +193,7 @@ export function LoginForm({
           onClick={() => handleSocial("google")}
           className={`mt-3 w-full ${buttonSecondary}`}
         >
+          <GoogleLogo />
           Continue with Google
         </button>
       )}


### PR DESCRIPTION
Found via the new login-form error display: the iOS link flow failed social sign-in with **Invalid callbackURL** because the link-device page's login redirect interpolated the device name raw — "iPhone 17 Pro" put literal spaces into the callbackURL, which Better Auth rejects. Desktop never hit it (Mac hostnames have no spaces).

- Inner `next` query now built with `URLSearchParams` (spaces encoded)
- Verified against production: raw-space callbackURL → `INVALID_CALLBACK_URL`; encoded → returns the Microsoft authorize URL
- Verified in live preview: redirect carries `name=iPhone+17+Pro`, no raw spaces
- Bonus: Google "G" logo on the Google button, matching the Microsoft logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)