### PR TITLE
Richer AI meeting notes: detail-preserving prompt + restructured template

### DIFF
--- a/apps/ios/DoodleNote/AI/NotePrompt.swift
+++ b/apps/ios/DoodleNote/AI/NotePrompt.swift
@@ -13,6 +13,8 @@ enum NotePrompt {
     - The rough notes tell you what the user cared about — give those points prominence and keep the user's wording where it is clear.
     - Spell names and product terms exactly as they appear in the transcript.
     - This transcript is a single-channel in-person recording: speakers are NOT separated. Attribute an action item or decision to a person ONLY when the transcript itself makes the owner unambiguous; otherwise leave it unowned.
+    - Preserve concrete details exactly as spoken: people and company names, product and tool names, dollar amounts, quantities, dates, deadlines, URLs. When the transcript names a specific thing, the notes name it too — a generic line that could describe any meeting ("discussed improving security") is a failure when the transcript has specifics ("move the repos to the Acme GitHub org and add SSO").
+    - Detail scales with the transcript. A long, substantive meeting deserves thorough notes that follow each discussion; a short or garbled transcript deserves short notes. Never pad thin material into something that sounds complete.
     - Write in tight, plain English. No filler, no corporate fluff.
     - A section heading with nothing real to put under it is omitted entirely.
 
@@ -32,13 +34,19 @@ enum NotePrompt {
             Output format (markdown, nothing before or after it):
             # <meeting title>
 
-            <1-2 sentence summary of what the meeting was about and its outcome>
+            **Purpose:** <one line: why this meeting happened>
 
-            ## Notes
-            <the substance, grouped under short bold topic lines following the meeting's flow; bullets, not paragraphs>
+            ## Key takeaways
+            <3-6 bullets: the decisions and conclusions someone who skipped the meeting must know. Each bullet carries its concrete specifics (who, what, how much, by when) — not a vague theme.>
 
-            ## Decisions
-            <bullet list of decisions actually made; omit the section if none>
+            ## Topics
+            <one short **bold heading** per major topic discussed, in meeting order, each followed by bullets. Where the discussion had this shape, capture it explicitly as sub-bullets: the problem, the decision or solution, and the rationale given. Keep every concrete detail — names, tools, products, dollar amounts, quantities, dates.>
+
+            ## Status updates
+            <project-by-project status the attendees reported, one bullet each; omit the section if none>
+
+            ## Next steps
+            <grouped by owner: a **bold owner name** followed by that person's items; omit the section if none>
 
             ## Action items
             <markdown checkboxes: - [ ] Owner — task (deadline if stated); omit the section if none>

--- a/packages/ai/src/local-engine.ts
+++ b/packages/ai/src/local-engine.ts
@@ -129,7 +129,7 @@ export class LocalNotesEngine implements NotesEngine {
     let context: Awaited<ReturnType<LlamaModel['createContext']>>
     try {
       context = await this.model!.createContext({
-        contextSize: this.options.contextSize ?? 8192
+        contextSize: this.options.contextSize ?? 16384
       })
     } catch (err) {
       if (this.forceCpu) throw err
@@ -141,7 +141,7 @@ export class LocalNotesEngine implements NotesEngine {
       this.llama = null
       await this.prepare()
       context = await this.model!.createContext({
-        contextSize: this.options.contextSize ?? 8192
+        contextSize: this.options.contextSize ?? 16384
       })
     }
     try {

--- a/packages/ai/src/prompt.ts
+++ b/packages/ai/src/prompt.ts
@@ -21,6 +21,8 @@ Rules:
 - Spell names and product terms exactly as they appear in the transcript.
 - "You" is the note-taker; "Them" is everyone else on the call.
 - Attribute every action item and decision to whoever actually committed to it in the transcript. Use "You" as an owner ONLY when a [You] line contains that commitment; if a [Them] line says "I will…", the owner is the person speaking (use their name if known, otherwise "Them").
+- Preserve concrete details exactly as spoken: people and company names, product and tool names, dollar amounts, quantities, dates, deadlines, URLs. When the transcript names a specific thing, the notes name it too — a generic line that could describe any meeting ("discussed improving security") is a failure when the transcript has specifics ("move the repos to the Acme GitHub org and add SSO").
+- Detail scales with the transcript. A long, substantive meeting deserves thorough notes that follow each discussion; a short or garbled transcript deserves short notes. Never pad thin material into something that sounds complete.
 - Write in tight, plain English. No filler, no corporate fluff.
 - A section heading with nothing real to put under it is omitted entirely.
 
@@ -44,11 +46,27 @@ export function formatTranscript(segments: MergeSegment[]): string {
   return segments.map((s) => `[${formatTimestamp(s.startMs)}] ${s.speaker}: ${s.text}`).join('\n')
 }
 
+/**
+ * Transcript budget for the merge prompt. Sized to the local engine's
+ * context window (16K tokens ≈ 60K chars, leaving room for rules + output);
+ * cloud models never come close. Overflow keeps the head and tail — the
+ * setup and the conclusions — and says so, rather than silently truncating
+ * (a truncated-but-unmarked transcript invites the model to fill gaps).
+ */
+const MAX_TRANSCRIPT_CHARS = 48_000
+
 export function buildMergeUserMessage(input: MergeInput): string {
   const title = input.title?.trim() || 'Untitled meeting'
   const rough = input.rawNotesMarkdown.trim() || '(the user took no rough notes)'
-  const transcript =
+  let transcript =
     input.segments.length > 0 ? formatTranscript(input.segments) : '(no transcript captured)'
+  if (transcript.length > MAX_TRANSCRIPT_CHARS) {
+    const half = MAX_TRANSCRIPT_CHARS / 2
+    transcript =
+      transcript.slice(0, half) +
+      '\n[… middle of a long transcript omitted — do not guess at its contents …]\n' +
+      transcript.slice(-half)
+  }
   const duration =
     input.durationMs !== undefined
       ? `\nDuration: ${Math.round(input.durationMs / 60000)} minutes`

--- a/packages/ai/src/templates.ts
+++ b/packages/ai/src/templates.ts
@@ -19,17 +19,23 @@ export const NOTE_TEMPLATES: NoteTemplate[] = [
   {
     id: 'general',
     label: 'General meeting',
-    description: 'Summary, notes by topic, decisions, action items',
+    description: 'Purpose, key takeaways, topics with rationale, next steps by owner',
     outputFormat: `Output format (markdown, nothing before or after it):
 # <meeting title>
 
-<1-2 sentence summary of what the meeting was about and its outcome>
+**Purpose:** <one line: why this meeting happened>
 
-## Notes
-<the substance, grouped under short bold topic lines following the meeting's flow; bullets, not paragraphs>
+## Key takeaways
+<3-6 bullets: the decisions and conclusions someone who skipped the meeting must know. Each bullet carries its concrete specifics (who, what, how much, by when) — not a vague theme.>
 
-## Decisions
-<bullet list of decisions actually made; ${OMIT}>
+## Topics
+<one short **bold heading** per major topic discussed, in meeting order, each followed by bullets. Where the discussion had this shape, capture it explicitly as sub-bullets: the problem, the decision or solution, and the rationale given. Keep every concrete detail — names, tools, products, dollar amounts, quantities, dates.>
+
+## Status updates
+<project-by-project status the attendees reported, one bullet each; ${OMIT}>
+
+## Next steps
+<grouped by owner: a **bold owner name** followed by that person's items; ${OMIT}>
 
 ## Action items
 <markdown checkboxes: - [ ] Owner — task (deadline if stated); ${OMIT}>`


### PR DESCRIPTION
Motivated by a real side-by-side: Fathom's summary of the same meeting kept the names, prices, and tools ("Codex $200/mo", "DGX Spark", "Yardi") while DoodleNote's genericized them. Changes across packages/ai (desktop + web) and the iOS NotePrompt port:

**Prompt rules** — preserve concrete details verbatim (a generic line that could describe any meeting is called out as a failure); detail scales with the transcript, never pad thin material.

**General template** — restructured to: Purpose → Key takeaways → Topics (with problem / decision / rationale sub-bullets) → Status updates → Next steps grouped by owner → Action items.

**Long meetings** — local engine context 8K→16K tokens (the existing GPU→CPU KV-cache fallback covers tight-RAM machines); transcripts over 48K chars are head/tail-trimmed with an explicit "middle omitted — do not guess" marker instead of silently overflowing the context.

Note for testing: the biggest quality lever is still the model — the motivating summary was generated by the Fast tier (Qwen3-4B). These changes help every tier, but Quality (Gemma-12B) or BYOK is where they shine.

Verified: `@repo/ai` + desktop typecheck, desktop tests 61/61, iOS build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)