### PR TITLE
iOS: unbrick recording — bounded stop, cancellable start, store recovery

### DIFF
--- a/apps/ios/DoodleNote/DoodleNoteApp.swift
+++ b/apps/ios/DoodleNote/DoodleNoteApp.swift
@@ -9,7 +9,25 @@ struct DoodleNoteApp: App {
         do {
             return try ModelContainer(for: Meeting.self, Segment.self, Folder.self)
         } catch {
-            fatalError("Failed to create model container: \(error)")
+            // A force-kill mid-write can leave the store unopenable, and a
+            // fatalError here bricks the app into a black screen forever
+            // (exactly what happened on the first device test). Move the
+            // damaged store aside and start clean — synced meetings come
+            // back from the cloud; a fresh store beats a dead app.
+            let fm = FileManager.default
+            if let support = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+                let stamp = Int(Date().timeIntervalSince1970)
+                for suffix in ["", "-shm", "-wal"] {
+                    let file = support.appendingPathComponent("default.store\(suffix)")
+                    let backup = support.appendingPathComponent("default.store.corrupt-\(stamp)\(suffix)")
+                    try? fm.moveItem(at: file, to: backup)
+                }
+            }
+            do {
+                return try ModelContainer(for: Meeting.self, Segment.self, Folder.self)
+            } catch {
+                fatalError("Failed to create model container even after store reset: \(error)")
+            }
         }
     }()
 

--- a/apps/ios/DoodleNote/Recording/AppleSpeechProvider.swift
+++ b/apps/ios/DoodleNote/Recording/AppleSpeechProvider.swift
@@ -118,8 +118,17 @@ final class AppleSpeechProvider: TranscriptionProvider, @unchecked Sendable {
             inputBuilder = nil
         }
 
-        try? await analyzer?.finalizeAndFinishThroughEndOfInput()
-        await resultsTask?.value
+        // Both awaits are bounded: SpeechAnalyzer's finalize has wedged on a
+        // real device (assets mid-download), and a provider that can't finish
+        // pins the whole controller in .stopping. Losing the transcript tail
+        // beats losing the session.
+        if let analyzer {
+            await withTimeout(seconds: 4) { try? await analyzer.finalizeAndFinishThroughEndOfInput() }
+        }
+        if let resultsTask {
+            await withTimeout(seconds: 2) { await resultsTask.value }
+            resultsTask.cancel()
+        }
         eventsCont.finish()
         analyzer = nil
         converter = nil

--- a/apps/ios/DoodleNote/Recording/AppleSpeechProvider.swift
+++ b/apps/ios/DoodleNote/Recording/AppleSpeechProvider.swift
@@ -22,10 +22,30 @@ final class AppleSpeechProvider: TranscriptionProvider, @unchecked Sendable {
     }
 
     func prepare() async throws {
+        // Fast path first: when this locale's assets are already on the
+        // device, skip AssetInventory entirely — the install-request path
+        // hung indefinitely on a real device and must only run when needed.
+        let installed = await SpeechTranscriber.installedLocales
+        let current = Locale.current
+        let match: (Locale) -> Bool = {
+            $0.identifier(.bcp47) == current.identifier(.bcp47)
+                || $0.language.languageCode == current.language.languageCode
+        }
+        if let ready = installed.first(where: match) ?? installed.first(where: {
+            $0.language.languageCode == Locale(identifier: "en-US").language.languageCode
+        }) {
+            self.transcriber = SpeechTranscriber(
+                locale: ready,
+                transcriptionOptions: [],
+                reportingOptions: [.volatileResults],
+                attributeOptions: [.audioTimeRange]
+            )
+            return
+        }
+
         let supported = await SpeechTranscriber.supportedLocales
         let locale =
-            supported.first { $0.identifier(.bcp47) == Locale.current.identifier(.bcp47) }
-            ?? supported.first { $0.language.languageCode == Locale.current.language.languageCode }
+            supported.first(where: match)
             ?? Locale(identifier: "en-US")
 
         let transcriber = SpeechTranscriber(
@@ -36,9 +56,13 @@ final class AppleSpeechProvider: TranscriptionProvider, @unchecked Sendable {
         )
         self.transcriber = transcriber
 
-        // Downloads the language assets if missing; no-op when installed.
+        // First run on this device: the language assets must download. Hard
+        // bound: surface a real error instead of pinning the session in
+        // "preparing" forever (which is what bricked the first device test).
         if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
-            try await request.downloadAndInstall()
+            try await withThrowingTimeout(seconds: 120) {
+                try await request.downloadAndInstall()
+            }
         }
     }
 

--- a/apps/ios/DoodleNote/Recording/RecordingController.swift
+++ b/apps/ios/DoodleNote/Recording/RecordingController.swift
@@ -6,6 +6,13 @@ import SwiftUI
 /// Owns one recording session: audio session config, the mic tap, the chosen
 /// transcription provider, and persistence of finalized segments into the
 /// meeting. One instance per MeetingView.
+///
+/// Hardened after the first real-device test bricked a session: every await
+/// in `start` is generation-guarded so a stop during preparation can never
+/// be resurrected by a resuming continuation, and `stop` bounds the
+/// provider drain with a timeout so the controller ALWAYS returns to idle —
+/// a hung SpeechAnalyzer finalize must never leave the UI in a dead state
+/// with the mic held open.
 @MainActor
 @Observable
 final class RecordingController {
@@ -26,6 +33,9 @@ final class RecordingController {
     private var provider: TranscriptionProvider?
     private var eventsTask: Task<Void, Never>?
 
+    /// Bumped by stop(); awaits inside start() abort when it moves past them.
+    private var generation = 0
+
     var isActive: Bool {
         switch state {
         case .preparing, .recording, .stopping: true
@@ -35,12 +45,16 @@ final class RecordingController {
 
     func start(meeting: Meeting, context: ModelContext) async {
         guard state == .idle || !isActive else { return }
+        let gen = generation
 
         state = .preparing("Requesting microphone…")
         guard await AVAudioApplication.requestRecordPermission() else {
-            state = .failed("Microphone access is off. Enable it in Settings → Privacy → Microphone.")
+            if gen == generation {
+                state = .failed("Microphone access is off. Enable it in Settings → Privacy → Microphone.")
+            }
             return
         }
+        guard gen == generation else { return } // stopped while prompting
 
         let engineChoice = TranscriptionEngine(
             rawValue: UserDefaults.standard.string(forKey: "transcriptionEngine") ?? "apple"
@@ -51,8 +65,12 @@ final class RecordingController {
         do {
             state = .preparing(engineChoice == .parakeet
                 ? "Loading Parakeet models (first run downloads ~440 MB)…"
-                : "Preparing transcription…")
+                : "Preparing transcription (first run downloads speech assets)…")
             try await provider.prepare()
+            guard gen == generation else { // stopped mid-download — stay dead
+                await provider.finish()
+                return
+            }
 
             let session = AVAudioSession.sharedInstance()
             try session.setCategory(.playAndRecord, mode: .default, options: [.allowBluetoothHFP, .defaultToSpeaker])
@@ -61,6 +79,11 @@ final class RecordingController {
             let input = engine.inputNode
             let format = input.outputFormat(forBus: 0)
             try await provider.start(inputFormat: format)
+            guard gen == generation else {
+                teardownAudio()
+                await provider.finish()
+                return
+            }
 
             input.installTap(onBus: 0, bufferSize: 4096, format: format) { buffer, _ in
                 provider.ingest(buffer)
@@ -82,16 +105,30 @@ final class RecordingController {
             }
         } catch {
             teardownAudio()
-            state = .failed("Could not start recording: \(error.localizedDescription)")
+            if gen == generation {
+                state = .failed("Could not start recording: \(error.localizedDescription)")
+            }
         }
     }
 
     func stop(meeting: Meeting, context: ModelContext) async {
         guard state == .recording || isPreparing else { return }
+        // Invalidate any in-flight start continuation FIRST — whatever it was
+        // waiting on (asset download, engine spin-up) aborts at its next guard.
+        generation += 1
         state = .stopping
         teardownAudio()
-        await provider?.finish()
-        await eventsTask?.value
+
+        // The provider drain is best-effort with a hard bound: a wedged
+        // SpeechAnalyzer finalize loses the tail of the transcript, never
+        // the ability to stop. (The first device test hung here forever.)
+        if let provider {
+            await withTimeout(seconds: 5) { await provider.finish() }
+        }
+        if let eventsTask {
+            await withTimeout(seconds: 2) { await eventsTask.value }
+            eventsTask.cancel()
+        }
         eventsTask = nil
         provider = nil
         livePartial = ""
@@ -129,5 +166,18 @@ final class RecordingController {
                 print("[recording] \(message)")
             }
         }
+    }
+}
+
+/// Run an async operation but give up waiting after `seconds`. The operation
+/// itself is cancelled on timeout; either way this function returns.
+func withTimeout(seconds: Double, _ operation: @escaping @Sendable () async -> Void) async {
+    await withTaskGroup(of: Void.self) { group in
+        group.addTask { await operation() }
+        group.addTask {
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+        }
+        await group.next() // whichever finishes first
+        group.cancelAll()
     }
 }

--- a/apps/ios/DoodleNote/Recording/RecordingController.swift
+++ b/apps/ios/DoodleNote/Recording/RecordingController.swift
@@ -181,3 +181,28 @@ func withTimeout(seconds: Double, _ operation: @escaping @Sendable () async -> V
         group.cancelAll()
     }
 }
+
+/// Throwing variant: give the operation `seconds`, then throw a timeout so
+/// callers surface an actionable failure instead of waiting forever.
+func withThrowingTimeout<T: Sendable>(
+    seconds: Double,
+    _ operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask { try await operation() }
+        group.addTask {
+            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            throw TimeoutError()
+        }
+        guard let first = try await group.next() else { throw TimeoutError() }
+        group.cancelAll()
+        return first
+    }
+}
+
+struct TimeoutError: LocalizedError {
+    var errorDescription: String? {
+        "Timed out. Check your internet connection and try again — the first "
+            + "recording needs to download speech assets."
+    }
+}


### PR DESCRIPTION
Fixes Sean's first-device-test failure chain (stuck "recording", dead Stop button, force-kill, mic indicator lingering, permanent black screen on relaunch).

## Diagnosis
1. First run: `prepare()` hung downloading Apple's speech language assets → state pinned at `.preparing` (read as "recording"; timer keyed to `.recording` correctly never started).
2. Tapping **Stop** entered `.stopping` and awaited `analyzer.finalizeAndFinishThroughEndOfInput()` — which never resolves when the analyzer never fully started → controller wedged forever; every further Stop tap fails the state guard (hence "nothing happened").
3. Force-kill mid-write left the SwiftData store unopenable → the launch path's `fatalError` = black screen on every subsequent open.

## Fixes
- **`stop()` always reaches idle**: bumps a generation counter that invalidates any in-flight `start()` continuation (a stop during preparation can never be resurrected into a ghost recording), tears down audio first, and bounds the provider/events drains with 5s/2s timeouts. Worst case loses the transcript tail — never the session.
- **`AppleSpeechProvider.finish()`** internally bounded (finalize 4s, results 2s) and always terminates its event stream.
- **Launch recovery**: an unopenable store is renamed aside (`default.store.corrupt-<ts>`) and recreated instead of `fatalError` — cloud-synced meetings restore via pull; a fresh store beats a bricked app.
- Preparing banner copy now mentions the first-run asset download.

## Verification
`xcodegen` + `xcodebuild` (iOS Simulator) build clean. Device re-test needed: first-run flow on a phone that hasn't downloaded speech assets (Settings → General → Storage shows them under Dictation/Siri once installed).

## For Sean's phone right now
Delete the current (bricked) install from the phone, rebuild from this branch, reinstall. Deleting the app also clears the corrupt store and releases anything lingering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)