### PR TITLE
Agent access: local + hosted MCP, connector exports, GBrain integration

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -10,7 +10,11 @@ export default defineConfig({
     // EXTERNAL — it ships prebuilt binaries and is ESM-only with top-level
     // await, so it is loaded at runtime via a lazy import() from
     // node_modules instead of being bundled.
-    plugins: [externalizeDepsPlugin({ exclude: ['@repo/ai'] })],
+    plugins: [
+      externalizeDepsPlugin({
+        exclude: ['@repo/ai', '@repo/meetings-store', '@repo/connectors']
+      })
+    ],
     build: {
       rollupOptions: {
         // engine-win is the Windows ASR utilityProcess entry — built as its

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -26,7 +26,9 @@
     "@tiptap/extension-image": "^3.27.2",
     "electron-updater": "^6.8.9",
     "node-llama-cpp": "^3.19.0",
-    "sherpa-onnx-node": "^1.13.4"
+    "sherpa-onnx-node": "^1.13.4",
+    "@repo/meetings-store": "workspace:*",
+    "@repo/connectors": "workspace:*"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",

--- a/apps/desktop/src/main/agent-access-service.ts
+++ b/apps/desktop/src/main/agent-access-service.ts
@@ -1,0 +1,55 @@
+import { ipcMain } from 'electron'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import {
+  AGENT_ACCESS_GET_CHANNEL,
+  AGENT_ACCESS_SET_CHANNEL,
+  type AgentAccessStatus
+} from '../shared/integrations-api'
+
+/**
+ * Owns the opt-in file the standalone doodle-note-mcp server requires
+ * (~/.doodlenote/mcp.json). Agent access to meetings is off until the user
+ * flips the Settings toggle, which writes { enabled: true, meetingsDir }
+ * with the exact store path — the MCP server never guesses paths. Toggling
+ * off rewrites enabled: false, which the server refuses on next launch.
+ */
+export class AgentAccessService {
+  private readonly configPath: string
+
+  constructor(private readonly meetingsDir: string) {
+    this.configPath =
+      process.env.DOODLE_NOTE_MCP_CONFIG ?? join(homedir(), '.doodlenote', 'mcp.json')
+  }
+
+  registerIpc(): void {
+    ipcMain.handle(AGENT_ACCESS_GET_CHANNEL, () => this.status())
+    ipcMain.handle(AGENT_ACCESS_SET_CHANNEL, (_event, enabled: unknown) =>
+      this.setEnabled(Boolean(enabled))
+    )
+  }
+
+  status(): AgentAccessStatus {
+    return { enabled: this.readEnabled(), configPath: this.configPath }
+  }
+
+  setEnabled(enabled: boolean): AgentAccessStatus {
+    mkdirSync(dirname(this.configPath), { recursive: true })
+    writeFileSync(
+      this.configPath,
+      JSON.stringify({ enabled, meetingsDir: this.meetingsDir }, null, 2) + '\n'
+    )
+    return this.status()
+  }
+
+  private readEnabled(): boolean {
+    try {
+      if (!existsSync(this.configPath)) return false
+      const parsed = JSON.parse(readFileSync(this.configPath, 'utf8')) as { enabled?: unknown }
+      return parsed.enabled === true
+    } catch {
+      return false
+    }
+  }
+}

--- a/apps/desktop/src/main/connectors-service.ts
+++ b/apps/desktop/src/main/connectors-service.ts
@@ -1,0 +1,216 @@
+import { ipcMain, safeStorage } from 'electron'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  ConnectorError,
+  connectorStatus,
+  gbrainConnector,
+  planDeliveries,
+  buildFinalizedEvent,
+  recordFailure,
+  recordSuccess,
+  resetFailures,
+  type ConnectorStateMap,
+  type PlannedDelivery
+} from '@repo/connectors'
+import type { MeetingRecord } from '@repo/meetings-store'
+import {
+  CONNECTORS_CONFIGURE_GBRAIN_CHANNEL,
+  CONNECTORS_STATUS_CHANNEL,
+  CONNECTORS_STATUS_EVENT_CHANNEL,
+  CONNECTORS_SYNC_NOW_CHANNEL,
+  type ConnectorsStatus,
+  type GBrainConfigUpdate
+} from '../shared/integrations-api'
+import type { FoldersService } from './folders-service'
+import type { MeetingsService } from './meetings-service'
+
+const DISPATCH_DEBOUNCE_MS = 5_000
+/** Retry sweep; cheap no-op when nothing is due. */
+const RETRY_INTERVAL_MS = 60_000
+
+interface ConnectorsConfig {
+  gbrain: {
+    enabled: boolean
+    endpointUrl: string
+    /** safeStorage-encrypted API key, base64. */
+    apiKeyEnc?: string
+  }
+}
+
+const DEFAULT_CONFIG: ConnectorsConfig = { gbrain: { enabled: false, endpointUrl: '' } }
+
+/**
+ * Runs connector exports: watches the meetings store, and once a meeting is
+ * finalized (AI notes generated) delivers it to every ENABLED connector via
+ * the pure planner in @repo/connectors. Exports are strictly opt-in,
+ * credentials are safeStorage-encrypted at rest, deliveries are idempotent
+ * (content-hash keyed) and retried with backoff, and per-connector status is
+ * surfaced to Settings. Meetings pulled from cloud sync (e.g. recorded on
+ * iOS) land in the same store, so they dispatch here too.
+ */
+export class ConnectorsService {
+  private config: ConnectorsConfig
+  private state: ConnectorStateMap
+  private readonly configPath: string
+  private readonly statePath: string
+  private debounceTimer: NodeJS.Timeout | null = null
+  private running = false
+
+  constructor(
+    userDataDir: string,
+    private readonly meetings: MeetingsService,
+    private readonly folders: FoldersService,
+    private readonly broadcast: (channel: string, payload: unknown) => void
+  ) {
+    this.configPath = join(userDataDir, 'connectors.json')
+    this.statePath = join(userDataDir, 'connector-deliveries.json')
+    this.config = readJson(this.configPath, DEFAULT_CONFIG)
+    this.state = readJson(this.statePath, {})
+  }
+
+  registerIpc(): void {
+    ipcMain.handle(CONNECTORS_STATUS_CHANNEL, () => this.status())
+    ipcMain.handle(CONNECTORS_CONFIGURE_GBRAIN_CHANNEL, (_event, update: unknown) =>
+      this.configureGBrain(update as GBrainConfigUpdate)
+    )
+    ipcMain.handle(CONNECTORS_SYNC_NOW_CHANNEL, () => this.syncNow())
+
+    setInterval(() => {
+      if (this.enabledConnectorIds().length > 0) void this.dispatchCycle()
+    }, RETRY_INTERVAL_MS).unref()
+  }
+
+  /** Store-change hook: debounced like cloud sync so bursts coalesce. */
+  onMeetingsChanged(): void {
+    if (this.enabledConnectorIds().length === 0) return
+    if (this.debounceTimer) clearTimeout(this.debounceTimer)
+    this.debounceTimer = setTimeout(() => void this.dispatchCycle(), DISPATCH_DEBOUNCE_MS)
+    this.debounceTimer.unref()
+  }
+
+  status(): ConnectorsStatus {
+    const stats = connectorStatus(this.state, 'gbrain')
+    const lastDeliveredAt = Object.values(this.state['gbrain'] ?? {})
+      .map((e) => e.deliveredAt)
+      .filter((d): d is string => Boolean(d))
+      .sort()
+      .at(-1)
+    return {
+      gbrain: {
+        enabled: this.config.gbrain.enabled,
+        endpointUrl: this.config.gbrain.endpointUrl,
+        hasApiKey: Boolean(this.config.gbrain.apiKeyEnc),
+        stats: { ...stats, ...(lastDeliveredAt ? { lastDeliveredAt } : {}) }
+      }
+    }
+  }
+
+  configureGBrain(update: GBrainConfigUpdate): ConnectorsStatus {
+    const next = { ...this.config.gbrain }
+    next.enabled = Boolean(update.enabled)
+    next.endpointUrl = String(update.endpointUrl ?? '').trim()
+    if (typeof update.apiKey === 'string') {
+      if (update.apiKey.length === 0) {
+        delete next.apiKeyEnc
+      } else if (safeStorage.isEncryptionAvailable()) {
+        next.apiKeyEnc = safeStorage.encryptString(update.apiKey).toString('base64')
+      } else {
+        throw new Error('Secure credential storage is unavailable on this machine.')
+      }
+    }
+    this.config = { ...this.config, gbrain: next }
+    writeFileSync(this.configPath, JSON.stringify(this.config, null, 2))
+    if (next.enabled) this.onMeetingsChanged()
+    return this.status()
+  }
+
+  async syncNow(): Promise<ConnectorsStatus> {
+    this.state = resetFailures(this.state, 'gbrain')
+    this.persistState()
+    await this.dispatchCycle()
+    return this.status()
+  }
+
+  private enabledConnectorIds(): string[] {
+    return this.config.gbrain.enabled ? ['gbrain'] : []
+  }
+
+  private async dispatchCycle(): Promise<void> {
+    if (this.running) return
+    this.running = true
+    try {
+      const connectorIds = this.enabledConnectorIds()
+      if (connectorIds.length === 0) return
+      const records = this.meetings.readAll()
+      const planned = planDeliveries({
+        records,
+        state: this.state,
+        connectorIds,
+        now: Date.now()
+      })
+      if (planned.length === 0) return
+      const byId = new Map(records.map((r) => [r.id, r]))
+      const folderNames = new Map(this.folders.list().map((f) => [f.id, f.name]))
+      for (const delivery of planned) {
+        const record = byId.get(delivery.meetingId)
+        if (!record) continue
+        await this.deliverOne(delivery, record, folderNames)
+      }
+      this.broadcast(CONNECTORS_STATUS_EVENT_CHANNEL, {})
+    } finally {
+      this.running = false
+    }
+  }
+
+  private async deliverOne(
+    delivery: PlannedDelivery,
+    record: MeetingRecord,
+    folderNames: Map<string, string>
+  ): Promise<void> {
+    try {
+      const event = buildFinalizedEvent(record, {
+        folderName: record.folderId ? folderNames.get(record.folderId) : undefined
+      })
+      await gbrainConnector.deliver(event, {
+        endpointUrl: this.config.gbrain.endpointUrl,
+        apiKey: this.decryptApiKey()
+      })
+      this.state = recordSuccess(this.state, delivery, Date.now())
+    } catch (err) {
+      const retryable = err instanceof ConnectorError ? err.retryable : true
+      const message = err instanceof Error ? err.message : String(err)
+      // Status/log surface: message only — connector errors never carry
+      // meeting content, and neither may anything logged here.
+      console.error(`[connectors] gbrain delivery failed for ${delivery.meetingId}: ${message}`)
+      this.state = recordFailure(this.state, delivery, message, retryable, Date.now())
+    }
+    this.persistState()
+  }
+
+  private decryptApiKey(): string {
+    const enc = this.config.gbrain.apiKeyEnc
+    if (!enc) return ''
+    try {
+      return safeStorage.decryptString(Buffer.from(enc, 'base64'))
+    } catch {
+      return ''
+    }
+  }
+
+  private persistState(): void {
+    try {
+      writeFileSync(this.statePath, JSON.stringify(this.state, null, 2))
+    } catch (err) {
+      console.error('[connectors] failed to persist delivery state:', err)
+    }
+  }
+}
+
+function readJson<T>(path: string, fallback: T): T {
+  try {
+    return { ...fallback, ...(JSON.parse(readFileSync(path, 'utf8')) as T) }
+  } catch {
+    return fallback
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -20,6 +20,8 @@ import { WinEngineHost } from './engine-host-win'
 import { FoldersService } from './folders-service'
 import { initAutoUpdater, isQuittingForUpdate } from './updater'
 import { MediaService } from './media-service'
+import { AgentAccessService } from './agent-access-service'
+import { ConnectorsService } from './connectors-service'
 import { MeetingsService } from './meetings-service'
 import { MicWatcher } from './mic-watcher'
 import { NotesService } from './notes-service'
@@ -258,7 +260,9 @@ app.whenReady().then(() => {
 
   // Persistent event log: every engine event, timestamped, so failed sessions
   // can be diagnosed from disk instead of reproduced. Token arrays collapse to
-  // a count to keep lines small; rotated when it grows past ~5MB.
+  // a count and spoken text to a length — transcript bodies are sensitive and
+  // never belong in logs; timings/counts are enough to debug a session.
+  // Rotated when it grows past ~5MB.
   const engineLogPath = join(app.getPath('userData'), 'engine-events.log')
   try {
     if (existsSync(engineLogPath) && statSync(engineLogPath).size > 5 * 1024 * 1024) {
@@ -269,9 +273,11 @@ app.whenReady().then(() => {
   }
   const logEngineEvent = (event: EngineEvent): void => {
     try {
-      const compact = JSON.stringify(event, (key, value) =>
-        key === 'tokens' && Array.isArray(value) ? `[${value.length} tokens]` : value
-      )
+      const compact = JSON.stringify(event, (key, value) => {
+        if (key === 'tokens' && Array.isArray(value)) return `[${value.length} tokens]`
+        if (key === 'text' && typeof value === 'string') return `[${value.length} chars]`
+        return value
+      })
       appendFileSync(engineLogPath, `${new Date().toISOString()} ${compact}\n`)
     } catch {
       // Never let logging interfere with the session.
@@ -386,7 +392,26 @@ app.whenReady().then(() => {
     broadcast
   )
   syncService.registerIpc()
-  meetingsService.onDidWrite = (change) => syncService.onMeetingsChanged(change.deletedId)
+
+  // Integrations: the local-MCP opt-in file and connector exports (GBrain
+  // et al). Both are off until the user enables them in Settings.
+  const agentAccessService = new AgentAccessService(join(app.getPath('userData'), 'meetings'))
+  agentAccessService.registerIpc()
+  const connectorsService = new ConnectorsService(
+    app.getPath('userData'),
+    meetingsService,
+    foldersService,
+    broadcast
+  )
+  connectorsService.registerIpc()
+
+  // Store writes fan out to cloud sync and connector dispatch. Meetings
+  // recorded on other devices arrive via sync pull, which also writes the
+  // store — so iOS meetings flow to connectors through this same hook.
+  meetingsService.onDidWrite = (change) => {
+    syncService.onMeetingsChanged(change.deletedId)
+    connectorsService.onMeetingsChanged()
+  }
   foldersService.onDidWrite = (change) => syncService.onFoldersChanged(change.deletedId)
 
   // Image attachments for the notes editor (doodle-media:// protocol).

--- a/apps/desktop/src/main/meetings-service.ts
+++ b/apps/desktop/src/main/meetings-service.ts
@@ -1,38 +1,23 @@
 import { ipcMain } from 'electron'
-import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
-import type { TranscriptSegment } from '../shared/engine-events'
+import { MeetingFileStore } from '@repo/meetings-store'
+import type { MeetingUpsert } from '@repo/meetings-store'
 import {
   MEETINGS_DELETE_CHANNEL,
   MEETINGS_GET_CHANNEL,
   MEETINGS_LIST_CHANNEL,
   MEETINGS_SEARCH_CHANNEL,
-  MEETINGS_UPSERT_CHANNEL,
-  type MeetingChatEntry,
-  type MeetingRecord,
-  type MeetingSearchHit,
-  type MeetingSummary,
-  type MeetingUpsert
+  MEETINGS_UPSERT_CHANNEL
 } from '../shared/meetings-api'
 
-/** Meeting ids are renderer-minted UUIDs; anything else never touches disk. */
-const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9-]{0,63}$/
-
 /**
- * Owns the meetings store: one JSON document per meeting under
- * userData/meetings/. The renderer drives all writes (debounced upserts of
- * the active meeting); this service just validates, merges and persists.
+ * The Electron face of the meetings store: IPC registration on top of the
+ * shared MeetingFileStore (one JSON document per meeting under
+ * userData/meetings/). The renderer drives all writes (debounced upserts of
+ * the active meeting); the store validates, merges and persists. All store
+ * logic lives in @repo/meetings-store so the standalone MCP server reads
+ * the exact same data the app writes.
  */
-export class MeetingsService {
-  /**
-   * Post-write hook (cloud sync): fires after any persisted change.
-   * `deletedId` is set when a meeting was hard-deleted or moved to trash —
-   * both mean its cloud copy (if any) should go away.
-   */
-  onDidWrite: ((change: { deletedId?: string }) => void) | null = null
-
-  constructor(private readonly dir: string) {}
-
+export class MeetingsService extends MeetingFileStore {
   registerIpc(): void {
     ipcMain.handle(MEETINGS_LIST_CHANNEL, () => this.list())
     ipcMain.handle(MEETINGS_GET_CHANNEL, (_event, id: unknown) => this.get(String(id)))
@@ -44,172 +29,4 @@ export class MeetingsService {
       this.search(String(query ?? ''))
     )
   }
-
-  /* ---- queries ---- */
-
-  list(): MeetingSummary[] {
-    const summaries: MeetingSummary[] = []
-    for (const file of this.listFiles()) {
-      const record = this.readFile(file)
-      if (!record) continue
-      summaries.push({
-        id: record.id,
-        ...(record.kind === 'note' ? { kind: 'note' as const } : {}),
-        title: record.title,
-        createdAt: record.createdAt,
-        ...(record.startedAt ? { startedAt: record.startedAt } : {}),
-        ...(durationMinOf(record) !== undefined ? { durationMin: durationMinOf(record) } : {}),
-        ...(record.folderId ? { folderId: record.folderId } : {}),
-        ...(record.trashedAt ? { trashedAt: record.trashedAt } : {}),
-        ...(record.calendarEventId ? { calendarEventId: record.calendarEventId } : {})
-      })
-    }
-    // Newest first; createdAt is ISO so string compare sorts chronologically.
-    summaries.sort((a, b) => (a.createdAt < b.createdAt ? 1 : a.createdAt > b.createdAt ? -1 : 0))
-    return summaries
-  }
-
-  get(id: string): MeetingRecord | null {
-    if (!SAFE_ID.test(id)) return null
-    return this.readFile(`${id}.json`)
-  }
-
-  /**
-   * Every stored meeting document, trashed ones included (callers filter).
-   * Powers cross-meeting features in other services — e.g. NotesService
-   * gathering context for the Home-level "ask anything".
-   */
-  readAll(): MeetingRecord[] {
-    const records: MeetingRecord[] = []
-    for (const file of this.listFiles()) {
-      const record = this.readFile(file)
-      if (record) records.push(record)
-    }
-    return records
-  }
-
-  /**
-   * Case-insensitive substring search across every stored document. A few
-   * hundred JSON files scan in single-digit milliseconds — no index needed
-   * at this scale. Reports the strongest matching field per meeting
-   * (title > notes > transcript) so the UI can hint where the hit was.
-   */
-  search(query: string): MeetingSearchHit[] {
-    const q = query.trim().toLowerCase()
-    if (q.length === 0) return []
-    const hits: MeetingSearchHit[] = []
-    for (const record of this.readAll()) {
-      if ((record.title || '').toLowerCase().includes(q)) {
-        hits.push({ id: record.id, field: 'title' })
-      } else if (
-        record.rawNotesMarkdown.toLowerCase().includes(q) ||
-        (record.enhancedMarkdown ?? '').toLowerCase().includes(q)
-      ) {
-        hits.push({ id: record.id, field: 'notes' })
-      } else if (record.segments.some((s) => s.text.toLowerCase().includes(q))) {
-        hits.push({ id: record.id, field: 'transcript' })
-      }
-    }
-    return hits
-  }
-
-  /* ---- writes ---- */
-
-  upsert(patch: MeetingUpsert): MeetingRecord {
-    const id = typeof patch.id === 'string' ? patch.id : ''
-    if (!SAFE_ID.test(id)) {
-      throw new Error(`Invalid meeting id: ${JSON.stringify(patch.id)}`)
-    }
-    const existing = this.get(id)
-    const merged = normalizeRecord({ ...(existing ?? {}), ...patch, id })
-    mkdirSync(this.dir, { recursive: true })
-    writeFileSync(join(this.dir, `${id}.json`), JSON.stringify(merged, null, 2))
-    this.onDidWrite?.(merged.trashedAt ? { deletedId: id } : {})
-    return merged
-  }
-
-  delete(id: string): void {
-    if (!SAFE_ID.test(id)) return
-    rmSync(join(this.dir, `${id}.json`), { force: true })
-    this.onDidWrite?.({ deletedId: id })
-  }
-
-  /* ---- disk ---- */
-
-  private listFiles(): string[] {
-    try {
-      return readdirSync(this.dir).filter((f) => f.endsWith('.json'))
-    } catch {
-      return [] // dir doesn't exist yet — no meetings
-    }
-  }
-
-  private readFile(name: string): MeetingRecord | null {
-    try {
-      const raw = JSON.parse(readFileSync(join(this.dir, name), 'utf8')) as Partial<MeetingRecord>
-      if (typeof raw.id !== 'string' || !SAFE_ID.test(raw.id)) return null
-      return normalizeRecord(raw as MeetingUpsert)
-    } catch {
-      return null // unreadable/corrupt file — skip rather than crash the list
-    }
-  }
-}
-
-/** Fill defaults so every stored/returned record has the full shape. */
-function normalizeRecord(raw: MeetingUpsert): MeetingRecord {
-  return {
-    id: raw.id,
-    // Only "note" is stored; anything else normalizes to the meeting default.
-    ...(raw.kind === 'note' ? { kind: 'note' as const } : {}),
-    title: typeof raw.title === 'string' ? raw.title : '',
-    createdAt: typeof raw.createdAt === 'string' ? raw.createdAt : new Date().toISOString(),
-    ...(typeof raw.startedAt === 'string' ? { startedAt: raw.startedAt } : {}),
-    ...(typeof raw.endedAt === 'string' ? { endedAt: raw.endedAt } : {}),
-    rawNotesMarkdown: typeof raw.rawNotesMarkdown === 'string' ? raw.rawNotesMarkdown : '',
-    ...(typeof raw.enhancedMarkdown === 'string' ? { enhancedMarkdown: raw.enhancedMarkdown } : {}),
-    ...(typeof raw.engine === 'string' ? { engine: raw.engine } : {}),
-    ...(typeof raw.templateId === 'string' && raw.templateId.length > 0
-      ? { templateId: raw.templateId }
-      : {}),
-    segments: Array.isArray(raw.segments) ? (raw.segments as TranscriptSegment[]) : [],
-    echoSuppressed: typeof raw.echoSuppressed === 'number' ? raw.echoSuppressed : 0,
-    ...(Array.isArray(raw.chat) ? { chat: raw.chat.filter(isChatEntry) } : {}),
-    // A null (or invalid) value drops the field — that's how "move back to
-    // My notes" (folderId: null) and "restore from trash" (trashedAt: null)
-    // clear state through the { ...existing, ...patch } merge above.
-    ...(typeof raw.folderId === 'string' && raw.folderId.length > 0
-      ? { folderId: raw.folderId }
-      : {}),
-    ...(isIsoString(raw.trashedAt) ? { trashedAt: raw.trashedAt } : {}),
-    // Graph event ids are opaque and can be long — validate shape, cap length.
-    ...(typeof raw.calendarEventId === 'string' &&
-    raw.calendarEventId.length > 0 &&
-    raw.calendarEventId.length <= 512
-      ? { calendarEventId: raw.calendarEventId }
-      : {})
-  }
-}
-
-function isIsoString(value: unknown): value is string {
-  return typeof value === 'string' && !Number.isNaN(Date.parse(value))
-}
-
-function isChatEntry(entry: unknown): entry is MeetingChatEntry {
-  if (typeof entry !== 'object' || entry === null) return false
-  const e = entry as Partial<MeetingChatEntry>
-  return (
-    typeof e.question === 'string' && typeof e.answer === 'string' && typeof e.askedAt === 'string'
-  )
-}
-
-function durationMinOf(record: MeetingRecord): number | undefined {
-  if (record.startedAt && record.endedAt) {
-    const ms = Date.parse(record.endedAt) - Date.parse(record.startedAt)
-    if (Number.isFinite(ms) && ms > 0) return Math.max(1, Math.round(ms / 60_000))
-  }
-  if (record.segments.length > 0) {
-    const ms = Math.max(...record.segments.map((s) => s.endMs))
-    if (Number.isFinite(ms) && ms > 0) return Math.max(1, Math.round(ms / 60_000))
-  }
-  return undefined
 }

--- a/apps/desktop/src/main/sync-service.ts
+++ b/apps/desktop/src/main/sync-service.ts
@@ -592,6 +592,7 @@ export class SyncService {
 
     const incoming: MeetingRecord = {
       id,
+      ...(remote.kind === 'note' ? { kind: 'note' as const } : {}),
       title: typeof remote.title === 'string' ? remote.title : '',
       createdAt: typeof remote.createdAt === 'string' ? remote.createdAt : new Date().toISOString(),
       ...(typeof remote.startedAt === 'string' ? { startedAt: remote.startedAt } : {}),
@@ -751,6 +752,7 @@ export class SyncService {
 
 interface RemoteMeeting {
   id?: unknown
+  kind?: unknown
   title?: unknown
   createdAt?: unknown
   updatedAt?: unknown
@@ -805,6 +807,7 @@ function contentHash(record: MeetingRecord, mediaUrls: Record<string, string>): 
 function toPushMeeting(record: MeetingRecord, mediaUrls: Record<string, string>): object {
   return {
     id: record.id,
+    ...(record.kind === 'note' ? { kind: 'note' } : {}),
     title: record.title,
     createdAt: record.createdAt,
     ...(record.startedAt ? { startedAt: record.startedAt } : {}),

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -2,6 +2,7 @@ import type { CalendarApi } from '../shared/calendar-api'
 import type { DetectApi } from '../shared/detect-api'
 import type { EngineApi } from '../shared/engine-events'
 import type { FoldersApi } from '../shared/folders-api'
+import type { IntegrationsApi } from '../shared/integrations-api'
 import type { MediaApi } from '../shared/media-api'
 import type { MeetingsApi } from '../shared/meetings-api'
 import type { NotesApi } from '../shared/notes-api'
@@ -21,6 +22,7 @@ declare global {
     detect: DetectApi
     themeNative: ThemeApi
     updates: UpdateApi
+    integrations: IntegrationsApi
   }
 }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -71,6 +71,18 @@ import {
   type FoldersApi
 } from '../shared/folders-api'
 import {
+  AGENT_ACCESS_GET_CHANNEL,
+  AGENT_ACCESS_SET_CHANNEL,
+  CONNECTORS_CONFIGURE_GBRAIN_CHANNEL,
+  CONNECTORS_STATUS_CHANNEL,
+  CONNECTORS_STATUS_EVENT_CHANNEL,
+  CONNECTORS_SYNC_NOW_CHANNEL,
+  type AgentAccessStatus,
+  type ConnectorsStatus,
+  type GBrainConfigUpdate,
+  type IntegrationsApi
+} from '../shared/integrations-api'
+import {
   UPDATE_CHECK_CHANNEL,
   UPDATE_GET_STATE_CHANNEL,
   UPDATE_INSTALL_CHANNEL,
@@ -78,11 +90,7 @@ import {
   type UpdateApi,
   type UpdateState
 } from '../shared/update-api'
-import {
-  THEME_SET_SOURCE_CHANNEL,
-  type ThemeApi,
-  type ThemeSource
-} from '../shared/theme-api'
+import { THEME_SET_SOURCE_CHANNEL, type ThemeApi, type ThemeSource } from '../shared/theme-api'
 import {
   DETECT_GET_STATE_CHANNEL,
   DETECT_MEETING_ENDED_CHANNEL,
@@ -405,6 +413,35 @@ const detectApi: DetectApi = {
   }
 }
 
+const integrationsApi: IntegrationsApi = {
+  getAgentAccess(): Promise<AgentAccessStatus> {
+    return ipcRenderer.invoke(AGENT_ACCESS_GET_CHANNEL) as Promise<AgentAccessStatus>
+  },
+
+  setAgentAccess(enabled: boolean): Promise<AgentAccessStatus> {
+    return ipcRenderer.invoke(AGENT_ACCESS_SET_CHANNEL, enabled) as Promise<AgentAccessStatus>
+  },
+
+  getConnectors(): Promise<ConnectorsStatus> {
+    return ipcRenderer.invoke(CONNECTORS_STATUS_CHANNEL) as Promise<ConnectorsStatus>
+  },
+
+  configureGBrain(update: GBrainConfigUpdate): Promise<ConnectorsStatus> {
+    return ipcRenderer.invoke(
+      CONNECTORS_CONFIGURE_GBRAIN_CHANNEL,
+      update
+    ) as Promise<ConnectorsStatus>
+  },
+
+  connectorsSyncNow(): Promise<ConnectorsStatus> {
+    return ipcRenderer.invoke(CONNECTORS_SYNC_NOW_CHANNEL) as Promise<ConnectorsStatus>
+  },
+
+  onStatusChanged(cb: () => void): () => void {
+    return subscribe(CONNECTORS_STATUS_EVENT_CHANNEL, cb)
+  }
+}
+
 if (process.contextIsolated) {
   try {
     contextBridge.exposeInMainWorld('engine', engineApi)
@@ -417,6 +454,7 @@ if (process.contextIsolated) {
     contextBridge.exposeInMainWorld('detect', detectApi)
     contextBridge.exposeInMainWorld('themeNative', themeApi)
     contextBridge.exposeInMainWorld('updates', updateApi)
+    contextBridge.exposeInMainWorld('integrations', integrationsApi)
   } catch (error) {
     console.error(error)
   }
@@ -441,4 +479,6 @@ if (process.contextIsolated) {
   window.themeNative = themeApi
   // @ts-ignore (defined in index.d.ts)
   window.updates = updateApi
+  // @ts-ignore (defined in index.d.ts)
+  window.integrations = integrationsApi
 }

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -2,8 +2,9 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { CalendarPrefsUpdate, CalendarState } from '../../shared/calendar-api'
 import type { DetectState } from '../../shared/detect-api'
 import type { SyncStatus } from '../../shared/sync-api'
+import type { AgentAccessStatus, ConnectorsStatus } from '../../shared/integrations-api'
 import type { UpdateState } from '../../shared/update-api'
-import { CalendarIcon, CloudIcon, GearIcon, SparkleIcon } from './icons'
+import { CalendarIcon, CloudIcon, GearIcon, SparkleIcon, UsersIcon } from './icons'
 import { getThemePref, setThemePref, type ThemePref } from './theme'
 import type {
   CloudProvider,
@@ -133,13 +134,14 @@ function Toggle({
   )
 }
 
-export type SettingsSection = 'general' | 'calendar' | 'sync' | 'model'
+export type SettingsSection = 'general' | 'calendar' | 'sync' | 'model' | 'integrations'
 
 const SETTINGS_NAV: Array<{ key: SettingsSection; icon: React.JSX.Element; label: string }> = [
   { key: 'general', icon: <GearIcon size={15} />, label: 'General' },
   { key: 'calendar', icon: <CalendarIcon size={15} />, label: 'Calendar' },
   { key: 'sync', icon: <CloudIcon size={15} />, label: 'Cloud sync' },
-  { key: 'model', icon: <SparkleIcon size={15} />, label: 'Notes model' }
+  { key: 'model', icon: <SparkleIcon size={15} />, label: 'Notes model' },
+  { key: 'integrations', icon: <UsersIcon size={15} />, label: 'Integrations' }
 ]
 
 export default function ModelsView({
@@ -177,6 +179,60 @@ export default function ModelsView({
   /* ---- cloud sync ---- */
   const [syncStatus, setSyncStatus] = useState<SyncStatus | null>(null)
   const [linkPending, setLinkPending] = useState(false)
+
+  /* ---- integrations: agent access + connectors ---- */
+  const [agentAccess, setAgentAccess] = useState<AgentAccessStatus | null>(null)
+  const [connectors, setConnectors] = useState<ConnectorsStatus | null>(null)
+  const [gbrainUrl, setGbrainUrl] = useState('')
+  const [gbrainKey, setGbrainKey] = useState('')
+  const [gbrainSaved, setGbrainSaved] = useState(false)
+  const [gbrainError, setGbrainError] = useState<string | null>(null)
+  const gbrainFormSeeded = useRef(false)
+
+  const adoptConnectors = useCallback((status: ConnectorsStatus) => {
+    setConnectors(status)
+    if (!gbrainFormSeeded.current && status.gbrain.endpointUrl) {
+      gbrainFormSeeded.current = true
+      setGbrainUrl(status.gbrain.endpointUrl)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!active) return
+    void window.integrations
+      .getAgentAccess()
+      .then(setAgentAccess)
+      .catch(() => setAgentAccess(null))
+    void window.integrations
+      .getConnectors()
+      .then(adoptConnectors)
+      .catch(() => setConnectors(null))
+  }, [active, adoptConnectors])
+
+  useEffect(
+    () =>
+      window.integrations.onStatusChanged(() => {
+        void window.integrations.getConnectors().then(adoptConnectors)
+      }),
+    [adoptConnectors]
+  )
+
+  const saveGBrain = async (enabled: boolean): Promise<void> => {
+    setGbrainError(null)
+    try {
+      const status = await window.integrations.configureGBrain({
+        enabled,
+        endpointUrl: gbrainUrl.trim(),
+        ...(gbrainKey.length > 0 ? { apiKey: gbrainKey } : {})
+      })
+      adoptConnectors(status)
+      setGbrainKey('')
+      setGbrainSaved(true)
+      setTimeout(() => setGbrainSaved(false), 2000)
+    } catch (err) {
+      setGbrainError(err instanceof Error ? err.message : String(err))
+    }
+  }
 
   /* ---- meeting detection ---- */
   const [detect, setDetect] = useState<DetectState | null>(null)
@@ -507,7 +563,8 @@ export default function ModelsView({
             <section className="keys-section">
               <h3>On-device model</h3>
               <p className="models-sub">
-                DoodleNote polishes your meeting notes with a model that runs entirely on this computer
+                DoodleNote polishes your meeting notes with a model that runs entirely on this
+                computer
                 {data ? ` (${data.ramGB} GB RAM)` : ''}. Download one once — nothing leaves your
                 machine.
               </p>
@@ -970,9 +1027,9 @@ export default function ModelsView({
             <section className="keys-section calendar-section">
               <h3>Sync with cloud</h3>
               <p className="models-sub">
-                Off by default — your meetings live only on this computer. Turn it on to push meetings,
-                transcripts, and notes to your DoodleNote workspace so you can browse and share them
-                on the web.
+                Off by default — your meetings live only on this computer. Turn it on to push
+                meetings, transcripts, and notes to your DoodleNote workspace so you can browse and
+                share them on the web.
               </p>
 
               {syncStatus?.lastError && <div className="models-error">{syncStatus.lastError}</div>}
@@ -1063,6 +1120,123 @@ export default function ModelsView({
                 </div>
               )}
             </section>
+          )}
+
+          {section === 'integrations' && (
+            <>
+              <section className="keys-section calendar-section">
+                <h3>Agent access</h3>
+                <p className="models-sub">
+                  Let AI tools on this computer (Claude, Codex, and other MCP clients) read your
+                  meetings, notes, and transcripts. Read-only, off by default, and local — nothing
+                  is uploaded. Turning this off revokes access immediately.
+                </p>
+                {agentAccess === null ? (
+                  <span className="calendar-note">loading…</span>
+                ) : (
+                  <div className="cal-subcard">
+                    <div className="cal-row">
+                      <span className="cal-row-main">
+                        <span className="cal-row-label">
+                          Allow local AI agents to read meetings
+                        </span>
+                        <span className="cal-row-sub">
+                          {agentAccess.enabled
+                            ? `Enabled — MCP clients connect via the doodle-note-mcp server (config: ${agentAccess.configPath})`
+                            : 'Disabled — the doodle-note-mcp server refuses to start'}
+                        </span>
+                      </span>
+                      <Toggle
+                        checked={agentAccess.enabled}
+                        label="Allow local AI agents to read meetings"
+                        onChange={() => {
+                          void window.integrations
+                            .setAgentAccess(!agentAccess.enabled)
+                            .then(setAgentAccess)
+                        }}
+                      />
+                    </div>
+                  </div>
+                )}
+              </section>
+
+              <section className="keys-section calendar-section">
+                <h3>Second-brain export (GBrain)</h3>
+                <p className="models-sub">
+                  Send finished meetings — notes and transcript — to a GBrain ingestion endpoint as
+                  soon as their AI notes are generated. Off by default; the API key is encrypted
+                  with your system keychain.
+                </p>
+
+                {gbrainError && <div className="models-error">{gbrainError}</div>}
+
+                {connectors === null ? (
+                  <span className="calendar-note">loading…</span>
+                ) : (
+                  <>
+                    <div className="cal-subcard">
+                      <div className="cal-row">
+                        <span className="cal-row-main">
+                          <span className="cal-row-label">Export finalized meetings</span>
+                          <span className="cal-row-sub">
+                            {connectors.gbrain.enabled
+                              ? connectors.gbrain.stats.failed > 0
+                                ? `${connectors.gbrain.stats.failed} failed — ${connectors.gbrain.stats.lastError ?? 'check the endpoint'}`
+                                : connectors.gbrain.stats.pending > 0
+                                  ? `${connectors.gbrain.stats.pending} waiting to send`
+                                  : connectors.gbrain.stats.delivered > 0
+                                    ? `${connectors.gbrain.stats.delivered} meeting${connectors.gbrain.stats.delivered === 1 ? '' : 's'} exported`
+                                    : 'Waiting for the first finalized meeting'
+                              : 'Paused — nothing is sent while this is off'}
+                          </span>
+                        </span>
+                        <Toggle
+                          checked={connectors.gbrain.enabled}
+                          label="Export finalized meetings to GBrain"
+                          onChange={() => void saveGBrain(!connectors.gbrain.enabled)}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="key-form">
+                      <input
+                        type="url"
+                        placeholder="Ingestion endpoint URL (https://…)"
+                        value={gbrainUrl}
+                        onChange={(e) => setGbrainUrl(e.target.value)}
+                      />
+                      <input
+                        type="password"
+                        placeholder={
+                          connectors.gbrain.hasApiKey
+                            ? 'API key saved — enter to replace'
+                            : 'API key'
+                        }
+                        value={gbrainKey}
+                        onChange={(e) => setGbrainKey(e.target.value)}
+                      />
+                      <div className="calendar-actions">
+                        <button
+                          type="button"
+                          onClick={() => void saveGBrain(connectors.gbrain.enabled)}
+                        >
+                          {gbrainSaved ? 'Saved ✓' : 'Save'}
+                        </button>
+                        <button
+                          type="button"
+                          disabled={!connectors.gbrain.enabled}
+                          onClick={() => {
+                            void window.integrations.connectorsSyncNow().then(adoptConnectors)
+                          }}
+                        >
+                          Export now
+                        </button>
+                      </div>
+                    </div>
+                  </>
+                )}
+              </section>
+            </>
           )}
 
           {section === 'model' && (

--- a/apps/desktop/src/shared/engine-events.ts
+++ b/apps/desktop/src/shared/engine-events.ts
@@ -173,21 +173,12 @@ export interface EngineExitEvent {
  * A contiguous stretch of one speaker's words, cut on pauses. The unit that
  * becomes a transcript_segments row in the database.
  */
-export interface TranscriptSegment {
-  id: string
-  channel: EngineChannel
-  speaker: 'You' | 'Them'
-  text: string
-  /** Milliseconds relative to this channel's stream start. */
-  startMs: number
-  endMs: number
-  /** Mean token confidence 0..1. */
-  confidence: number
-  /** Wall-clock ms (channel epoch + startMs); present once channel_start arrived. */
-  absoluteStartMs?: number
-  /** True when the segment was judged to be far-side audio bleeding into the mic. */
-  echo?: boolean
-}
+// The segment shape now lives in @repo/meetings-store (shared with the MCP
+// server and connectors); its MeetingChannel is the same 'mic' | 'system'
+// union as EngineChannel. Re-exported here so engine-facing code keeps its
+// existing import path.
+export type { TranscriptSegment } from '@repo/meetings-store/types'
+import type { TranscriptSegment } from '@repo/meetings-store/types'
 
 /** Newly completed segments (echo-flagged ones included; display layers filter). */
 export interface EngineSegmentsEvent {

--- a/apps/desktop/src/shared/integrations-api.ts
+++ b/apps/desktop/src/shared/integrations-api.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared IPC contract for Settings → Integrations: local agent access (the
+ * doodle-note-mcp opt-in file) and connector exports (GBrain today; the
+ * connector list is generic by design).
+ */
+
+export const AGENT_ACCESS_GET_CHANNEL = 'agent-access:get'
+export const AGENT_ACCESS_SET_CHANNEL = 'agent-access:set'
+
+export const CONNECTORS_STATUS_CHANNEL = 'connectors:status'
+export const CONNECTORS_CONFIGURE_GBRAIN_CHANNEL = 'connectors:configure-gbrain'
+export const CONNECTORS_SYNC_NOW_CHANNEL = 'connectors:sync-now'
+/** main → renderer: delivery state changed — refetch status. */
+export const CONNECTORS_STATUS_EVENT_CHANNEL = 'connectors:status-event'
+
+export interface AgentAccessStatus {
+  enabled: boolean
+  /** Where the opt-in config lives (~/.doodlenote/mcp.json). */
+  configPath: string
+}
+
+export interface ConnectorDeliveryStats {
+  delivered: number
+  pending: number
+  failed: number
+  lastError?: string
+  lastDeliveredAt?: string
+}
+
+export interface GBrainSettingsView {
+  enabled: boolean
+  endpointUrl: string
+  /** True when an API key is stored (the key itself never crosses IPC back). */
+  hasApiKey: boolean
+  stats: ConnectorDeliveryStats
+}
+
+export interface ConnectorsStatus {
+  gbrain: GBrainSettingsView
+}
+
+export interface GBrainConfigUpdate {
+  enabled: boolean
+  endpointUrl: string
+  /** Omit to keep the stored key; empty string clears it. */
+  apiKey?: string
+}
+
+/** API surface exposed on `window.integrations` by the preload script. */
+export interface IntegrationsApi {
+  getAgentAccess(): Promise<AgentAccessStatus>
+  setAgentAccess(enabled: boolean): Promise<AgentAccessStatus>
+  getConnectors(): Promise<ConnectorsStatus>
+  configureGBrain(update: GBrainConfigUpdate): Promise<ConnectorsStatus>
+  /** Re-plan immediately (also clears exhausted failures for a manual retry). */
+  connectorsSyncNow(): Promise<ConnectorsStatus>
+  onStatusChanged(cb: () => void): () => void
+}

--- a/apps/desktop/src/shared/meetings-api.ts
+++ b/apps/desktop/src/shared/meetings-api.ts
@@ -5,9 +5,26 @@
  * the renderer owns the *active* meeting document and upserts it as the
  * user types / records / enhances. TranscriptSession's sessions/*.json
  * backups are unrelated and stay as-is.
+ *
+ * The data model itself lives in @repo/meetings-store (shared with the
+ * standalone MCP server and connector exports); the type re-exports below
+ * keep existing imports working and are erased at build time.
  */
 
-import type { TranscriptSegment } from './engine-events'
+import type {
+  MeetingRecord,
+  MeetingSearchHit,
+  MeetingSummary,
+  MeetingUpsert
+} from '@repo/meetings-store/types'
+
+export type {
+  MeetingChatEntry,
+  MeetingRecord,
+  MeetingSummary,
+  MeetingUpsert,
+  MeetingSearchHit
+} from '@repo/meetings-store/types'
 
 export const MEETINGS_LIST_CHANNEL = 'meetings:list'
 export const MEETINGS_GET_CHANNEL = 'meetings:get'
@@ -17,80 +34,7 @@ export const MEETINGS_DELETE_CHANNEL = 'meetings:delete'
 /** main → renderer: the store changed outside the renderer (cloud pull). */
 export const MEETINGS_CHANGED_EVENT_CHANNEL = 'meetings:changed-event'
 
-/** One persisted "ask anything" exchange. */
-export interface MeetingChatEntry {
-  question: string
-  answer: string
-  /** ISO timestamp of when the question was asked. */
-  askedAt: string
-}
-
-/** Full meeting document as stored on disk. */
-export interface MeetingRecord {
-  id: string
-  /**
-   * What this document is: a meeting (default when absent) or a standalone
-   * quick note ("+ New note" — same editor and optional recording, but
-   * created without a meeting context and never auto-recorded).
-   */
-  kind?: 'meeting' | 'note'
-  title: string
-  /** ISO timestamp of creation ("+ New meeting"). */
-  createdAt: string
-  /** ISO timestamp of the first live-capture start, if any. */
-  startedAt?: string
-  /** ISO timestamp of the last live-capture end, if any. */
-  endedAt?: string
-  /** The user's rough notes (TipTap doc serialized to markdown). */
-  rawNotesMarkdown: string
-  /** AI-merged notes, present after a successful Enhance run. */
-  enhancedMarkdown?: string
-  /** Which notes engine produced enhancedMarkdown (e.g. "local:…"). */
-  engine?: string
-  /** Note template used for Generate notes; absent = "general". */
-  templateId?: string
-  /** Interleaved You/Them transcript segments (echo-flagged ones excluded). */
-  segments: TranscriptSegment[]
-  /** How many echo segments were suppressed across the session(s). */
-  echoSuppressed: number
-  /** "Ask anything" conversation for this meeting, oldest first. */
-  chat?: MeetingChatEntry[]
-  /** Folder assignment; null/absent = unfiled ("My notes"). */
-  folderId?: string | null
-  /** ISO timestamp of the move to trash; null/absent = not trashed. */
-  trashedAt?: string | null
-  /** Microsoft 365 event id when created from a calendar prompt (dedupe key). */
-  calendarEventId?: string
-}
-
-/** Lightweight row for the Home list, sorted newest-first. */
-export interface MeetingSummary {
-  id: string
-  /** "note" marks standalone quick notes; absent = meeting. */
-  kind?: 'meeting' | 'note'
-  title: string
-  createdAt: string
-  startedAt?: string
-  /** Recorded length in whole minutes, when derivable. */
-  durationMin?: number
-  /** Folder assignment; null/absent = unfiled ("My notes"). */
-  folderId?: string | null
-  /** ISO timestamp of the move to trash; null/absent = not trashed. */
-  trashedAt?: string | null
-  /** Microsoft 365 event id when created from a calendar prompt (dedupe key). */
-  calendarEventId?: string
-}
-
-/** Partial update; `id` is required, omitted fields keep their stored value. */
-export type MeetingUpsert = Partial<Omit<MeetingRecord, 'id'>> & { id: string }
-
 /** API surface exposed on `window.meetings` by the preload script. */
-/** Where a full-text search query matched (strongest field reported). */
-export interface MeetingSearchHit {
-  id: string
-  field: 'title' | 'notes' | 'transcript'
-}
-
 export interface MeetingsApi {
   /** Case-insensitive search across titles, notes, and transcripts. */
   search(query: string): Promise<MeetingSearchHit[]>

--- a/apps/web/app/api/agent-tokens/[id]/route.ts
+++ b/apps/web/app/api/agent-tokens/[id]/route.ts
@@ -1,0 +1,29 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { agentTokens, and, eq, getDb } from "@repo/db";
+
+import { auth } from "@/lib/auth";
+
+/** Revoke an agent token. Only the user who minted it can delete it. */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ error: "Not signed in" }, { status: 401 });
+  }
+  const { id } = await params;
+
+  const db = getDb();
+  const owned = await db
+    .select({ id: agentTokens.id })
+    .from(agentTokens)
+    .where(and(eq(agentTokens.id, id), eq(agentTokens.userId, session.user.id)))
+    .limit(1);
+  if (!owned[0]) {
+    return NextResponse.json({ error: "Token not found" }, { status: 404 });
+  }
+  await db.delete(agentTokens).where(eq(agentTokens.id, id));
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/app/api/agent-tokens/route.ts
+++ b/apps/web/app/api/agent-tokens/route.ts
@@ -1,0 +1,67 @@
+import { randomUUID } from "node:crypto";
+
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { agentTokens, and, eq, getDb, member } from "@repo/db";
+
+import { hashAgentToken, mintAgentToken } from "@/lib/agent-auth";
+import { auth } from "@/lib/auth";
+import { entitlementFor } from "@/lib/billing";
+
+/**
+ * Mint an agent token for the signed-in user in one of their workspaces.
+ * Session (cookie) authenticated — called from the workspaces panel.
+ * Returns the plaintext token exactly once; only its hash is stored.
+ */
+export async function POST(request: Request) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ error: "Not signed in" }, { status: 401 });
+  }
+  const entitlement = await entitlementFor(session.user.id);
+  if (!entitlement.entitled) {
+    return NextResponse.json(
+      { error: "Subscription required", needsSubscription: true },
+      { status: 402 },
+    );
+  }
+
+  let body: { organizationId?: unknown; name?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const organizationId = String(body.organizationId ?? "");
+  const name = String(body.name ?? "Agent").trim().slice(0, 80) || "Agent";
+
+  const db = getDb();
+  const membership = await db
+    .select({ id: member.id })
+    .from(member)
+    .where(
+      and(
+        eq(member.userId, session.user.id),
+        eq(member.organizationId, organizationId),
+      ),
+    )
+    .limit(1);
+  if (!membership[0]) {
+    return NextResponse.json(
+      { error: "Not a member of that workspace" },
+      { status: 403 },
+    );
+  }
+
+  const token = mintAgentToken();
+  const id = randomUUID();
+  await db.insert(agentTokens).values({
+    id,
+    tokenHash: hashAgentToken(token),
+    userId: session.user.id,
+    organizationId,
+    name,
+  });
+
+  return NextResponse.json({ id, token, name });
+}

--- a/apps/web/app/api/mcp/route.ts
+++ b/apps/web/app/api/mcp/route.ts
@@ -1,0 +1,147 @@
+import { NextResponse } from "next/server";
+import {
+  AGENT_TOOLS,
+  executeAgentTool,
+  type MeetingSource,
+} from "@repo/agent-contract";
+import { getDb } from "@repo/db";
+
+import { authenticateEntitledAgentRequest } from "@/lib/agent-auth";
+import { CloudMeetingSource } from "@/lib/cloud-meeting-source";
+
+/**
+ * DoodleNote's hosted MCP server: the same read-only tool contract as the
+ * local doodle-note-mcp stdio server, backed by the workspace's cloud-synced
+ * meetings instead of the on-disk store. Agents authenticate with a
+ * revocable `dnag_` token (Authorization: Bearer), minted in the web app's
+ * workspaces panel; every query is tenant-scoped to that token's workspace.
+ *
+ * Transport: stateless MCP Streamable HTTP. Each POST is one JSON-RPC
+ * message answered directly with application/json — no sessions, no SSE
+ * stream, no server-held state, which is exactly what serverless wants.
+ * Claude (Code/Desktop/web), Codex, and other MCP clients handle the
+ * JSON-response mode per the 2025-06-18 spec revision.
+ */
+
+const SERVER_VERSION = "0.1.0";
+const SUPPORTED_PROTOCOL_VERSIONS = [
+  "2025-06-18",
+  "2025-03-26",
+  "2024-11-05",
+];
+
+interface JsonRpcRequest {
+  jsonrpc?: unknown;
+  id?: unknown;
+  method?: unknown;
+  params?: unknown;
+}
+
+function rpcResult(id: unknown, result: unknown): NextResponse {
+  return NextResponse.json({ jsonrpc: "2.0", id: id ?? null, result });
+}
+
+function rpcError(
+  id: unknown,
+  code: number,
+  message: string,
+  status = 200,
+): NextResponse {
+  return NextResponse.json(
+    { jsonrpc: "2.0", id: id ?? null, error: { code, message } },
+    { status },
+  );
+}
+
+export async function POST(request: Request) {
+  const authed = await authenticateEntitledAgentRequest(request);
+  if (authed.response) return authed.response;
+
+  let message: JsonRpcRequest;
+  try {
+    message = (await request.json()) as JsonRpcRequest;
+  } catch {
+    return rpcError(null, -32700, "Parse error", 400);
+  }
+  if (Array.isArray(message)) {
+    // JSON-RPC batching was removed in the 2025-06-18 MCP revision.
+    return rpcError(null, -32600, "Batch requests are not supported", 400);
+  }
+  const method = typeof message.method === "string" ? message.method : "";
+  const id = message.id;
+
+  // Notifications (no id) are acknowledged and ignored — stateless server.
+  if (id === undefined || id === null) {
+    return new NextResponse(null, { status: 202 });
+  }
+
+  switch (method) {
+    case "initialize": {
+      const params = (message.params ?? {}) as { protocolVersion?: unknown };
+      const requested = String(params.protocolVersion ?? "");
+      const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(requested)
+        ? requested
+        : SUPPORTED_PROTOCOL_VERSIONS[0];
+      return rpcResult(id, {
+        protocolVersion,
+        capabilities: { tools: {} },
+        serverInfo: { name: "doodle-note", version: SERVER_VERSION },
+        instructions:
+          "Read-only access to this DoodleNote workspace's meetings. " +
+          "Use search_meetings or list_recent_meetings to find meetings, " +
+          "get_meeting_notes for summaries, get_meeting_transcript for full transcripts.",
+      });
+    }
+
+    case "ping":
+      return rpcResult(id, {});
+
+    case "tools/list":
+      return rpcResult(id, {
+        tools: AGENT_TOOLS.map((t) => ({
+          name: t.name,
+          description: t.description,
+          inputSchema: t.inputSchema,
+        })),
+      });
+
+    case "tools/call": {
+      const params = (message.params ?? {}) as {
+        name?: unknown;
+        arguments?: unknown;
+      };
+      const source: MeetingSource = new CloudMeetingSource(
+        getDb(),
+        authed.agent.organizationId,
+      );
+      const outcome = await executeAgentTool(
+        source,
+        String(params.name ?? ""),
+        (params.arguments ?? {}) as Record<string, unknown>,
+      );
+      if (!outcome.ok) {
+        return rpcResult(id, {
+          content: [{ type: "text", text: outcome.message }],
+          isError: true,
+        });
+      }
+      return rpcResult(id, {
+        content: [
+          { type: "text", text: JSON.stringify(outcome.result, null, 2) },
+        ],
+      });
+    }
+
+    default:
+      return rpcError(id, -32601, `Method not found: ${method}`);
+  }
+}
+
+/** No SSE stream in stateless mode — clients that GET get a clear 405. */
+export async function GET() {
+  return new NextResponse(null, { status: 405, headers: { allow: "POST" } });
+}
+
+export async function DELETE() {
+  return new NextResponse(null, { status: 405, headers: { allow: "POST" } });
+}

--- a/apps/web/app/api/sync/pull/route.ts
+++ b/apps/web/app/api/sync/pull/route.ts
@@ -95,6 +95,7 @@ export async function GET(request: Request) {
     const note = notesByMeeting.get(m.id);
     return {
       id: m.id,
+      ...(m.kind === "note" ? { kind: "note" as const } : {}),
       title: m.title,
       createdAt: (m.createdAt ?? new Date()).toISOString(),
       updatedAt: (m.updatedAt ?? new Date()).toISOString(),

--- a/apps/web/app/api/sync/push/route.ts
+++ b/apps/web/app/api/sync/push/route.ts
@@ -27,6 +27,7 @@ interface PushSegment {
 interface PushMeeting {
   id: string;
   title: string;
+  kind?: "meeting" | "note";
   createdAt: string;
   startedAt?: string;
   endedAt?: string;
@@ -153,6 +154,7 @@ export async function POST(request: Request) {
       const row = {
         organizationId: device.organizationId,
         title: String(item.title ?? "").slice(0, 500) || "Untitled meeting",
+        kind: item.kind === "note" ? ("note" as const) : ("meeting" as const),
         status: "complete" as const,
         calendarEventId:
           typeof item.calendarEventId === "string"

--- a/apps/web/app/app/workspaces/page.tsx
+++ b/apps/web/app/app/workspaces/page.tsx
@@ -1,6 +1,8 @@
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { agentTokens, desc, eq, getDb } from "@repo/db";
+
 import { auth } from "@/lib/auth";
 import { ensurePersonalWorkspace } from "@/lib/workspace";
 
@@ -45,6 +47,24 @@ export default async function WorkspacesPage() {
     }
   }
 
+  // The user's agent tokens (hosted-MCP access), newest first.
+  const tokenRows = await getDb()
+    .select({
+      id: agentTokens.id,
+      name: agentTokens.name,
+      createdAt: agentTokens.createdAt,
+      lastUsedAt: agentTokens.lastUsedAt,
+    })
+    .from(agentTokens)
+    .where(eq(agentTokens.userId, session.user.id))
+    .orderBy(desc(agentTokens.createdAt));
+  const agentTokenList = tokenRows.map((t) => ({
+    id: t.id,
+    name: t.name,
+    createdAt: (t.createdAt ?? new Date()).toISOString(),
+    lastUsedAt: t.lastUsedAt ? t.lastUsedAt.toISOString() : null,
+  }));
+
   return (
     <WorkspacesPanel
       userEmail={session.user.email}
@@ -56,6 +76,7 @@ export default async function WorkspacesPage() {
       }))}
       members={members}
       invitations={invitations}
+      agentTokens={agentTokenList}
     />
   );
 }

--- a/apps/web/app/app/workspaces/workspaces-panel.tsx
+++ b/apps/web/app/app/workspaces/workspaces-panel.tsx
@@ -24,24 +24,37 @@ interface Invitation {
   status: string;
 }
 
+interface AgentToken {
+  id: string;
+  name: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
 export function WorkspacesPanel({
   userEmail,
   activeOrganizationId,
   organizations,
   members,
   invitations,
+  agentTokens,
 }: {
   userEmail: string;
   activeOrganizationId: string | null;
   organizations: Workspace[];
   members: Member[];
   invitations: Invitation[];
+  agentTokens: AgentToken[];
 }) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const [inviteEmail, setInviteEmail] = useState("");
   const [invitePending, setInvitePending] = useState(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [tokenName, setTokenName] = useState("");
+  const [tokenPending, setTokenPending] = useState(false);
+  const [mintedToken, setMintedToken] = useState<string | null>(null);
+  const [tokenCopied, setTokenCopied] = useState(false);
 
   async function handleSetActive(organizationId: string) {
     setError(null);
@@ -94,6 +107,54 @@ export function WorkspacesPanel({
       return;
     }
     router.refresh();
+  }
+
+  async function createAgentToken(event: React.FormEvent) {
+    event.preventDefault();
+    if (!activeOrganizationId) return;
+    setError(null);
+    setTokenPending(true);
+    try {
+      const res = await fetch("/api/agent-tokens", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          organizationId: activeOrganizationId,
+          name: tokenName.trim() || "Agent",
+        }),
+      });
+      const data = (await res.json()) as { token?: string; error?: string };
+      if (!res.ok || !data.token) {
+        setError(data.error ?? "Could not create the agent token");
+        return;
+      }
+      setMintedToken(data.token);
+      setTokenName("");
+      router.refresh();
+    } finally {
+      setTokenPending(false);
+    }
+  }
+
+  async function revokeAgentToken(id: string) {
+    setError(null);
+    const res = await fetch(`/api/agent-tokens/${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      setError("Could not revoke the token");
+      return;
+    }
+    router.refresh();
+  }
+
+  async function copyMintedToken() {
+    if (!mintedToken) return;
+    try {
+      await navigator.clipboard.writeText(mintedToken);
+      setTokenCopied(true);
+      setTimeout(() => setTokenCopied(false), 2500);
+    } catch {
+      // The token is visible in the panel — nothing else to do.
+    }
   }
 
   return (
@@ -220,6 +281,99 @@ export function WorkspacesPanel({
           Invitations don&rsquo;t send email yet — copy the link and send it
           yourself. It works once they sign in with the invited address.
         </p>
+      </section>
+
+      <section className="mt-10">
+        <h2 className="font-display text-lg font-semibold text-ink">
+          AI agents
+        </h2>
+        <p className="mt-1 text-sm text-stone">
+          Tokens let AI tools (Claude, Codex, and other MCP clients) read this
+          workspace&rsquo;s synced meetings through DoodleNote&rsquo;s hosted
+          MCP server. Read-only; revoke anytime.
+        </p>
+
+        {mintedToken && (
+          <div className="mt-4 rounded-md border border-sand bg-sage-fill/40 p-3">
+            <p className="text-xs font-medium text-ink">
+              Copy this token now — it won&rsquo;t be shown again.
+            </p>
+            <p className="mt-1 break-all font-mono text-xs text-ink">
+              {mintedToken}
+            </p>
+            <div className="mt-2 flex items-center gap-3">
+              <button
+                type="button"
+                onClick={copyMintedToken}
+                className="rounded-md border border-sand bg-card px-2.5 py-1 text-xs text-ink transition-colors hover:bg-sage-fill"
+              >
+                {tokenCopied ? "Copied ✓" : "Copy token"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setMintedToken(null)}
+                className="text-xs text-stone hover:text-ink"
+              >
+                Done
+              </button>
+            </div>
+            <p className="mt-2 text-xs text-stone">
+              Connect with:{" "}
+              <code className="break-all">
+                claude mcp add --transport http doodle-note
+                https://www.doodlenote.ai/api/mcp --header
+                &quot;Authorization: Bearer &lt;token&gt;&quot;
+              </code>
+            </p>
+          </div>
+        )}
+
+        {agentTokens.length > 0 && (
+          <ul className="mt-4 border-y border-sand">
+            {agentTokens.map((t) => (
+              <li
+                key={t.id}
+                className="flex items-center justify-between gap-4 border-b border-sand px-2 py-3 last:border-b-0"
+              >
+                <span className="min-w-0">
+                  <span className="block truncate text-sm text-ink">
+                    {t.name}
+                  </span>
+                  <span className="text-xs text-stone">
+                    created {new Date(t.createdAt).toLocaleDateString()}
+                    {t.lastUsedAt
+                      ? ` · last used ${new Date(t.lastUsedAt).toLocaleDateString()}`
+                      : " · never used"}
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  onClick={() => revokeAgentToken(t.id)}
+                  className="shrink-0 rounded-md px-2 py-1 text-xs text-stone hover:text-red-700"
+                >
+                  Revoke
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <form onSubmit={createAgentToken} className="mt-4 flex items-start gap-2">
+          <input
+            type="text"
+            placeholder="Token name (e.g. Claude on laptop)"
+            value={tokenName}
+            onChange={(e) => setTokenName(e.target.value)}
+            className={`flex-1 ${inputClass}`}
+          />
+          <button
+            type="submit"
+            disabled={tokenPending || !activeOrganizationId}
+            className={buttonPrimary}
+          >
+            {tokenPending ? "Creating…" : "Create token"}
+          </button>
+        </form>
       </section>
     </main>
   );

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -11,6 +11,7 @@ const eslintConfig = defineConfig([
     ".next/**",
     ".next-preview/**",
     ".next-build/**",
+    ".next-agent/**",
     "out/**",
     "build/**",
     "next-env.d.ts",

--- a/apps/web/lib/agent-auth.ts
+++ b/apps/web/lib/agent-auth.ts
@@ -1,0 +1,93 @@
+import { createHash, randomBytes } from "node:crypto";
+
+import { NextResponse } from "next/server";
+import { agentTokens, eq, getDb } from "@repo/db";
+
+import { entitlementFor } from "@/lib/billing";
+
+/**
+ * Auth for the hosted MCP (/api/mcp): revocable, READ-ONLY agent tokens.
+ * Same trust model as sync devices — plaintext `dnag_…` shown once at mint,
+ * only its SHA-256 stored, requests send `Authorization: Bearer`. Distinct
+ * prefix from `dnsy_` sync tokens so one can never be used as the other.
+ */
+
+export function hashAgentToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export function mintAgentToken(): string {
+  return `dnag_${randomBytes(32).toString("hex")}`;
+}
+
+export interface AgentAuth {
+  tokenId: string;
+  userId: string;
+  organizationId: string;
+}
+
+/** Resolves the bearer header to an agent token row, or null. */
+export async function authenticateAgentRequest(
+  request: Request,
+): Promise<AgentAuth | null> {
+  const header = request.headers.get("authorization") ?? "";
+  const token = header.startsWith("Bearer ") ? header.slice(7).trim() : "";
+  if (!token.startsWith("dnag_") || token.length < 40) return null;
+
+  const db = getDb();
+  const rows = await db
+    .select({
+      tokenId: agentTokens.id,
+      userId: agentTokens.userId,
+      organizationId: agentTokens.organizationId,
+    })
+    .from(agentTokens)
+    .where(eq(agentTokens.tokenHash, hashAgentToken(token)))
+    .limit(1);
+  const found = rows[0];
+  if (!found) return null;
+
+  // Best-effort liveness stamp; never block the request on it.
+  db.update(agentTokens)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(agentTokens.id, found.tokenId))
+    .catch(() => {});
+
+  return found;
+}
+
+/**
+ * Agent auth + billing in one step, mirroring sync's entitlement gate —
+ * remote agent access reads cloud-synced data, so it's part of the same
+ * paid Sync feature.
+ */
+export async function authenticateEntitledAgentRequest(
+  request: Request,
+): Promise<
+  | { agent: AgentAuth; response?: undefined }
+  | { agent?: undefined; response: Response }
+> {
+  const agent = await authenticateAgentRequest(request);
+  if (!agent) {
+    return {
+      response: NextResponse.json(
+        { error: "Invalid agent token" },
+        { status: 401 },
+      ),
+    };
+  }
+  const entitlement = await entitlementFor(agent.userId);
+  if (!entitlement.entitled) {
+    return {
+      response: NextResponse.json(
+        {
+          error:
+            "Remote agent access needs an active subscription — manage billing at https://www.doodlenote.ai/pricing",
+          needsSubscription: true,
+        },
+        { status: 402 },
+      ),
+    };
+  }
+  return { agent };
+}

--- a/apps/web/lib/cloud-meeting-source.ts
+++ b/apps/web/lib/cloud-meeting-source.ts
@@ -1,0 +1,208 @@
+import type {
+  AgentMeetingNotes,
+  AgentMeetingSummary,
+  AgentSearchResult,
+  AgentTranscript,
+  MeetingSource,
+} from "@repo/agent-contract";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  meetings,
+  notes,
+  or,
+  sql,
+  transcriptSegments,
+  type Db,
+} from "@repo/db";
+
+/**
+ * MeetingSource backed by the cloud database — the hosted twin of the local
+ * MCP server's file-store source. Every query is scoped to ONE workspace
+ * (organizationId from the agent token), which is the tenant-isolation
+ * boundary: an agent can never see another workspace's meetings. Cloud rows
+ * only exist for non-trashed meetings (deletion removes the row), and
+ * pushed segments already exclude echo-flagged ones, so both invariants of
+ * the contract hold by construction.
+ */
+export class CloudMeetingSource implements MeetingSource {
+  constructor(
+    private readonly db: Db,
+    private readonly organizationId: string,
+  ) {}
+
+  async listRecent(limit: number): Promise<AgentMeetingSummary[]> {
+    const rows = await this.baseSelect()
+      .where(eq(meetings.organizationId, this.organizationId))
+      .orderBy(desc(meetings.createdAt))
+      .limit(limit);
+    return rows.map((r) => toSummary(r));
+  }
+
+  async search(query: string, limit: number): Promise<AgentSearchResult[]> {
+    const pattern = `%${escapeLike(query)}%`;
+    const titleMatch = sql`${meetings.title} ilike ${pattern}`;
+    const notesMatch = sql`(coalesce(${notes.rawContent}->>'markdown', '') ilike ${pattern} or coalesce(${notes.enhancedContent}->>'markdown', '') ilike ${pattern})`;
+    const transcriptMatch = sql`exists (select 1 from ${transcriptSegments} ts where ts.meeting_id = ${meetings.id} and ts.text ilike ${pattern})`;
+    const rows = await this.baseSelect({
+      matchedField: sql<string>`case when ${titleMatch} then 'title' when ${notesMatch} then 'notes' else 'transcript' end`,
+    })
+      .where(
+        and(
+          eq(meetings.organizationId, this.organizationId),
+          or(titleMatch, notesMatch, transcriptMatch),
+        ),
+      )
+      .orderBy(desc(meetings.createdAt))
+      .limit(limit);
+    return rows.map((r) => ({
+      ...toSummary(r),
+      matched_field: normalizeField(
+        (r as { matchedField?: unknown }).matchedField,
+      ),
+    }));
+  }
+
+  async getMeeting(meetingId: string): Promise<AgentMeetingSummary | null> {
+    const row = await this.getOwnRow(meetingId);
+    return row ? toSummary(row) : null;
+  }
+
+  async getNotes(meetingId: string): Promise<AgentMeetingNotes | null> {
+    const row = await this.getOwnRow(meetingId);
+    if (!row) return null;
+    const enhanced = markdownOf(row.enhancedContent);
+    return {
+      meeting_id: row.id,
+      title: row.title,
+      raw_notes_markdown: markdownOf(row.rawContent) ?? "",
+      ...(enhanced ? { enhanced_markdown: enhanced } : {}),
+    };
+  }
+
+  async getTranscript(meetingId: string): Promise<AgentTranscript | null> {
+    const row = await this.getOwnRow(meetingId);
+    if (!row) return null;
+    const segmentRows = await this.db
+      .select({
+        speaker: transcriptSegments.speaker,
+        text: transcriptSegments.text,
+        startMs: transcriptSegments.startMs,
+        endMs: transcriptSegments.endMs,
+      })
+      .from(transcriptSegments)
+      .where(eq(transcriptSegments.meetingId, meetingId))
+      .orderBy(asc(transcriptSegments.startMs));
+    const segments = segmentRows.map((s) => ({
+      speaker: s.speaker === "Them" ? ("Them" as const) : ("You" as const),
+      text: s.text,
+      start_ms: s.startMs,
+      end_ms: s.endMs,
+    }));
+    const duration = durationMin(row, segments.at(-1)?.end_ms);
+    return {
+      meeting_id: row.id,
+      title: row.title,
+      segments,
+      text: segments.map((s) => `${s.speaker}: ${s.text}`).join("\n"),
+      ...(duration !== undefined ? { duration_min: duration } : {}),
+    };
+  }
+
+  /* ---- shared query shapes ---- */
+
+  /** Meeting row + notes envelopes + a has-transcript flag in one select. */
+  private baseSelect(extra: Record<string, ReturnType<typeof sql>> = {}) {
+    return this.db
+      .select({
+        id: meetings.id,
+        kind: meetings.kind,
+        title: meetings.title,
+        createdAt: meetings.createdAt,
+        startedAt: meetings.startedAt,
+        endedAt: meetings.endedAt,
+        calendarEventId: meetings.calendarEventId,
+        rawContent: notes.rawContent,
+        enhancedContent: notes.enhancedContent,
+        hasTranscript: sql<boolean>`exists (select 1 from ${transcriptSegments} ts where ts.meeting_id = ${meetings.id})`,
+        ...extra,
+      })
+      .from(meetings)
+      .leftJoin(notes, eq(notes.meetingId, meetings.id));
+  }
+
+  private async getOwnRow(meetingId: string): Promise<MeetingRow | null> {
+    if (!UUID_RE.test(meetingId)) return null;
+    const rows = await this.baseSelect()
+      .where(
+        and(
+          eq(meetings.id, meetingId),
+          eq(meetings.organizationId, this.organizationId),
+        ),
+      )
+      .limit(1);
+    return rows[0] ?? null;
+  }
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface MeetingRow {
+  id: string;
+  kind: "meeting" | "note";
+  title: string;
+  createdAt: Date | null;
+  startedAt: Date | null;
+  endedAt: Date | null;
+  calendarEventId: string | null;
+  rawContent: unknown;
+  enhancedContent: unknown;
+  hasTranscript: boolean;
+}
+
+/** Escape LIKE wildcards so a query of "100%" matches literally. */
+function escapeLike(query: string): string {
+  return query.replace(/[\\%_]/g, (c) => `\\${c}`);
+}
+
+function markdownOf(envelope: unknown): string | null {
+  if (typeof envelope !== "object" || envelope === null) return null;
+  const md = (envelope as { markdown?: unknown }).markdown;
+  return typeof md === "string" && md.length > 0 ? md : null;
+}
+
+function normalizeField(value: unknown): "title" | "notes" | "transcript" {
+  return value === "title" || value === "notes" ? value : "transcript";
+}
+
+function durationMin(row: MeetingRow, lastEndMs?: number): number | undefined {
+  if (row.startedAt && row.endedAt) {
+    const ms = row.endedAt.getTime() - row.startedAt.getTime();
+    if (Number.isFinite(ms) && ms > 0) return Math.max(1, Math.round(ms / 60_000));
+  }
+  if (typeof lastEndMs === "number" && lastEndMs > 0) {
+    return Math.max(1, Math.round(lastEndMs / 60_000));
+  }
+  return undefined;
+}
+
+function toSummary(row: MeetingRow): AgentMeetingSummary {
+  const raw = markdownOf(row.rawContent);
+  const enhanced = markdownOf(row.enhancedContent);
+  const duration = durationMin(row);
+  return {
+    meeting_id: row.id,
+    kind: row.kind === "note" ? "note" : "meeting",
+    title: row.title,
+    created_at: (row.createdAt ?? new Date()).toISOString(),
+    ...(row.startedAt ? { started_at: row.startedAt.toISOString() } : {}),
+    ...(row.endedAt ? { ended_at: row.endedAt.toISOString() } : {}),
+    ...(duration !== undefined ? { duration_min: duration } : {}),
+    has_notes: Boolean(raw?.trim() || enhanced?.trim()),
+    has_transcript: Boolean(row.hasTranscript),
+    ...(row.calendarEventId ? { calendar_event_id: row.calendarEventId } : {}),
+  };
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -17,7 +17,7 @@ const nextConfig: NextConfig = {
    */
   distDir: process.env.NEXT_DIST_DIR || ".next",
   /** @repo/db ships raw TypeScript — let Next transpile it. */
-  transpilePackages: ["@repo/db"],
+  transpilePackages: ["@repo/db", "@repo/agent-contract"],
   /**
    * PGlite loads its WASM/data payloads relative to the module on disk, so it
    * must stay a native `require` instead of being bundled into the server

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,8 @@
     "start": "next start --port 4040",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "auth-smoke": "tsx scripts/auth-smoke.ts"
+    "auth-smoke": "tsx scripts/auth-smoke.ts",
+    "test": "tsx --test tests/*.test.ts"
   },
   "dependencies": {
     "@repo/db": "workspace:*",
@@ -18,7 +19,8 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-markdown": "^10.1.0",
-    "stripe": "^22.3.0"
+    "stripe": "^22.3.0",
+    "@repo/agent-contract": "workspace:*"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/apps/web/tests/cloud-meeting-source.test.ts
+++ b/apps/web/tests/cloud-meeting-source.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+import { organization, user } from "@repo/db/auth-schema";
+import { meetings, notes, transcriptSegments } from "@repo/db/schema";
+import { createInMemoryDb, type InMemoryDb } from "@repo/db/testing";
+
+import { CloudMeetingSource } from "../lib/cloud-meeting-source";
+
+let mem: InMemoryDb;
+let source: CloudMeetingSource;
+
+const ORG_A = "org-a";
+const ORG_B = "org-b";
+const M1 = "11111111-1111-4111-8111-111111111111";
+const M2 = "22222222-2222-4222-8222-222222222222";
+const NOTE1 = "33333333-3333-4333-8333-333333333333";
+const OTHER = "44444444-4444-4444-8444-444444444444";
+
+before(async () => {
+  mem = await createInMemoryDb();
+  const db = mem.db;
+  await db.insert(user).values({
+    id: "u1",
+    name: "Sean",
+    email: "sean@example.com",
+    emailVerified: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  await db.insert(organization).values([
+    { id: ORG_A, name: "Workspace A", slug: "workspace-a", createdAt: new Date() },
+    { id: ORG_B, name: "Workspace B", slug: "workspace-b", createdAt: new Date() },
+  ]);
+  await db.insert(meetings).values([
+    {
+      id: M1,
+      organizationId: ORG_A,
+      title: "Budget review",
+      kind: "meeting",
+      createdAt: new Date("2026-07-01T10:00:00Z"),
+      startedAt: new Date("2026-07-01T10:00:00Z"),
+      endedAt: new Date("2026-07-01T10:30:00Z"),
+      calendarEventId: "cal-1",
+    },
+    {
+      id: M2,
+      organizationId: ORG_A,
+      title: "Standup",
+      kind: "meeting",
+      createdAt: new Date("2026-07-02T10:00:00Z"),
+    },
+    {
+      id: NOTE1,
+      organizationId: ORG_A,
+      title: "Quick idea",
+      kind: "note",
+      createdAt: new Date("2026-07-03T10:00:00Z"),
+    },
+    {
+      id: OTHER,
+      organizationId: ORG_B,
+      title: "Other workspace secret budget",
+      kind: "meeting",
+      createdAt: new Date("2026-07-04T10:00:00Z"),
+    },
+  ]);
+  await db.insert(notes).values([
+    {
+      meetingId: M1,
+      rawContent: { format: "markdown", markdown: "- ask about budget" },
+      enhancedContent: { format: "markdown", markdown: "## Decisions\n- approved" },
+    },
+    {
+      meetingId: OTHER,
+      rawContent: { format: "markdown", markdown: "secret budget notes" },
+    },
+  ]);
+  await db.insert(transcriptSegments).values([
+    {
+      meetingId: M1,
+      channel: "system",
+      speaker: "Them",
+      text: "the budget looks fine",
+      startMs: 0,
+      endMs: 2000,
+    },
+    {
+      meetingId: M1,
+      channel: "mic",
+      speaker: "You",
+      text: "great, approved",
+      startMs: 2000,
+      endMs: 3000,
+    },
+  ]);
+  // The class takes the app's Db union type; PGlite's drizzle client is
+  // runtime-compatible (same schema, same query builder).
+  source = new CloudMeetingSource(db as never, ORG_A);
+});
+
+after(async () => {
+  await mem.close();
+});
+
+test("listRecent is newest-first, org-scoped, with kind and flags", async () => {
+  const list = await source.listRecent(10);
+  assert.deepEqual(
+    list.map((m) => m.meeting_id),
+    [NOTE1, M2, M1],
+  );
+  assert.equal(list[0]?.kind, "note");
+  const m1 = list[2]!;
+  assert.equal(m1.kind, "meeting");
+  assert.equal(m1.has_notes, true);
+  assert.equal(m1.has_transcript, true);
+  assert.equal(m1.duration_min, 30);
+  assert.equal(m1.calendar_event_id, "cal-1");
+  assert.equal(list[1]?.has_notes, false);
+  assert.equal(list[1]?.has_transcript, false);
+});
+
+test("another workspace's meetings are invisible to every tool", async () => {
+  assert.equal(await source.getMeeting(OTHER), null);
+  assert.equal(await source.getNotes(OTHER), null);
+  assert.equal(await source.getTranscript(OTHER), null);
+  const hits = await source.search("secret", 10);
+  assert.deepEqual(hits, []);
+});
+
+test("search reports strongest field: title > notes > transcript", async () => {
+  const titleHit = await source.search("standup", 10);
+  assert.equal(titleHit[0]?.matched_field, "title");
+
+  const notesHit = await source.search("approved", 10);
+  // M1 matches "approved" in notes (enhanced) — notes outranks transcript.
+  assert.equal(notesHit[0]?.meeting_id, M1);
+  assert.equal(notesHit[0]?.matched_field, "notes");
+
+  const transcriptHit = await source.search("looks fine", 10);
+  assert.equal(transcriptHit[0]?.meeting_id, M1);
+  assert.equal(transcriptHit[0]?.matched_field, "transcript");
+});
+
+test("search escapes LIKE wildcards", async () => {
+  assert.deepEqual(await source.search("100%", 10), []);
+  assert.deepEqual(await source.search("_", 10), []);
+});
+
+test("getNotes returns markdown from both envelopes", async () => {
+  const n = await source.getNotes(M1);
+  assert.ok(n);
+  assert.equal(n.raw_notes_markdown, "- ask about budget");
+  assert.equal(n.enhanced_markdown, "## Decisions\n- approved");
+});
+
+test("getTranscript orders by startMs and renders speaker lines", async () => {
+  const t = await source.getTranscript(M1);
+  assert.ok(t);
+  assert.equal(t.text, "Them: the budget looks fine\nYou: great, approved");
+  assert.equal(t.segments.length, 2);
+  assert.equal(t.duration_min, 30);
+});
+
+test("malformed meeting ids return null instead of erroring", async () => {
+  assert.equal(await source.getMeeting("not-a-uuid"), null);
+  assert.equal(await source.getMeeting("'; drop table meetings;--"), null);
+});

--- a/apps/web/tests/mcp-route.test.ts
+++ b/apps/web/tests/mcp-route.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+import { organization, user } from "@repo/db/auth-schema";
+import { agentTokens, meetings, notes } from "@repo/db/schema";
+import { createInMemoryDb, type InMemoryDb } from "@repo/db/testing";
+
+/**
+ * Route-level test of the hosted MCP: real JSON-RPC requests through the
+ * actual POST handler, against an in-memory database injected via getDb()'s
+ * globalThis singleton (billing is disabled in tests — no Stripe env — so
+ * entitlement passes).
+ */
+
+const TOKEN = `dnag_${"ab".repeat(32)}`;
+const OTHER_TOKEN = `dnag_${"cd".repeat(32)}`;
+const M1 = "11111111-1111-4111-8111-111111111111";
+
+let mem: InMemoryDb;
+let post: (request: Request) => Promise<Response>;
+
+function rpc(body: unknown, token = TOKEN): Request {
+  return new Request("http://localhost/api/mcp", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function call(method: string, params?: unknown, token = TOKEN) {
+  const res = await post(rpc({ jsonrpc: "2.0", id: 1, method, params }, token));
+  return { status: res.status, body: res.status === 202 ? null : await res.json() };
+}
+
+before(async () => {
+  mem = await createInMemoryDb();
+  (globalThis as { __repoDbClient?: unknown }).__repoDbClient = mem.db;
+  // Import AFTER the singleton is injected so the route sees the test db.
+  const route = await import("../app/api/mcp/route");
+  post = route.POST;
+
+  const { createHash } = await import("node:crypto");
+  const db = mem.db;
+  await db.insert(user).values([
+    {
+      id: "u1",
+      name: "Sean",
+      email: "sean@example.com",
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      id: "u2",
+      name: "Other",
+      email: "other@example.com",
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  ]);
+  await db.insert(organization).values([
+    { id: "org-a", name: "A", slug: "a", createdAt: new Date() },
+    { id: "org-b", name: "B", slug: "b", createdAt: new Date() },
+  ]);
+  await db.insert(agentTokens).values([
+    {
+      tokenHash: createHash("sha256").update(TOKEN).digest("hex"),
+      userId: "u1",
+      organizationId: "org-a",
+      name: "Test agent",
+    },
+    {
+      tokenHash: createHash("sha256").update(OTHER_TOKEN).digest("hex"),
+      userId: "u2",
+      organizationId: "org-b",
+      name: "Other workspace agent",
+    },
+  ]);
+  await db.insert(meetings).values({
+    id: M1,
+    organizationId: "org-a",
+    title: "Budget review",
+    kind: "meeting",
+    createdAt: new Date("2026-07-01T10:00:00Z"),
+  });
+  await db.insert(notes).values({
+    meetingId: M1,
+    enhancedContent: { format: "markdown", markdown: "## Approved" },
+  });
+});
+
+after(async () => {
+  await mem.close();
+});
+
+test("rejects missing or malformed bearer tokens with 401", async () => {
+  const res = await post(
+    new Request("http://localhost/api/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    }),
+  );
+  assert.equal(res.status, 401);
+  const wrongPrefix = await call("ping", undefined, `dnsy_${"ab".repeat(32)}`);
+  assert.equal(wrongPrefix.status, 401);
+});
+
+test("initialize negotiates a supported protocol version", async () => {
+  const { status, body } = await call("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "test", version: "0" },
+  });
+  assert.equal(status, 200);
+  assert.equal(body.result.protocolVersion, "2025-06-18");
+  assert.equal(body.result.serverInfo.name, "doodle-note");
+  assert.deepEqual(body.result.capabilities, { tools: {} });
+});
+
+test("notifications are acknowledged with 202 and no body", async () => {
+  const res = await post(
+    rpc({ jsonrpc: "2.0", method: "notifications/initialized" }),
+  );
+  assert.equal(res.status, 202);
+});
+
+test("tools/list returns the shared contract's five tools", async () => {
+  const { body } = await call("tools/list");
+  assert.deepEqual(
+    body.result.tools.map((t: { name: string }) => t.name),
+    [
+      "list_recent_meetings",
+      "search_meetings",
+      "get_meeting",
+      "get_meeting_notes",
+      "get_meeting_transcript",
+    ],
+  );
+});
+
+test("tools/call runs a tool against the token's workspace", async () => {
+  const { body } = await call("tools/call", {
+    name: "get_meeting_notes",
+    arguments: { meeting_id: M1 },
+  });
+  assert.equal(body.result.isError, undefined);
+  const payload = JSON.parse(body.result.content[0].text);
+  assert.equal(payload.schema_version, 1);
+  assert.equal(payload.notes.enhanced_markdown, "## Approved");
+});
+
+test("a token from another workspace cannot read the meeting", async () => {
+  const { body } = await call(
+    "tools/call",
+    { name: "get_meeting_notes", arguments: { meeting_id: M1 } },
+    OTHER_TOKEN,
+  );
+  assert.equal(body.result.isError, true);
+  assert.match(body.result.content[0].text, /No meeting found/);
+});
+
+test("unknown methods get a JSON-RPC -32601", async () => {
+  const { body } = await call("resources/list");
+  assert.equal(body.error.code, -32601);
+});
+
+test("tool validation errors surface as isError content, not crashes", async () => {
+  const { body } = await call("tools/call", {
+    name: "search_meetings",
+    arguments: {},
+  });
+  assert.equal(body.result.isError, true);
+  assert.match(body.result.content[0].text, /query is required/);
+});

--- a/packages/agent-contract/package.json
+++ b/packages/agent-contract/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@repo/agent-contract",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/*.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.1",
+    "tsx": "^4.23.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/agent-contract/src/index.ts
+++ b/packages/agent-contract/src/index.ts
@@ -1,0 +1,11 @@
+export { AGENT_SCHEMA_VERSION } from "./types";
+export type {
+  AgentMeetingSummary,
+  AgentSearchResult,
+  AgentMeetingNotes,
+  AgentTranscriptSegment,
+  AgentTranscript,
+  MeetingSource,
+} from "./types";
+export { AGENT_TOOLS, AgentToolError, executeAgentTool } from "./tools";
+export type { AgentToolDef, AgentToolResult } from "./tools";

--- a/packages/agent-contract/src/tools.test.ts
+++ b/packages/agent-contract/src/tools.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { AGENT_TOOLS, AgentToolError } from "./tools";
+import {
+  AGENT_SCHEMA_VERSION,
+  type MeetingSource,
+  type AgentMeetingSummary,
+} from "./types";
+
+const summary: AgentMeetingSummary = {
+  meeting_id: "m1",
+  kind: "meeting",
+  title: "Standup",
+  created_at: "2026-07-01T10:00:00.000Z",
+  has_notes: true,
+  has_transcript: true,
+};
+
+function fakeSource(overrides: Partial<MeetingSource> = {}): MeetingSource {
+  return {
+    listRecent: async (limit) => [summary].slice(0, limit),
+    search: async () => [{ ...summary, matched_field: "title" }],
+    getMeeting: async (id) => (id === "m1" ? summary : null),
+    getNotes: async (id) =>
+      id === "m1"
+        ? { meeting_id: "m1", title: "Standup", raw_notes_markdown: "hi" }
+        : null,
+    getTranscript: async (id) =>
+      id === "m1"
+        ? { meeting_id: "m1", title: "Standup", segments: [], text: "" }
+        : null,
+    ...overrides,
+  };
+}
+
+function tool(name: string) {
+  const def = AGENT_TOOLS.find((t) => t.name === name);
+  assert.ok(def, `tool ${name} exists`);
+  return def;
+}
+
+test("every tool result carries the schema version", async () => {
+  const source = fakeSource();
+  for (const [name, args] of [
+    ["list_recent_meetings", {}],
+    ["search_meetings", { query: "standup" }],
+    ["get_meeting", { meeting_id: "m1" }],
+    ["get_meeting_notes", { meeting_id: "m1" }],
+    ["get_meeting_transcript", { meeting_id: "m1" }],
+  ] as const) {
+    const result = await tool(name).run(source, { ...args });
+    assert.equal(result["schema_version"], AGENT_SCHEMA_VERSION, name);
+  }
+});
+
+test("limit is validated and clamped to the declared bounds", async () => {
+  const seen: number[] = [];
+  const source = fakeSource({
+    listRecent: async (limit) => {
+      seen.push(limit);
+      return [];
+    },
+  });
+  await tool("list_recent_meetings").run(source, {});
+  await tool("list_recent_meetings").run(source, { limit: 3 });
+  assert.deepEqual(seen, [10, 3]);
+  await assert.rejects(
+    tool("list_recent_meetings").run(source, { limit: 0 }),
+    AgentToolError,
+  );
+  await assert.rejects(
+    tool("list_recent_meetings").run(source, { limit: 999 }),
+    AgentToolError,
+  );
+  await assert.rejects(
+    tool("list_recent_meetings").run(source, { limit: "ten" }),
+    AgentToolError,
+  );
+});
+
+test("search requires a non-empty query", async () => {
+  const source = fakeSource();
+  await assert.rejects(tool("search_meetings").run(source, {}), AgentToolError);
+  await assert.rejects(
+    tool("search_meetings").run(source, { query: "   " }),
+    AgentToolError,
+  );
+});
+
+test("unknown meeting ids produce a clear error, not a null payload", async () => {
+  const source = fakeSource();
+  for (const name of [
+    "get_meeting",
+    "get_meeting_notes",
+    "get_meeting_transcript",
+  ]) {
+    await assert.rejects(
+      tool(name).run(source, { meeting_id: "nope" }),
+      (err: unknown) =>
+        err instanceof AgentToolError && /nope/.test(String(err)),
+      name,
+    );
+  }
+});
+
+test("tool input schemas are well-formed JSON Schema objects", () => {
+  for (const def of AGENT_TOOLS) {
+    assert.equal(typeof def.description, "string");
+    assert.ok(
+      def.description.length > 20,
+      `${def.name} has a real description`,
+    );
+    assert.equal(
+      (def.inputSchema as { type?: string }).type,
+      "object",
+      def.name,
+    );
+  }
+});

--- a/packages/agent-contract/src/tools.ts
+++ b/packages/agent-contract/src/tools.ts
@@ -1,0 +1,189 @@
+import { AGENT_SCHEMA_VERSION, type MeetingSource } from "./types";
+
+/**
+ * Tool definitions shared by every DoodleNote agent surface. Input schemas
+ * are plain JSON Schema (no validator dependency) so both the stdio MCP
+ * server and the hosted MCP can register them verbatim; argument checking
+ * happens in `run` with clear, agent-readable error messages.
+ */
+
+export class AgentToolError extends Error {}
+
+/** JSON-serializable tool result; servers wrap it as they see fit. */
+export type AgentToolResult = Record<string, unknown>;
+
+export interface AgentToolDef {
+  name: string;
+  description: string;
+  /** JSON Schema for the tool's arguments. */
+  inputSchema: Record<string, unknown>;
+  run(
+    source: MeetingSource,
+    args: Record<string, unknown>,
+  ): Promise<AgentToolResult>;
+}
+
+/**
+ * Run one tool by name against a source, normalizing errors: expected
+ * validation/not-found messages go back to the agent verbatim; anything
+ * else becomes a generic message (never internals, paths, or content).
+ * Both the stdio server and the hosted MCP call this, so error behavior
+ * stays identical across surfaces.
+ */
+export async function executeAgentTool(
+  source: MeetingSource,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ ok: true; result: AgentToolResult } | { ok: false; message: string }> {
+  const tool = AGENT_TOOLS.find((t) => t.name === name);
+  if (!tool) return { ok: false, message: `Unknown tool: ${name}` };
+  try {
+    return { ok: true, result: await tool.run(source, args) };
+  } catch (err) {
+    return {
+      ok: false,
+      message:
+        err instanceof AgentToolError
+          ? err.message
+          : "Internal error reading the meeting store.",
+    };
+  }
+}
+
+const DEFAULT_LIST_LIMIT = 10;
+const DEFAULT_SEARCH_LIMIT = 20;
+const MAX_LIMIT = 50;
+
+function readLimit(args: Record<string, unknown>, fallback: number): number {
+  const raw = args["limit"];
+  if (raw === undefined || raw === null) return fallback;
+  const n = typeof raw === "number" ? raw : Number.NaN;
+  if (!Number.isInteger(n) || n < 1 || n > MAX_LIMIT) {
+    throw new AgentToolError(
+      `limit must be an integer between 1 and ${MAX_LIMIT}`,
+    );
+  }
+  return n;
+}
+
+function readString(args: Record<string, unknown>, key: string): string {
+  const raw = args[key];
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new AgentToolError(
+      `${key} is required and must be a non-empty string`,
+    );
+  }
+  return raw.trim();
+}
+
+const MEETING_ID_PROPERTY = {
+  meeting_id: {
+    type: "string",
+    description:
+      "Stable DoodleNote meeting id, as returned by list/search tools.",
+  },
+} as const;
+
+export const AGENT_TOOLS: AgentToolDef[] = [
+  {
+    name: "list_recent_meetings",
+    description:
+      "List the most recent DoodleNote meetings and quick notes, newest first. " +
+      "Returns metadata only (titles, times, whether notes/transcript exist) — " +
+      "use get_meeting_notes or get_meeting_transcript to fetch content.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: {
+          type: "integer",
+          minimum: 1,
+          maximum: MAX_LIMIT,
+          description: `How many to return (default ${DEFAULT_LIST_LIMIT}).`,
+        },
+      },
+    },
+    async run(source, args) {
+      const meetings = await source.listRecent(
+        readLimit(args, DEFAULT_LIST_LIMIT),
+      );
+      return { schema_version: AGENT_SCHEMA_VERSION, meetings };
+    },
+  },
+  {
+    name: "search_meetings",
+    description:
+      "Case-insensitive keyword search across meeting titles, notes, and transcripts. " +
+      "Each result reports the strongest field that matched.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Text to search for." },
+        limit: {
+          type: "integer",
+          minimum: 1,
+          maximum: MAX_LIMIT,
+          description: `Maximum results (default ${DEFAULT_SEARCH_LIMIT}).`,
+        },
+      },
+      required: ["query"],
+    },
+    async run(source, args) {
+      const results = await source.search(
+        readString(args, "query"),
+        readLimit(args, DEFAULT_SEARCH_LIMIT),
+      );
+      return { schema_version: AGENT_SCHEMA_VERSION, results };
+    },
+  },
+  {
+    name: "get_meeting",
+    description:
+      "Fetch metadata for one meeting by id (no notes or transcript content).",
+    inputSchema: {
+      type: "object",
+      properties: { ...MEETING_ID_PROPERTY },
+      required: ["meeting_id"],
+    },
+    async run(source, args) {
+      const id = readString(args, "meeting_id");
+      const meeting = await source.getMeeting(id);
+      if (!meeting) throw new AgentToolError(`No meeting found with id ${id}`);
+      return { schema_version: AGENT_SCHEMA_VERSION, meeting };
+    },
+  },
+  {
+    name: "get_meeting_notes",
+    description:
+      "Fetch a meeting's notes: the user's own rough notes and, when present, the " +
+      "AI-generated notes. Prefer enhanced_markdown when it exists.",
+    inputSchema: {
+      type: "object",
+      properties: { ...MEETING_ID_PROPERTY },
+      required: ["meeting_id"],
+    },
+    async run(source, args) {
+      const id = readString(args, "meeting_id");
+      const notes = await source.getNotes(id);
+      if (!notes) throw new AgentToolError(`No meeting found with id ${id}`);
+      return { schema_version: AGENT_SCHEMA_VERSION, notes };
+    },
+  },
+  {
+    name: "get_meeting_transcript",
+    description:
+      "Fetch a meeting's full transcript as speaker-attributed segments plus a rendered " +
+      "text form. Transcripts can be long — prefer get_meeting_notes for summaries.",
+    inputSchema: {
+      type: "object",
+      properties: { ...MEETING_ID_PROPERTY },
+      required: ["meeting_id"],
+    },
+    async run(source, args) {
+      const id = readString(args, "meeting_id");
+      const transcript = await source.getTranscript(id);
+      if (!transcript)
+        throw new AgentToolError(`No meeting found with id ${id}`);
+      return { schema_version: AGENT_SCHEMA_VERSION, transcript };
+    },
+  },
+];

--- a/packages/agent-contract/src/types.ts
+++ b/packages/agent-contract/src/types.ts
@@ -1,0 +1,76 @@
+/**
+ * The versioned wire contract for agent access to DoodleNote meetings.
+ *
+ * Every surface that exposes meetings to AI agents — the standalone local
+ * MCP server (reads the on-disk store) and the hosted MCP/API (reads the
+ * cloud database) — registers the SAME tools with the SAME argument and
+ * response shapes, defined here. Wire fields are snake_case and decoupled
+ * from internal model types so either backend can evolve independently.
+ *
+ * Source implementations MUST:
+ *  - exclude trashed meetings entirely,
+ *  - exclude echo-flagged transcript segments (consistent with the app),
+ *  - be read-only.
+ */
+
+/** Bump when a response shape changes incompatibly. */
+export const AGENT_SCHEMA_VERSION = 1;
+
+export interface AgentMeetingSummary {
+  meeting_id: string;
+  /** "meeting" or standalone quick "note". */
+  kind: "meeting" | "note";
+  title: string;
+  created_at: string;
+  started_at?: string;
+  ended_at?: string;
+  duration_min?: number;
+  has_notes: boolean;
+  has_transcript: boolean;
+  calendar_event_id?: string;
+}
+
+export interface AgentSearchResult extends AgentMeetingSummary {
+  /** Strongest matching field: title > notes > transcript. */
+  matched_field: "title" | "notes" | "transcript";
+}
+
+export interface AgentMeetingNotes {
+  meeting_id: string;
+  title: string;
+  /** The user's own rough notes (markdown). */
+  raw_notes_markdown: string;
+  /** AI-generated notes (markdown); absent if never generated. */
+  enhanced_markdown?: string;
+  /** Which engine generated enhanced_markdown, e.g. "local:qwen3-4b-instruct". */
+  generated_with?: string;
+}
+
+export interface AgentTranscriptSegment {
+  speaker: "You" | "Them";
+  text: string;
+  start_ms: number;
+  end_ms: number;
+}
+
+export interface AgentTranscript {
+  meeting_id: string;
+  title: string;
+  segments: AgentTranscriptSegment[];
+  /** The transcript rendered as "Speaker: text" lines, ready for prompting. */
+  text: string;
+  duration_min?: number;
+}
+
+/**
+ * The data interface a backend implements to serve the agent tools.
+ * Local: MeetingFileStore. Hosted: org-scoped SQL. Async throughout so
+ * either fits. Return null for unknown/trashed meeting ids.
+ */
+export interface MeetingSource {
+  listRecent(limit: number): Promise<AgentMeetingSummary[]>;
+  search(query: string, limit: number): Promise<AgentSearchResult[]>;
+  getMeeting(meetingId: string): Promise<AgentMeetingSummary | null>;
+  getNotes(meetingId: string): Promise<AgentMeetingNotes | null>;
+  getTranscript(meetingId: string): Promise<AgentTranscript | null>;
+}

--- a/packages/agent-contract/tsconfig.json
+++ b/packages/agent-contract/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/connectors/GBRAIN_ENDPOINT_SPEC.md
+++ b/packages/connectors/GBRAIN_ENDPOINT_SPEC.md
@@ -1,0 +1,77 @@
+# GBrain ingestion endpoint — spec
+
+What the GBrain service (Railway) must implement to receive finalized
+DoodleNote meetings from the `gbrain` connector. The endpoint owns the Git
+writeback; DoodleNote clients (Mac/iOS) never hold GitHub credentials.
+
+## Request
+
+`POST <endpointUrl>` — e.g. `https://<gbrain-host>/api/ingest/doodlenote`
+
+Headers:
+- `Authorization: Bearer <api key>` — a GBrain-minted, per-user, revocable key
+- `Content-Type: application/json`
+
+Body (`schema_version: 1`):
+
+```json
+{
+  "schema_version": 1,
+  "source": "DoodleNote",
+  "doodlenote_id": "<uuid>",
+  "content_hash": "<sha256 hex>",
+  "files": [
+    { "path": "meetings/<YYYYMMDD>-<slug>-<uuid>.md", "content": "<markdown>" },
+    { "path": "meeting-summaries/<YYYYMMDD>-<slug>-<uuid>-summary.md", "content": "<markdown>" }
+  ],
+  "index": {
+    "doodlenote_id": "<uuid>",
+    "title": "Quarterly Budget: Review!",
+    "date": "2026-07-08T10:00:00.000Z",
+    "meeting_path": "meetings/<...>.md",
+    "summary_path": "meeting-summaries/<...>-summary.md",
+    "duration_min": 45
+  }
+}
+```
+
+- `files[].path` is relative to `brain/09-raw-sources/doodlenote/`.
+- `files[].content` already includes frontmatter (`source`, `source_kind`,
+  `doodlenote_id`, `title`, `created_at`, `started_at`, `ended_at`,
+  `calendar_event_id`, `folder`, `content_hash`). The server appends
+  `ingested_at: <commit-time ISO>` to each file's frontmatter before writing.
+- Rendering is deterministic client-side: the same content always produces
+  the same paths and bytes.
+
+## Required behavior
+
+1. **Validate** before touching Git:
+   - bearer key is valid and maps to a configured user (else `401`)
+   - body parses, `schema_version === 1`, paths match
+     `^meetings/|^meeting-summaries/` with no `..` traversal (else `422`)
+   - payload ≤ a sane cap, e.g. 10 MB (else `413`)
+2. **Upsert idempotently**, keyed on `doodlenote_id`:
+   - if a stored meeting with this `doodlenote_id` already has this
+     `content_hash`, return `200` and change nothing (retry no-op)
+   - otherwise delete any previously written files for this `doodlenote_id`
+     whose paths differ (title/date changed → filename changed), write the
+     new files, and regenerate the `meeting-index.md` entry from the `index`
+     block (one entry per `doodlenote_id`, newest first)
+3. **Commit server-side** to the 2nd-brain repo (one commit per ingestion is
+   fine; batching is an internal concern), then trigger the existing GBrain
+   import/embedding pipeline.
+4. **Respond**: `200`/`201` on success. The connector treats `5xx` and
+   network failures as retryable (exponential backoff, same payload), and
+   all other `4xx` as permanent until the meeting's content changes.
+5. **Log without content**: request logs should carry `doodlenote_id`,
+   `content_hash`, sizes, and outcome — never note/transcript bodies.
+
+## Suggested index entry format
+
+```markdown
+- 2026-07-08 — [Quarterly Budget: Review!](meetings/20260708-quarterly-budget-review-<uuid>.md)
+  ([summary](meeting-summaries/20260708-quarterly-budget-review-<uuid>-summary.md), 45 min)
+```
+
+The index is server-owned: regenerate the whole file from stored ingestion
+records rather than patching lines, so concurrent ingestions can't corrupt it.

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@repo/connectors",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/*.test.ts"
+  },
+  "dependencies": {
+    "@repo/meetings-store": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.1",
+    "tsx": "^4.23.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/connectors/src/dispatcher.test.ts
+++ b/packages/connectors/src/dispatcher.test.ts
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { MeetingRecord } from "@repo/meetings-store";
+import {
+  MAX_ATTEMPTS,
+  connectorStatus,
+  planDeliveries,
+  recordFailure,
+  recordSuccess,
+  resetFailures,
+} from "./dispatcher";
+import { contentHashOf } from "./event";
+import type { ConnectorStateMap } from "./types";
+
+function meeting(overrides: Partial<MeetingRecord> = {}): MeetingRecord {
+  return {
+    id: "m1",
+    title: "Kickoff",
+    createdAt: "2026-07-01T10:00:00.000Z",
+    rawNotesMarkdown: "raw",
+    enhancedMarkdown: "## Notes",
+    segments: [],
+    echoSuppressed: 0,
+    ...overrides,
+  };
+}
+
+const NOW = 1_800_000_000_000;
+
+test("plans a delivery for a finalized meeting once, then never again while unchanged", () => {
+  const records = [meeting()];
+  let state: ConnectorStateMap = {};
+  const first = planDeliveries({
+    records,
+    state,
+    connectorIds: ["gbrain"],
+    now: NOW,
+  });
+  assert.equal(first.length, 1);
+  state = recordSuccess(state, first[0]!, NOW);
+  const second = planDeliveries({
+    records,
+    state,
+    connectorIds: ["gbrain"],
+    now: NOW + 1,
+  });
+  assert.deepEqual(second, []);
+});
+
+test("content change re-plans delivery with a new hash", () => {
+  const original = meeting();
+  let state: ConnectorStateMap = {};
+  state = recordSuccess(
+    state,
+    {
+      connectorId: "gbrain",
+      meetingId: "m1",
+      contentHash: contentHashOf(original),
+    },
+    NOW,
+  );
+  const edited = meeting({ enhancedMarkdown: "## Notes v2" });
+  const planned = planDeliveries({
+    records: [edited],
+    state,
+    connectorIds: ["gbrain"],
+    now: NOW,
+  });
+  assert.equal(planned.length, 1);
+  assert.notEqual(planned[0]!.contentHash, contentHashOf(original));
+});
+
+test("unfinalized meetings never plan: no notes, or trashed", () => {
+  const noNotes = meeting({ enhancedMarkdown: undefined });
+  const trashed = meeting({ id: "m2", trashedAt: "2026-07-02T00:00:00.000Z" });
+  const planned = planDeliveries({
+    records: [noNotes, trashed],
+    state: {},
+    connectorIds: ["gbrain"],
+    now: NOW,
+  });
+  assert.deepEqual(planned, []);
+});
+
+test("retryable failure backs off exponentially and stops at MAX_ATTEMPTS", () => {
+  const records = [meeting()];
+  let state: ConnectorStateMap = {};
+  let now = NOW;
+  let attempts = 0;
+  for (let i = 0; i < 20; i++) {
+    const planned = planDeliveries({
+      records,
+      state,
+      connectorIds: ["gbrain"],
+      now,
+    });
+    if (planned.length === 0) {
+      const entry = state["gbrain"]!["m1"]!;
+      if (entry.attempts >= MAX_ATTEMPTS) break;
+      now = entry.nextAttemptAt!; // jump past the backoff window
+      continue;
+    }
+    attempts++;
+    state = recordFailure(state, planned[0]!, "boom", true, now);
+  }
+  assert.equal(attempts, MAX_ATTEMPTS);
+  // Exhausted — even far in the future nothing is planned.
+  const later = planDeliveries({
+    records,
+    state,
+    connectorIds: ["gbrain"],
+    now: now + 10 ** 9,
+  });
+  assert.deepEqual(later, []);
+});
+
+test("non-retryable failure exhausts immediately but new content retries", () => {
+  const records = [meeting()];
+  let state: ConnectorStateMap = {};
+  const planned = planDeliveries({
+    records,
+    state,
+    connectorIds: ["gbrain"],
+    now: NOW,
+  });
+  state = recordFailure(state, planned[0]!, "bad key", false, NOW);
+  assert.deepEqual(
+    planDeliveries({
+      records,
+      state,
+      connectorIds: ["gbrain"],
+      now: NOW + 10 ** 9,
+    }),
+    [],
+  );
+  const edited = [meeting({ title: "Kickoff (renamed)" })];
+  assert.equal(
+    planDeliveries({
+      records: edited,
+      state,
+      connectorIds: ["gbrain"],
+      now: NOW,
+    }).length,
+    1,
+  );
+});
+
+test("resetFailures clears attempts so a manual retry re-plans", () => {
+  const records = [meeting()];
+  let state: ConnectorStateMap = {};
+  const planned = planDeliveries({
+    records,
+    state,
+    connectorIds: ["gbrain"],
+    now: NOW,
+  });
+  state = recordFailure(state, planned[0]!, "bad key", false, NOW);
+  state = resetFailures(state, "gbrain");
+  assert.equal(
+    planDeliveries({ records, state, connectorIds: ["gbrain"], now: NOW })
+      .length,
+    1,
+  );
+});
+
+test("failure keeps the previously delivered hash (edit-after-success failure path)", () => {
+  const original = meeting();
+  let state: ConnectorStateMap = {};
+  state = recordSuccess(
+    state,
+    {
+      connectorId: "gbrain",
+      meetingId: "m1",
+      contentHash: contentHashOf(original),
+    },
+    NOW,
+  );
+  const edited = meeting({ enhancedMarkdown: "## v2" });
+  state = recordFailure(
+    state,
+    {
+      connectorId: "gbrain",
+      meetingId: "m1",
+      contentHash: contentHashOf(edited),
+    },
+    "500",
+    true,
+    NOW,
+  );
+  const entry = state["gbrain"]!["m1"]!;
+  assert.equal(entry.deliveredHash, contentHashOf(original));
+  const status = connectorStatus(state, "gbrain");
+  assert.equal(status.delivered, 1);
+  assert.equal(status.pending, 1);
+  assert.equal(status.lastError, "500");
+});
+
+test("contentHash ignores volatile fields (chat, folder, engine)", () => {
+  const a = meeting();
+  const b = meeting({
+    chat: [{ question: "q", answer: "a", askedAt: "2026-07-01T11:00:00.000Z" }],
+    folderId: "f9",
+    engine: "cloud:claude-sonnet-5",
+  });
+  assert.equal(contentHashOf(a), contentHashOf(b));
+});

--- a/packages/connectors/src/dispatcher.ts
+++ b/packages/connectors/src/dispatcher.ts
@@ -1,0 +1,142 @@
+import type { MeetingRecord } from "@repo/meetings-store";
+import { contentHashOf, isFinalized } from "./event";
+import type { ConnectorStateMap, DeliveryState } from "./types";
+
+/**
+ * Pure dispatch planning: given the current store contents and persisted
+ * delivery state, decide which (connector, meeting) deliveries to attempt
+ * right now. The host app owns timers, persistence, and actually calling
+ * connectors — keeping this pure makes idempotency testable.
+ */
+
+const BASE_BACKOFF_MS = 30_000;
+const MAX_BACKOFF_MS = 60 * 60_000;
+/** Give up after this many consecutive failures of the same snapshot. */
+export const MAX_ATTEMPTS = 8;
+
+export interface PlannedDelivery {
+  connectorId: string;
+  meetingId: string;
+  contentHash: string;
+}
+
+export function planDeliveries(input: {
+  records: MeetingRecord[];
+  state: ConnectorStateMap;
+  connectorIds: string[];
+  now: number;
+}): PlannedDelivery[] {
+  const planned: PlannedDelivery[] = [];
+  for (const record of input.records) {
+    if (!isFinalized(record)) continue;
+    const hash = contentHashOf(record);
+    for (const connectorId of input.connectorIds) {
+      const state = input.state[connectorId]?.[record.id];
+      if (!needsDelivery(state, hash, input.now)) continue;
+      planned.push({ connectorId, meetingId: record.id, contentHash: hash });
+    }
+  }
+  return planned;
+}
+
+function needsDelivery(
+  state: DeliveryState | undefined,
+  hash: string,
+  now: number,
+): boolean {
+  if (!state) return true;
+  if (state.deliveredHash === hash) return false; // already delivered, unchanged
+  if (state.attemptHash !== hash) return true; // content changed — fresh attempt
+  if (state.attempts >= MAX_ATTEMPTS) return false; // exhausted; needs new content or manual retry
+  return state.nextAttemptAt === undefined || now >= state.nextAttemptAt;
+}
+
+export function recordSuccess(
+  state: ConnectorStateMap,
+  delivery: PlannedDelivery,
+  now: number,
+): ConnectorStateMap {
+  return withEntry(state, delivery, {
+    deliveredHash: delivery.contentHash,
+    deliveredAt: new Date(now).toISOString(),
+    attempts: 0,
+  });
+}
+
+export function recordFailure(
+  state: ConnectorStateMap,
+  delivery: PlannedDelivery,
+  error: string,
+  retryable: boolean,
+  now: number,
+): ConnectorStateMap {
+  const prev = state[delivery.connectorId]?.[delivery.meetingId];
+  const attempts =
+    (prev?.attemptHash === delivery.contentHash ? (prev?.attempts ?? 0) : 0) +
+    1;
+  return withEntry(state, delivery, {
+    ...(prev?.deliveredHash ? { deliveredHash: prev.deliveredHash } : {}),
+    ...(prev?.deliveredAt ? { deliveredAt: prev.deliveredAt } : {}),
+    attemptHash: delivery.contentHash,
+    attempts: retryable ? attempts : MAX_ATTEMPTS,
+    nextAttemptAt: now + backoffMs(attempts),
+    lastError: error,
+  });
+}
+
+/** Clear failure bookkeeping so an exhausted meeting is retried on demand. */
+export function resetFailures(
+  state: ConnectorStateMap,
+  connectorId: string,
+): ConnectorStateMap {
+  const forConnector = state[connectorId];
+  if (!forConnector) return state;
+  const cleared: Record<string, DeliveryState> = {};
+  for (const [meetingId, entry] of Object.entries(forConnector)) {
+    cleared[meetingId] = entry.deliveredHash
+      ? {
+          deliveredHash: entry.deliveredHash,
+          deliveredAt: entry.deliveredAt,
+          attempts: 0,
+        }
+      : { attempts: 0 };
+  }
+  return { ...state, [connectorId]: cleared };
+}
+
+function backoffMs(attempts: number): number {
+  return Math.min(BASE_BACKOFF_MS * 2 ** (attempts - 1), MAX_BACKOFF_MS);
+}
+
+function withEntry(
+  state: ConnectorStateMap,
+  delivery: PlannedDelivery,
+  entry: DeliveryState,
+): ConnectorStateMap {
+  return {
+    ...state,
+    [delivery.connectorId]: {
+      ...(state[delivery.connectorId] ?? {}),
+      [delivery.meetingId]: entry,
+    },
+  };
+}
+
+/** Summary the Settings UI shows per connector. */
+export function connectorStatus(
+  state: ConnectorStateMap,
+  connectorId: string,
+): { delivered: number; pending: number; failed: number; lastError?: string } {
+  const entries = Object.values(state[connectorId] ?? {});
+  const failed = entries.filter((e) => e.attempts >= MAX_ATTEMPTS);
+  const pending = entries.filter(
+    (e) => e.attempts > 0 && e.attempts < MAX_ATTEMPTS,
+  );
+  const lastError = [...entries].reverse().find((e) => e.lastError)?.lastError;
+  return {
+    delivered: entries.filter((e) => e.deliveredHash).length,
+    pending: pending.length,
+    failed: failed.length,
+    ...(lastError ? { lastError } : {}),
+  };
+}

--- a/packages/connectors/src/event.ts
+++ b/packages/connectors/src/event.ts
@@ -1,0 +1,81 @@
+import { createHash } from "node:crypto";
+import { durationMinOf, spokenSegments } from "@repo/meetings-store";
+import type { MeetingRecord } from "@repo/meetings-store";
+import type { FinalizedMeetingEvent } from "./types";
+
+/** A meeting is finalized once AI notes exist and it isn't trashed. */
+export function isFinalized(record: MeetingRecord): boolean {
+  return !record.trashedAt && Boolean(record.enhancedMarkdown?.trim());
+}
+
+/**
+ * Hash of the content a destination would store. Field order is fixed and
+ * volatile fields (chat, folder, engine) are excluded, so the hash is stable
+ * across retries and only changes when exported content actually changes.
+ */
+export function contentHashOf(record: MeetingRecord): string {
+  const segments = spokenSegments(record).map((s) => [
+    s.speaker,
+    s.text,
+    s.startMs,
+    s.endMs,
+  ]);
+  const material = JSON.stringify([
+    record.id,
+    record.kind === "note" ? "note" : "meeting",
+    record.title,
+    record.createdAt,
+    record.startedAt ?? "",
+    record.endedAt ?? "",
+    record.calendarEventId ?? "",
+    record.rawNotesMarkdown,
+    record.enhancedMarkdown ?? "",
+    segments,
+  ]);
+  return createHash("sha256").update(material).digest("hex");
+}
+
+export function buildFinalizedEvent(
+  record: MeetingRecord,
+  opts: { folderName?: string; finalizedAt?: string } = {},
+): FinalizedMeetingEvent {
+  if (!isFinalized(record)) {
+    throw new Error(
+      `Meeting ${record.id} is not finalized (no generated notes or trashed).`,
+    );
+  }
+  const segments = spokenSegments(record);
+  return {
+    schema_version: 1,
+    meeting: {
+      id: record.id,
+      kind: record.kind === "note" ? "note" : "meeting",
+      title: record.title,
+      created_at: record.createdAt,
+      ...(record.startedAt ? { started_at: record.startedAt } : {}),
+      ...(record.endedAt ? { ended_at: record.endedAt } : {}),
+      ...(durationMinOf(record) !== undefined
+        ? { duration_min: durationMinOf(record) }
+        : {}),
+      ...(record.calendarEventId
+        ? { calendar_event_id: record.calendarEventId }
+        : {}),
+      ...(opts.folderName ? { folder: opts.folderName } : {}),
+    },
+    notes: {
+      raw_markdown: record.rawNotesMarkdown,
+      enhanced_markdown: record.enhancedMarkdown ?? "",
+    },
+    transcript: {
+      segments: segments.map((s) => ({
+        speaker: s.speaker,
+        text: s.text,
+        start_ms: s.startMs,
+        end_ms: s.endMs,
+      })),
+      text: segments.map((s) => `${s.speaker}: ${s.text}`).join("\n"),
+    },
+    content_hash: contentHashOf(record),
+    finalized_at: opts.finalizedAt ?? new Date().toISOString(),
+  };
+}

--- a/packages/connectors/src/gbrain-markdown.ts
+++ b/packages/connectors/src/gbrain-markdown.ts
@@ -1,0 +1,139 @@
+import type { FinalizedMeetingEvent } from "./types";
+
+/**
+ * Deterministic markdown rendering for the GBrain second-brain repo.
+ * Same event → byte-identical files, so server-side upserts by path are
+ * safe under retries. Paths are relative to the GBrain doodlenote source
+ * root (brain/09-raw-sources/doodlenote/); `ingested_at` frontmatter is
+ * added SERVER-side at commit time (see GBRAIN_ENDPOINT_SPEC.md).
+ */
+
+export interface GBrainFile {
+  path: string;
+  content: string;
+}
+
+export interface GBrainPayload {
+  schema_version: 1;
+  source: "DoodleNote";
+  doodlenote_id: string;
+  content_hash: string;
+  files: GBrainFile[];
+  /** Data the server needs to maintain meeting-index.md. */
+  index: {
+    doodlenote_id: string;
+    title: string;
+    date: string;
+    meeting_path: string;
+    summary_path: string;
+    duration_min?: number;
+  };
+}
+
+/** "Quarterly Budget: Review!" → "quarterly-budget-review" (max 50 chars). */
+export function slugify(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "") // strip diacritics
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 50)
+    .replace(/-+$/, "");
+  return slug || "untitled";
+}
+
+/** YYYYMMDD in UTC from the meeting's start (or creation) time. */
+export function fileDate(event: FinalizedMeetingEvent): string {
+  const iso = event.meeting.started_at ?? event.meeting.created_at;
+  return iso.slice(0, 10).replaceAll("-", "");
+}
+
+export function buildGBrainPayload(
+  event: FinalizedMeetingEvent,
+): GBrainPayload {
+  const base = `${fileDate(event)}-${slugify(event.meeting.title)}-${event.meeting.id}`;
+  const meetingPath = `meetings/${base}.md`;
+  const summaryPath = `meeting-summaries/${base}-summary.md`;
+  return {
+    schema_version: 1,
+    source: "DoodleNote",
+    doodlenote_id: event.meeting.id,
+    content_hash: event.content_hash,
+    files: [
+      { path: meetingPath, content: renderMeetingDoc(event) },
+      { path: summaryPath, content: renderSummaryDoc(event) },
+    ],
+    index: {
+      doodlenote_id: event.meeting.id,
+      title: event.meeting.title || "Untitled meeting",
+      date: event.meeting.started_at ?? event.meeting.created_at,
+      meeting_path: meetingPath,
+      summary_path: summaryPath,
+      ...(event.meeting.duration_min !== undefined
+        ? { duration_min: event.meeting.duration_min }
+        : {}),
+    },
+  };
+}
+
+function frontmatter(event: FinalizedMeetingEvent, sourceKind: string): string {
+  const m = event.meeting;
+  const lines = [
+    "---",
+    "source: DoodleNote",
+    `source_kind: ${sourceKind}`,
+    `doodlenote_id: ${m.id}`,
+    `title: ${yamlString(m.title || "Untitled meeting")}`,
+    `created_at: ${m.created_at}`,
+    ...(m.started_at ? [`started_at: ${m.started_at}`] : []),
+    ...(m.ended_at ? [`ended_at: ${m.ended_at}`] : []),
+    ...(m.calendar_event_id
+      ? [`calendar_event_id: ${yamlString(m.calendar_event_id)}`]
+      : []),
+    ...(m.folder ? [`folder: ${yamlString(m.folder)}`] : []),
+    `content_hash: ${event.content_hash}`,
+    "---",
+  ];
+  return lines.join("\n");
+}
+
+/** Quote a YAML scalar safely (titles can contain anything). */
+function yamlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function renderMeetingDoc(event: FinalizedMeetingEvent): string {
+  const m = event.meeting;
+  const kind =
+    m.kind === "note" ? "doodlenote-quick-note" : "doodlenote-meeting";
+  const parts = [
+    frontmatter(event, kind),
+    "",
+    `# ${m.title || "Untitled meeting"}`,
+    "",
+  ];
+  if (event.notes.raw_markdown.trim()) {
+    parts.push("## My notes", "", event.notes.raw_markdown.trim(), "");
+  }
+  if (event.transcript.segments.length > 0) {
+    parts.push("## Transcript", "", event.transcript.text, "");
+  }
+  return parts.join("\n");
+}
+
+function renderSummaryDoc(event: FinalizedMeetingEvent): string {
+  const m = event.meeting;
+  const kind =
+    m.kind === "note"
+      ? "doodlenote-quick-note-summary"
+      : "doodlenote-meeting-summary";
+  return [
+    frontmatter(event, kind),
+    "",
+    `# ${m.title || "Untitled meeting"} — summary`,
+    "",
+    event.notes.enhanced_markdown.trim(),
+    "",
+  ].join("\n");
+}

--- a/packages/connectors/src/gbrain.test.ts
+++ b/packages/connectors/src/gbrain.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { MeetingRecord } from "@repo/meetings-store";
+import { buildFinalizedEvent } from "./event";
+import { buildGBrainPayload, fileDate, slugify } from "./gbrain-markdown";
+
+function record(): MeetingRecord {
+  return {
+    id: "0b7e4a2c-1111-4222-8333-abcdefabcdef",
+    title: "Quarterly Budget: Review!",
+    createdAt: "2026-07-08T09:55:00.000Z",
+    startedAt: "2026-07-08T10:00:00.000Z",
+    endedAt: "2026-07-08T10:45:00.000Z",
+    calendarEventId: "cal-evt-42",
+    rawNotesMarkdown: "- follow up with legal",
+    enhancedMarkdown: "## Decisions\n- budget approved",
+    segments: [
+      {
+        id: "s1",
+        channel: "mic",
+        speaker: "You",
+        text: "shall we approve the budget",
+        startMs: 0,
+        endMs: 2000,
+        confidence: 0.95,
+      },
+      {
+        id: "s2",
+        channel: "system",
+        speaker: "Them",
+        text: "approved",
+        startMs: 2000,
+        endMs: 3000,
+        confidence: 0.92,
+      },
+    ],
+    echoSuppressed: 1,
+  };
+}
+
+test("slugify produces stable, filesystem-safe slugs", () => {
+  assert.equal(slugify("Quarterly Budget: Review!"), "quarterly-budget-review");
+  assert.equal(slugify("  Café / naïve—test  "), "cafe-naive-test");
+  assert.equal(slugify("!!!"), "untitled");
+  assert.ok(slugify("x".repeat(200)).length <= 50);
+});
+
+test("payload uses the deterministic <date>-<slug>-<id> layout", () => {
+  const event = buildFinalizedEvent(record(), {
+    folderName: "Finance",
+    finalizedAt: "2026-07-08T11:00:00.000Z",
+  });
+  const payload = buildGBrainPayload(event);
+  assert.equal(fileDate(event), "20260708");
+  const base =
+    "20260708-quarterly-budget-review-0b7e4a2c-1111-4222-8333-abcdefabcdef";
+  assert.deepEqual(
+    payload.files.map((f) => f.path),
+    [`meetings/${base}.md`, `meeting-summaries/${base}-summary.md`],
+  );
+  assert.equal(payload.index.meeting_path, `meetings/${base}.md`);
+  assert.equal(payload.doodlenote_id, event.meeting.id);
+  assert.equal(payload.content_hash, event.content_hash);
+});
+
+test("rendering is byte-deterministic for the same event", () => {
+  const event = buildFinalizedEvent(record(), {
+    finalizedAt: "2026-07-08T11:00:00.000Z",
+  });
+  const a = buildGBrainPayload(event);
+  const b = buildGBrainPayload(event);
+  assert.deepEqual(a, b);
+  assert.equal(a.files[0]!.content, b.files[0]!.content);
+});
+
+test("meeting doc carries frontmatter, raw notes, and transcript; summary doc carries enhanced notes", () => {
+  const event = buildFinalizedEvent(record(), {
+    folderName: "Finance",
+    finalizedAt: "2026-07-08T11:00:00.000Z",
+  });
+  const [meetingFile, summaryFile] = buildGBrainPayload(event).files;
+  const doc = meetingFile!.content;
+  assert.ok(doc.startsWith("---\nsource: DoodleNote\n"));
+  assert.match(doc, /source_kind: doodlenote-meeting\n/);
+  assert.match(doc, /doodlenote_id: 0b7e4a2c-1111-4222-8333-abcdefabcdef\n/);
+  assert.match(doc, /title: "Quarterly Budget: Review!"\n/);
+  assert.match(doc, /calendar_event_id: "cal-evt-42"\n/);
+  assert.match(doc, /folder: "Finance"\n/);
+  assert.match(doc, /content_hash: [0-9a-f]{64}\n/);
+  assert.match(doc, /## My notes\n\n- follow up with legal/);
+  assert.match(
+    doc,
+    /## Transcript\n\nYou: shall we approve the budget\nThem: approved/,
+  );
+
+  const summary = summaryFile!.content;
+  assert.match(summary, /source_kind: doodlenote-meeting-summary\n/);
+  assert.match(summary, /## Decisions\n- budget approved/);
+  assert.ok(
+    !summary.includes("shall we approve"),
+    "summary must not embed the transcript",
+  );
+});
+
+test("echo segments never reach the export", () => {
+  const rec = record();
+  rec.segments.push({
+    id: "s3",
+    channel: "mic",
+    speaker: "You",
+    text: "ghost echo line",
+    startMs: 4000,
+    endMs: 5000,
+    confidence: 0.5,
+    echo: true,
+  });
+  const event = buildFinalizedEvent(rec, {
+    finalizedAt: "2026-07-08T11:00:00.000Z",
+  });
+  assert.ok(
+    !JSON.stringify(buildGBrainPayload(event)).includes("ghost echo line"),
+  );
+});

--- a/packages/connectors/src/gbrain.ts
+++ b/packages/connectors/src/gbrain.ts
@@ -1,0 +1,80 @@
+import { buildGBrainPayload } from "./gbrain-markdown";
+import {
+  ConnectorError,
+  type Connector,
+  type FinalizedMeetingEvent,
+} from "./types";
+
+export interface GBrainConfig {
+  /** Full URL of the GBrain ingestion endpoint, e.g. https://gbrain.example.com/api/ingest/doodlenote */
+  endpointUrl: string;
+  /** Bearer token minted by GBrain for this user. */
+  apiKey: string;
+}
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Sends finalized meetings to a GBrain ingestion endpoint, which performs
+ * the Git writeback server-side (clients never hold GitHub credentials).
+ * Idempotent by construction: deterministic file paths + content_hash let
+ * the server upsert; resending the same event is a no-op there.
+ */
+export const gbrainConnector: Connector<GBrainConfig> = {
+  id: "gbrain",
+
+  async deliver(
+    event: FinalizedMeetingEvent,
+    config: GBrainConfig,
+  ): Promise<void> {
+    if (!config.endpointUrl || !config.apiKey) {
+      throw new ConnectorError(
+        "GBrain connector is missing endpoint URL or API key.",
+        false,
+      );
+    }
+    const payload = buildGBrainPayload(event);
+    let response: Response;
+    try {
+      response = await fetch(config.endpointUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${config.apiKey}`,
+        },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch (err) {
+      // Network/timeout — retryable. Never include the payload in the error.
+      throw new ConnectorError(
+        `GBrain endpoint unreachable: ${describe(err)}`,
+        true,
+      );
+    }
+    if (response.ok) return;
+    const detail = (await response.text().catch(() => "")).slice(0, 300);
+    if (response.status === 401 || response.status === 403) {
+      throw new ConnectorError(
+        "GBrain rejected the API key. Check the connector settings.",
+        false,
+      );
+    }
+    if (response.status === 413) {
+      throw new ConnectorError(
+        "GBrain rejected the payload as too large.",
+        false,
+      );
+    }
+    // 4xx = our payload's fault (don't hammer); 5xx = server's fault (retry).
+    const retryable = response.status >= 500;
+    throw new ConnectorError(
+      `GBrain ingestion failed with HTTP ${response.status}${detail ? `: ${detail}` : ""}`,
+      retryable,
+    );
+  },
+};
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -1,0 +1,21 @@
+export { ConnectorError } from "./types";
+export type {
+  FinalizedMeetingEvent,
+  Connector,
+  DeliveryState,
+  ConnectorStateMap,
+} from "./types";
+export { buildFinalizedEvent, contentHashOf, isFinalized } from "./event";
+export {
+  planDeliveries,
+  recordSuccess,
+  recordFailure,
+  resetFailures,
+  connectorStatus,
+  MAX_ATTEMPTS,
+} from "./dispatcher";
+export type { PlannedDelivery } from "./dispatcher";
+export { gbrainConnector } from "./gbrain";
+export type { GBrainConfig } from "./gbrain";
+export { buildGBrainPayload, slugify, fileDate } from "./gbrain-markdown";
+export type { GBrainPayload, GBrainFile } from "./gbrain-markdown";

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -1,0 +1,80 @@
+/**
+ * The connector/export contract: external knowledge systems (GBrain,
+ * Obsidian, Notion, …) are optional DESTINATIONS that receive finalized
+ * meetings. DoodleNote core knows only this interface — never a specific
+ * connector — and connectors never reach back into core services.
+ */
+
+/** Snapshot of a finalized meeting, handed to connectors for delivery. */
+export interface FinalizedMeetingEvent {
+  schema_version: 1;
+  meeting: {
+    /** Stable DoodleNote meeting id (same id on every device and in the cloud). */
+    id: string;
+    kind: "meeting" | "note";
+    title: string;
+    created_at: string;
+    started_at?: string;
+    ended_at?: string;
+    duration_min?: number;
+    calendar_event_id?: string;
+    /** Folder NAME (resolved by the host app); absent = unfiled. */
+    folder?: string;
+  };
+  notes: {
+    raw_markdown: string;
+    /** Non-empty — a meeting is only "finalized" once notes were generated. */
+    enhanced_markdown: string;
+  };
+  transcript: {
+    segments: Array<{
+      speaker: "You" | "Them";
+      text: string;
+      start_ms: number;
+      end_ms: number;
+    }>;
+    /** Rendered "Speaker: text" lines. */
+    text: string;
+  };
+  /** SHA-256 over the durable content; identical retries carry identical hashes. */
+  content_hash: string;
+  /** When this snapshot was taken (ISO). */
+  finalized_at: string;
+}
+
+/** Thrown by connectors; `retryable` decides whether the dispatcher backs off and retries. */
+export class ConnectorError extends Error {
+  constructor(
+    message: string,
+    readonly retryable: boolean,
+  ) {
+    super(message);
+  }
+}
+
+export interface Connector<C = Record<string, unknown>> {
+  /** Stable id, e.g. "gbrain". Used as the state-map key. */
+  id: string;
+  /**
+   * Deliver one finalized meeting. MUST be idempotent — the dispatcher
+   * retries on ConnectorError(retryable=true) and re-sends when content
+   * changes, always with the content_hash the destination can upsert on.
+   */
+  deliver(event: FinalizedMeetingEvent, config: C): Promise<void>;
+}
+
+/** Per-(connector, meeting) delivery bookkeeping, persisted by the host app. */
+export interface DeliveryState {
+  /** Hash of the last successfully delivered snapshot. */
+  deliveredHash?: string;
+  deliveredAt?: string;
+  /** Hash of the snapshot currently being attempted (resets attempts when it changes). */
+  attemptHash?: string;
+  attempts: number;
+  /** Epoch ms before which no retry should run. */
+  nextAttemptAt?: number;
+  lastError?: string;
+}
+
+/** connectorId → meetingId → state. */
+export type ConnectorStateMap = Record<string, Record<string, DeliveryState>>;

--- a/packages/connectors/tsconfig.json
+++ b/packages/connectors/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/db/drizzle/0007_talented_raider.sql
+++ b/packages/db/drizzle/0007_talented_raider.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "agent_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"token_hash" text NOT NULL,
+	"user_id" text NOT NULL,
+	"organization_id" text NOT NULL,
+	"name" text DEFAULT 'Agent' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"last_used_at" timestamp with time zone,
+	CONSTRAINT "agent_tokens_token_hash_unique" UNIQUE("token_hash")
+);
+--> statement-breakpoint
+ALTER TABLE "meetings" ADD COLUMN "kind" text DEFAULT 'meeting' NOT NULL;--> statement-breakpoint
+ALTER TABLE "agent_tokens" ADD CONSTRAINT "agent_tokens_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "agent_tokens" ADD CONSTRAINT "agent_tokens_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "agent_tokens_user_id_idx" ON "agent_tokens" USING btree ("user_id");

--- a/packages/db/drizzle/meta/0007_snapshot.json
+++ b/packages/db/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1436 @@
+{
+  "id": "8c86dbcc-5407-4ad1-8b70-136ac2ec0f04",
+  "prevId": "fe396ff7-c10a-4841-bd6f-f9409c0fd0a4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_tokens": {
+      "name": "agent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Agent'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tokens_user_id_idx": {
+          "name": "agent_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tokens_user_id_user_id_fk": {
+          "name": "agent_tokens_user_id_user_id_fk",
+          "tableFrom": "agent_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tokens_organization_id_organization_id_fk": {
+          "name": "agent_tokens_organization_id_organization_id_fk",
+          "tableFrom": "agent_tokens",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tokens_token_hash_unique": {
+          "name": "agent_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.folders": {
+      "name": "folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "folders_organization_id_idx": {
+          "name": "folders_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "folders_organization_id_organization_id_fk": {
+          "name": "folders_organization_id_organization_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetings": {
+      "name": "meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled meeting'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'meeting'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetings_organization_id_idx": {
+          "name": "meetings_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetings_organization_id_organization_id_fk": {
+          "name": "meetings_organization_id_organization_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_folder_id_folders_id_fk": {
+          "name": "meetings_folder_id_folders_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meetings_share_token_unique": {
+          "name": "meetings_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notes": {
+      "name": "notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_content": {
+          "name": "raw_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enhanced_content": {
+          "name": "enhanced_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notes_meeting_id_meetings_id_fk": {
+          "name": "notes_meeting_id_meetings_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notes_meeting_id_unique": {
+          "name": "notes_meeting_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meeting_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grandfathered": {
+          "name": "grandfathered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_user_id_user_id_fk": {
+          "name": "subscriptions_user_id_user_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_customer_id_unique": {
+          "name": "subscriptions_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_devices": {
+      "name": "sync_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Desktop'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_devices_user_id_idx": {
+          "name": "sync_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_devices_user_id_user_id_fk": {
+          "name": "sync_devices_user_id_user_id_fk",
+          "tableFrom": "sync_devices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_devices_organization_id_organization_id_fk": {
+          "name": "sync_devices_organization_id_organization_id_fk",
+          "tableFrom": "sync_devices",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sync_devices_token_hash_unique": {
+          "name": "sync_devices_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcript_segments": {
+      "name": "transcript_segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker": {
+          "name": "speaker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcript_segments_meeting_id_idx": {
+          "name": "transcript_segments_meeting_id_idx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transcript_segments_meeting_id_meetings_id_fk": {
+          "name": "transcript_segments_meeting_id_meetings_id_fk",
+          "tableFrom": "transcript_segments",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verified_caller_ids": {
+      "name": "verified_caller_ids",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "outgoing_caller_id_sid": {
+          "name": "outgoing_caller_id_sid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "verified_caller_ids_user_id_user_id_fk": {
+          "name": "verified_caller_ids_user_id_user_id_fk",
+          "tableFrom": "verified_caller_ids",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1783516366575,
       "tag": "0006_conscious_ghost_rider",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1783624711777,
+      "tag": "0007_talented_raider",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -26,6 +26,10 @@ export const meetings = pgTable(
       .notNull()
       .references(() => organization.id, { onDelete: "cascade" }),
     title: text("title").notNull().default("Untitled meeting"),
+    /** "meeting" or standalone quick "note" (desktop's kind field). */
+    kind: text("kind", { enum: ["meeting", "note"] })
+      .notNull()
+      .default("meeting"),
     status: text("status", { enum: ["recording", "processing", "complete"] })
       .notNull()
       .default("complete"),
@@ -98,6 +102,30 @@ export const syncDevices = pgTable(
     lastSeenAt: timestamp("last_seen_at", { withTimezone: true }),
   },
   (table) => [index("sync_devices_user_id_idx").on(table.userId)],
+);
+
+/**
+ * A revocable, READ-ONLY token for remote AI agents (the hosted MCP at
+ * /api/mcp). Same trust model as sync_devices: the plaintext `dnag_…` token
+ * is shown once at mint time and only its SHA-256 lives here. Deleting the
+ * row revokes access immediately.
+ */
+export const agentTokens = pgTable(
+  "agent_tokens",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    tokenHash: text("token_hash").notNull().unique(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    name: text("name").notNull().default("Agent"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+    lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+  },
+  (table) => [index("agent_tokens_user_id_idx").on(table.userId)],
 );
 
 /**

--- a/packages/doodle-note-mcp/README.md
+++ b/packages/doodle-note-mcp/README.md
@@ -1,0 +1,100 @@
+# doodle-note-mcp
+
+A read-only [MCP](https://modelcontextprotocol.io) server that gives on-machine AI agents
+(Claude Desktop, Claude Code, Codex, and anything else that speaks MCP over stdio)
+access to your local DoodleNote meetings, notes, and transcripts.
+
+- **Opt-in**: refuses to start until you enable *Agent access* in DoodleNote's Settings,
+  which writes `~/.doodlenote/mcp.json`. Turning the toggle off (or deleting the file)
+  revokes access immediately.
+- **Read-only**: agents can list, search, and read — never write, edit, or delete.
+- **Local**: reads the same on-disk store the app writes (`userData/meetings/`);
+  works while the DoodleNote app is closed; nothing leaves your machine.
+- **Filtered**: trashed meetings are invisible; echo-suppressed transcript segments are
+  excluded, matching what the app shows you.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `list_recent_meetings` | Newest-first metadata (`limit`, default 10) |
+| `search_meetings` | Keyword search across titles, notes, transcripts |
+| `get_meeting` | Metadata for one meeting id |
+| `get_meeting_notes` | Rough + AI-generated notes (markdown) |
+| `get_meeting_transcript` | Speaker-attributed segments + rendered text |
+
+Every response includes `schema_version`. Meeting ids are DoodleNote's stable UUIDs —
+the same ids on every device and in cloud sync.
+
+## Setup
+
+1. In DoodleNote: **Settings → Agent access → Enable**.
+2. Build once from the repo: `pnpm --filter doodle-note-mcp build` (emits `dist/cli.js`).
+
+**Claude Code**
+
+```bash
+claude mcp add doodle-note -- node /path/to/packages/doodle-note-mcp/dist/cli.js
+```
+
+**Claude Desktop** (`claude_desktop_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "doodle-note": {
+      "command": "node",
+      "args": ["/path/to/packages/doodle-note-mcp/dist/cli.js"]
+    }
+  }
+}
+```
+
+**Codex** (`~/.codex/config.toml`)
+
+```toml
+[mcp_servers.doodle-note]
+command = "node"
+args = ["/path/to/packages/doodle-note-mcp/dist/cli.js"]
+```
+
+Once published to npm, `npx doodle-note-mcp` replaces the `node …/dist/cli.js` command.
+
+## Configuration
+
+`~/.doodlenote/mcp.json` (written by the app; `DOODLE_NOTE_MCP_CONFIG` overrides the path):
+
+```json
+{
+  "enabled": true,
+  "meetingsDir": "/Users/you/Library/Application Support/DoodleNote/meetings"
+}
+```
+
+## Hosted MCP (remote agents)
+
+The same five tools are served remotely at `https://www.doodlenote.ai/api/mcp`,
+backed by your cloud-synced meetings instead of the local store — for Claude
+web/mobile, cloud Codex, and agents that don't run on your machine. Mint a
+read-only agent token in the web app (**Workspaces → AI agents**), then:
+
+```bash
+claude mcp add --transport http doodle-note https://www.doodlenote.ai/api/mcp \
+  --header "Authorization: Bearer dnag_…"
+```
+
+Tokens are workspace-scoped and revocable from the same panel. Remote access
+requires cloud sync (it reads the synced copy of your meetings).
+
+## Development
+
+```bash
+pnpm --filter doodle-note-mcp test        # unit tests
+pnpm --filter doodle-note-mcp typecheck
+pnpm --filter doodle-note-mcp build
+```
+
+The tool contract (names, arguments, response schemas) lives in
+`@repo/agent-contract` and is shared verbatim with DoodleNote's hosted MCP,
+so agents built against this server work unchanged against a DoodleNote
+account's cloud data.

--- a/packages/doodle-note-mcp/package.json
+++ b/packages/doodle-note-mcp/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "doodle-note-mcp",
+  "version": "0.1.0",
+  "description": "Read-only MCP server exposing your local DoodleNote meetings, notes, and transcripts to AI agents.",
+  "type": "module",
+  "bin": {
+    "doodle-note-mcp": "./dist/cli.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "esbuild src/cli.ts --bundle --platform=node --format=esm --outfile=dist/cli.js --banner:js=\"#!/usr/bin/env node\" && chmod +x dist/cli.js",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/*.test.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.17.0",
+    "@repo/agent-contract": "workspace:*",
+    "@repo/meetings-store": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.1",
+    "esbuild": "^0.25.0",
+    "tsx": "^4.23.0",
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/doodle-note-mcp/src/cli.ts
+++ b/packages/doodle-note-mcp/src/cli.ts
@@ -1,0 +1,25 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { ConfigError, loadConfig } from "./config";
+import { LocalMeetingSource } from "./local-source";
+import { createServer } from "./server";
+
+const VERSION = "0.1.0";
+
+async function main(): Promise<void> {
+  let config;
+  try {
+    config = loadConfig();
+  } catch (err) {
+    // stderr only — stdout belongs to the MCP protocol.
+    console.error(err instanceof ConfigError ? err.message : String(err));
+    process.exit(1);
+  }
+  const source = new LocalMeetingSource(config.meetingsDir);
+  const server = createServer(source, VERSION);
+  await server.connect(new StdioServerTransport());
+  console.error(
+    `doodle-note-mcp ${VERSION} serving meetings from ${config.meetingsDir}`,
+  );
+}
+
+void main();

--- a/packages/doodle-note-mcp/src/config.ts
+++ b/packages/doodle-note-mcp/src/config.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Agent access is strictly opt-in: this server refuses to start unless the
+ * user has explicitly enabled it, which the DoodleNote app does by writing
+ * this config file (Settings → Agent access). Deleting the file or setting
+ * enabled=false revokes access; nothing else is consulted.
+ */
+export interface McpConfig {
+  enabled: boolean;
+  /** Absolute path to DoodleNote's meetings directory. */
+  meetingsDir: string;
+}
+
+export function defaultConfigPath(): string {
+  return (
+    process.env["DOODLE_NOTE_MCP_CONFIG"] ??
+    join(homedir(), ".doodlenote", "mcp.json")
+  );
+}
+
+export class ConfigError extends Error {}
+
+export function loadConfig(path = defaultConfigPath()): McpConfig {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    throw new ConfigError(
+      `Agent access is not enabled. No config found at ${path}.\n` +
+        "Enable it in the DoodleNote app under Settings → Agent access, " +
+        "which writes this file with the correct meetings path.",
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new ConfigError(`Config at ${path} is not valid JSON.`);
+  }
+  const cfg = parsed as Partial<McpConfig>;
+  if (cfg.enabled !== true) {
+    throw new ConfigError(
+      `Agent access is disabled in ${path}. ` +
+        "Re-enable it in the DoodleNote app under Settings → Agent access.",
+    );
+  }
+  if (typeof cfg.meetingsDir !== "string" || cfg.meetingsDir.length === 0) {
+    throw new ConfigError(`Config at ${path} is missing "meetingsDir".`);
+  }
+  return { enabled: true, meetingsDir: cfg.meetingsDir };
+}

--- a/packages/doodle-note-mcp/src/local-source.test.ts
+++ b/packages/doodle-note-mcp/src/local-source.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { MeetingFileStore } from "@repo/meetings-store";
+import type { TranscriptSegment } from "@repo/meetings-store";
+import { LocalMeetingSource } from "./local-source";
+
+function seg(
+  text: string,
+  opts: Partial<TranscriptSegment> & { startMs?: number } = {},
+): TranscriptSegment {
+  return {
+    id: opts.id ?? `s-${opts.startMs ?? 0}`,
+    channel: opts.channel ?? "mic",
+    speaker: opts.speaker ?? "You",
+    text,
+    startMs: opts.startMs ?? 0,
+    endMs: (opts.startMs ?? 0) + 1000,
+    confidence: 0.9,
+    ...(opts.absoluteStartMs !== undefined
+      ? { absoluteStartMs: opts.absoluteStartMs }
+      : {}),
+    ...(opts.echo !== undefined ? { echo: opts.echo } : {}),
+  };
+}
+
+function fixture(): {
+  source: LocalMeetingSource;
+  store: MeetingFileStore;
+  cleanup: () => void;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "doodle-mcp-"));
+  const store = new MeetingFileStore(dir);
+  store.upsert({
+    id: "meet-1",
+    title: "Kickoff",
+    createdAt: "2026-07-01T10:00:00.000Z",
+    startedAt: "2026-07-01T10:00:00.000Z",
+    endedAt: "2026-07-01T10:30:00.000Z",
+    rawNotesMarkdown: "agenda",
+    enhancedMarkdown: "## Kickoff notes",
+    engine: "local:qwen3-4b-instruct",
+    segments: [
+      seg("hello there", { speaker: "You", startMs: 0, absoluteStartMs: 1000 }),
+      seg("hi, thanks for joining", {
+        speaker: "Them",
+        channel: "system",
+        startMs: 0,
+        absoluteStartMs: 500,
+        id: "sys-0",
+      }),
+      seg("echo bleed", { speaker: "You", startMs: 2000, echo: true }),
+    ],
+  });
+  store.upsert({
+    id: "trashed-1",
+    title: "Secret meeting",
+    createdAt: "2026-07-02T10:00:00.000Z",
+    trashedAt: "2026-07-03T10:00:00.000Z",
+    rawNotesMarkdown: "sensitive",
+  });
+  store.upsert({
+    id: "note-1",
+    kind: "note",
+    title: "Quick idea",
+    createdAt: "2026-07-03T10:00:00.000Z",
+    rawNotesMarkdown: "remember this",
+  });
+  return {
+    source: new LocalMeetingSource(dir),
+    store,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+test("listRecent excludes trashed meetings and marks kinds", async () => {
+  const { source, cleanup } = fixture();
+  try {
+    const meetings = await source.listRecent(10);
+    assert.deepEqual(
+      meetings.map((m) => m.meeting_id),
+      ["note-1", "meet-1"],
+    );
+    assert.equal(meetings[0]?.kind, "note");
+    assert.equal(meetings[1]?.kind, "meeting");
+    assert.equal(meetings[1]?.duration_min, 30);
+  } finally {
+    cleanup();
+  }
+});
+
+test("trashed meetings are invisible to every tool, including search and direct get", async () => {
+  const { source, cleanup } = fixture();
+  try {
+    assert.equal(await source.getMeeting("trashed-1"), null);
+    assert.equal(await source.getNotes("trashed-1"), null);
+    assert.equal(await source.getTranscript("trashed-1"), null);
+    const hits = await source.search("sensitive", 10);
+    assert.deepEqual(hits, []);
+  } finally {
+    cleanup();
+  }
+});
+
+test("transcript filters echo segments and orders by wall clock", async () => {
+  const { source, cleanup } = fixture();
+  try {
+    const t = await source.getTranscript("meet-1");
+    assert.ok(t);
+    assert.deepEqual(
+      t.segments.map((s) => s.speaker),
+      ["Them", "You"], // absoluteStartMs 500 before 1000
+    );
+    assert.ok(!t.text.includes("echo bleed"));
+    assert.equal(t.text, "Them: hi, thanks for joining\nYou: hello there");
+  } finally {
+    cleanup();
+  }
+});
+
+test("notes carry raw + enhanced markdown and the generating engine", async () => {
+  const { source, cleanup } = fixture();
+  try {
+    const notes = await source.getNotes("meet-1");
+    assert.ok(notes);
+    assert.equal(notes.raw_notes_markdown, "agenda");
+    assert.equal(notes.enhanced_markdown, "## Kickoff notes");
+    assert.equal(notes.generated_with, "local:qwen3-4b-instruct");
+  } finally {
+    cleanup();
+  }
+});
+
+test("has_transcript is false when the only segments are echo", async () => {
+  const { source, store, cleanup } = fixture();
+  try {
+    store.upsert({
+      id: "echo-only",
+      title: "Echoes",
+      createdAt: "2026-07-04T10:00:00.000Z",
+      segments: [seg("ghost", { echo: true })],
+    });
+    const meeting = await source.getMeeting("echo-only");
+    assert.equal(meeting?.has_transcript, false);
+  } finally {
+    cleanup();
+  }
+});

--- a/packages/doodle-note-mcp/src/local-source.ts
+++ b/packages/doodle-note-mcp/src/local-source.ts
@@ -1,0 +1,120 @@
+import type {
+  AgentMeetingNotes,
+  AgentMeetingSummary,
+  AgentSearchResult,
+  AgentTranscript,
+  MeetingSource,
+} from "@repo/agent-contract";
+import {
+  MeetingFileStore,
+  durationMinOf,
+  spokenSegments,
+} from "@repo/meetings-store";
+import type { MeetingRecord } from "@repo/meetings-store";
+
+/**
+ * MeetingSource backed by the local on-disk store the DoodleNote app writes.
+ * Read-only by construction (only query methods are called), trashed
+ * meetings are invisible, and echo-flagged segments are filtered the same
+ * way the app's display layer filters them.
+ */
+export class LocalMeetingSource implements MeetingSource {
+  private readonly store: MeetingFileStore;
+
+  constructor(meetingsDir: string) {
+    this.store = new MeetingFileStore(meetingsDir);
+  }
+
+  async listRecent(limit: number): Promise<AgentMeetingSummary[]> {
+    return this.visibleRecords()
+      .slice(0, limit)
+      .map((r) => toSummary(r));
+  }
+
+  async search(query: string, limit: number): Promise<AgentSearchResult[]> {
+    const hits = this.store.search(query);
+    const results: AgentSearchResult[] = [];
+    for (const hit of hits) {
+      const record = this.getVisible(hit.id);
+      if (!record) continue;
+      results.push({ ...toSummary(record), matched_field: hit.field });
+      if (results.length >= limit) break;
+    }
+    return results;
+  }
+
+  async getMeeting(meetingId: string): Promise<AgentMeetingSummary | null> {
+    const record = this.getVisible(meetingId);
+    return record ? toSummary(record) : null;
+  }
+
+  async getNotes(meetingId: string): Promise<AgentMeetingNotes | null> {
+    const record = this.getVisible(meetingId);
+    if (!record) return null;
+    return {
+      meeting_id: record.id,
+      title: record.title,
+      raw_notes_markdown: record.rawNotesMarkdown,
+      ...(record.enhancedMarkdown
+        ? { enhanced_markdown: record.enhancedMarkdown }
+        : {}),
+      ...(record.engine ? { generated_with: record.engine } : {}),
+    };
+  }
+
+  async getTranscript(meetingId: string): Promise<AgentTranscript | null> {
+    const record = this.getVisible(meetingId);
+    if (!record) return null;
+    const segments = spokenSegments(record);
+    return {
+      meeting_id: record.id,
+      title: record.title,
+      segments: segments.map((s) => ({
+        speaker: s.speaker,
+        text: s.text,
+        start_ms: s.startMs,
+        end_ms: s.endMs,
+      })),
+      text: segments.map((s) => `${s.speaker}: ${s.text}`).join("\n"),
+      ...(durationMinOf(record) !== undefined
+        ? { duration_min: durationMinOf(record) }
+        : {}),
+    };
+  }
+
+  /** All non-trashed records, newest first (createdAt is ISO — string sort works). */
+  private visibleRecords(): MeetingRecord[] {
+    return this.store
+      .readAll()
+      .filter((r) => !r.trashedAt)
+      .sort((a, b) =>
+        a.createdAt < b.createdAt ? 1 : a.createdAt > b.createdAt ? -1 : 0,
+      );
+  }
+
+  private getVisible(id: string): MeetingRecord | null {
+    const record = this.store.get(id);
+    return record && !record.trashedAt ? record : null;
+  }
+}
+
+function toSummary(record: MeetingRecord): AgentMeetingSummary {
+  return {
+    meeting_id: record.id,
+    kind: record.kind === "note" ? "note" : "meeting",
+    title: record.title,
+    created_at: record.createdAt,
+    ...(record.startedAt ? { started_at: record.startedAt } : {}),
+    ...(record.endedAt ? { ended_at: record.endedAt } : {}),
+    ...(durationMinOf(record) !== undefined
+      ? { duration_min: durationMinOf(record) }
+      : {}),
+    has_notes: Boolean(
+      record.rawNotesMarkdown.trim() || record.enhancedMarkdown?.trim(),
+    ),
+    has_transcript: record.segments.some((s) => !s.echo),
+    ...(record.calendarEventId
+      ? { calendar_event_id: record.calendarEventId }
+      : {}),
+  };
+}

--- a/packages/doodle-note-mcp/src/server.ts
+++ b/packages/doodle-note-mcp/src/server.ts
@@ -1,0 +1,52 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  AGENT_TOOLS,
+  executeAgentTool,
+  type MeetingSource,
+} from "@repo/agent-contract";
+
+/**
+ * Build the MCP server from the shared tool contract. The hosted DoodleNote
+ * MCP registers the same AGENT_TOOLS against its own MeetingSource — tool
+ * names, arguments, response shapes, and error behavior stay identical
+ * across surfaces (executeAgentTool owns error normalization).
+ */
+export function createServer(source: MeetingSource, version: string): Server {
+  const server = new Server(
+    { name: "doodle-note", version },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: AGENT_TOOLS.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    })),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const outcome = await executeAgentTool(
+      source,
+      request.params.name,
+      request.params.arguments ?? {},
+    );
+    if (!outcome.ok) {
+      return {
+        content: [{ type: "text", text: outcome.message }],
+        isError: true,
+      };
+    }
+    return {
+      content: [
+        { type: "text", text: JSON.stringify(outcome.result, null, 2) },
+      ],
+    };
+  });
+
+  return server;
+}

--- a/packages/doodle-note-mcp/tsconfig.json
+++ b/packages/doodle-note-mcp/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/meetings-store/package.json
+++ b/packages/meetings-store/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@repo/meetings-store",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./types": "./src/types.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/*.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.1",
+    "tsx": "^4.23.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/meetings-store/src/index.ts
+++ b/packages/meetings-store/src/index.ts
@@ -1,0 +1,15 @@
+export {
+  MeetingFileStore,
+  normalizeRecord,
+  durationMinOf,
+  spokenSegments,
+} from "./store";
+export type {
+  MeetingChannel,
+  TranscriptSegment,
+  MeetingChatEntry,
+  MeetingRecord,
+  MeetingSummary,
+  MeetingUpsert,
+  MeetingSearchHit,
+} from "./types";

--- a/packages/meetings-store/src/store.test.ts
+++ b/packages/meetings-store/src/store.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { MeetingFileStore } from "./store";
+import type { TranscriptSegment } from "./types";
+
+function tempStore(): {
+  store: MeetingFileStore;
+  dir: string;
+  cleanup: () => void;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "meetings-store-"));
+  return {
+    store: new MeetingFileStore(dir),
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function segment(text: string, startMs = 0, endMs = 1000): TranscriptSegment {
+  return {
+    id: `s-${startMs}`,
+    channel: "mic",
+    speaker: "You",
+    text,
+    startMs,
+    endMs,
+    confidence: 0.9,
+  };
+}
+
+test("upsert + get round-trips a record and fills defaults", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    store.upsert({ id: "abc-123", title: "Standup" });
+    const got = store.get("abc-123");
+    assert.ok(got);
+    assert.equal(got.title, "Standup");
+    assert.equal(got.rawNotesMarkdown, "");
+    assert.deepEqual(got.segments, []);
+    assert.equal(got.echoSuppressed, 0);
+  } finally {
+    cleanup();
+  }
+});
+
+test("upsert merges patches; null folderId clears the field", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    store.upsert({ id: "m1", title: "A", folderId: "f1" });
+    store.upsert({ id: "m1", enhancedMarkdown: "## Notes" });
+    assert.equal(store.get("m1")?.folderId, "f1");
+    assert.equal(store.get("m1")?.enhancedMarkdown, "## Notes");
+    store.upsert({ id: "m1", folderId: null });
+    assert.equal(store.get("m1")?.folderId, undefined);
+  } finally {
+    cleanup();
+  }
+});
+
+test("rejects unsafe ids for reads and writes", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    assert.throws(() => store.upsert({ id: "../evil", title: "x" }));
+    assert.equal(store.get("../evil"), null);
+  } finally {
+    cleanup();
+  }
+});
+
+test("list sorts newest-first and carries kind/trash markers", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    store.upsert({
+      id: "old",
+      title: "Old",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    store.upsert({
+      id: "new",
+      title: "New",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      kind: "note",
+    });
+    store.upsert({
+      id: "gone",
+      title: "Gone",
+      createdAt: "2026-03-01T00:00:00.000Z",
+      trashedAt: "2026-03-02T00:00:00.000Z",
+    });
+    const list = store.list();
+    assert.deepEqual(
+      list.map((m) => m.id),
+      ["new", "gone", "old"],
+    );
+    assert.equal(list[0]?.kind, "note");
+    assert.ok(list[1]?.trashedAt);
+  } finally {
+    cleanup();
+  }
+});
+
+test("search reports strongest field: title > notes > transcript", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    store.upsert({ id: "a", title: "Budget review" });
+    store.upsert({
+      id: "b",
+      title: "Standup",
+      rawNotesMarkdown: "discuss budget line",
+    });
+    store.upsert({
+      id: "c",
+      title: "Sync",
+      segments: [segment("the budget is fine")],
+    });
+    const hits = store.search("budget");
+    const byId = Object.fromEntries(hits.map((h) => [h.id, h.field]));
+    assert.deepEqual(byId, { a: "title", b: "notes", c: "transcript" });
+  } finally {
+    cleanup();
+  }
+});
+
+test("corrupt files are skipped rather than crashing the list", () => {
+  const { store, dir, cleanup } = tempStore();
+  try {
+    store.upsert({ id: "ok1", title: "Fine" });
+    writeFileSync(join(dir, "bad.json"), "{ not json");
+    assert.deepEqual(
+      store.list().map((m) => m.id),
+      ["ok1"],
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("onDidWrite fires with deletedId on trash and delete", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    const events: Array<{ deletedId?: string }> = [];
+    store.onDidWrite = (c) => events.push(c);
+    store.upsert({ id: "m1", title: "A" });
+    store.upsert({ id: "m1", trashedAt: new Date().toISOString() });
+    store.delete("m1");
+    assert.deepEqual(events, [{}, { deletedId: "m1" }, { deletedId: "m1" }]);
+  } finally {
+    cleanup();
+  }
+});

--- a/packages/meetings-store/src/store.ts
+++ b/packages/meetings-store/src/store.ts
@@ -1,0 +1,246 @@
+import {
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import type {
+  MeetingChatEntry,
+  MeetingRecord,
+  MeetingSearchHit,
+  MeetingSummary,
+  MeetingUpsert,
+  TranscriptSegment,
+} from "./types";
+
+/** Meeting ids are renderer-minted UUIDs; anything else never touches disk. */
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9-]{0,63}$/;
+
+/**
+ * The meetings store: one JSON document per meeting under a directory the
+ * caller owns (the Electron app passes userData/meetings). Pure Node — no
+ * Electron imports — so the standalone MCP server and tests can read the
+ * same store the app writes.
+ */
+export class MeetingFileStore {
+  /**
+   * Post-write hook (cloud sync, connector dispatch): fires after any
+   * persisted change. `deletedId` is set when a meeting was hard-deleted or
+   * moved to trash — both mean its cloud copy (if any) should go away.
+   */
+  onDidWrite: ((change: { deletedId?: string }) => void) | null = null;
+
+  constructor(readonly dir: string) {}
+
+  /* ---- queries ---- */
+
+  list(): MeetingSummary[] {
+    const summaries: MeetingSummary[] = [];
+    for (const file of this.listFiles()) {
+      const record = this.readFile(file);
+      if (!record) continue;
+      summaries.push({
+        id: record.id,
+        ...(record.kind === "note" ? { kind: "note" as const } : {}),
+        title: record.title,
+        createdAt: record.createdAt,
+        ...(record.startedAt ? { startedAt: record.startedAt } : {}),
+        ...(durationMinOf(record) !== undefined
+          ? { durationMin: durationMinOf(record) }
+          : {}),
+        ...(record.folderId ? { folderId: record.folderId } : {}),
+        ...(record.trashedAt ? { trashedAt: record.trashedAt } : {}),
+        ...(record.calendarEventId
+          ? { calendarEventId: record.calendarEventId }
+          : {}),
+      });
+    }
+    // Newest first; createdAt is ISO so string compare sorts chronologically.
+    summaries.sort((a, b) =>
+      a.createdAt < b.createdAt ? 1 : a.createdAt > b.createdAt ? -1 : 0,
+    );
+    return summaries;
+  }
+
+  get(id: string): MeetingRecord | null {
+    if (!SAFE_ID.test(id)) return null;
+    return this.readFile(`${id}.json`);
+  }
+
+  /**
+   * Every stored meeting document, trashed ones included (callers filter).
+   * Powers cross-meeting features in other services — e.g. NotesService
+   * gathering context for the Home-level "ask anything".
+   */
+  readAll(): MeetingRecord[] {
+    const records: MeetingRecord[] = [];
+    for (const file of this.listFiles()) {
+      const record = this.readFile(file);
+      if (record) records.push(record);
+    }
+    return records;
+  }
+
+  /**
+   * Case-insensitive substring search across every stored document. A few
+   * hundred JSON files scan in single-digit milliseconds — no index needed
+   * at this scale. Reports the strongest matching field per meeting
+   * (title > notes > transcript) so the UI can hint where the hit was.
+   */
+  search(query: string): MeetingSearchHit[] {
+    const q = query.trim().toLowerCase();
+    if (q.length === 0) return [];
+    const hits: MeetingSearchHit[] = [];
+    for (const record of this.readAll()) {
+      if ((record.title || "").toLowerCase().includes(q)) {
+        hits.push({ id: record.id, field: "title" });
+      } else if (
+        record.rawNotesMarkdown.toLowerCase().includes(q) ||
+        (record.enhancedMarkdown ?? "").toLowerCase().includes(q)
+      ) {
+        hits.push({ id: record.id, field: "notes" });
+      } else if (
+        record.segments.some((s) => s.text.toLowerCase().includes(q))
+      ) {
+        hits.push({ id: record.id, field: "transcript" });
+      }
+    }
+    return hits;
+  }
+
+  /* ---- writes ---- */
+
+  upsert(patch: MeetingUpsert): MeetingRecord {
+    const id = typeof patch.id === "string" ? patch.id : "";
+    if (!SAFE_ID.test(id)) {
+      throw new Error(`Invalid meeting id: ${JSON.stringify(patch.id)}`);
+    }
+    const existing = this.get(id);
+    const merged = normalizeRecord({ ...(existing ?? {}), ...patch, id });
+    mkdirSync(this.dir, { recursive: true });
+    writeFileSync(
+      join(this.dir, `${id}.json`),
+      JSON.stringify(merged, null, 2),
+    );
+    this.onDidWrite?.(merged.trashedAt ? { deletedId: id } : {});
+    return merged;
+  }
+
+  delete(id: string): void {
+    if (!SAFE_ID.test(id)) return;
+    rmSync(join(this.dir, `${id}.json`), { force: true });
+    this.onDidWrite?.({ deletedId: id });
+  }
+
+  /* ---- disk ---- */
+
+  private listFiles(): string[] {
+    try {
+      return readdirSync(this.dir).filter((f) => f.endsWith(".json"));
+    } catch {
+      return []; // dir doesn't exist yet — no meetings
+    }
+  }
+
+  private readFile(name: string): MeetingRecord | null {
+    try {
+      const raw = JSON.parse(
+        readFileSync(join(this.dir, name), "utf8"),
+      ) as Partial<MeetingRecord>;
+      if (typeof raw.id !== "string" || !SAFE_ID.test(raw.id)) return null;
+      return normalizeRecord(raw as MeetingUpsert);
+    } catch {
+      return null; // unreadable/corrupt file — skip rather than crash the list
+    }
+  }
+}
+
+/** Fill defaults so every stored/returned record has the full shape. */
+export function normalizeRecord(raw: MeetingUpsert): MeetingRecord {
+  return {
+    id: raw.id,
+    // Only "note" is stored; anything else normalizes to the meeting default.
+    ...(raw.kind === "note" ? { kind: "note" as const } : {}),
+    title: typeof raw.title === "string" ? raw.title : "",
+    createdAt:
+      typeof raw.createdAt === "string"
+        ? raw.createdAt
+        : new Date().toISOString(),
+    ...(typeof raw.startedAt === "string" ? { startedAt: raw.startedAt } : {}),
+    ...(typeof raw.endedAt === "string" ? { endedAt: raw.endedAt } : {}),
+    rawNotesMarkdown:
+      typeof raw.rawNotesMarkdown === "string" ? raw.rawNotesMarkdown : "",
+    ...(typeof raw.enhancedMarkdown === "string"
+      ? { enhancedMarkdown: raw.enhancedMarkdown }
+      : {}),
+    ...(typeof raw.engine === "string" ? { engine: raw.engine } : {}),
+    ...(typeof raw.templateId === "string" && raw.templateId.length > 0
+      ? { templateId: raw.templateId }
+      : {}),
+    segments: Array.isArray(raw.segments)
+      ? (raw.segments as TranscriptSegment[])
+      : [],
+    echoSuppressed:
+      typeof raw.echoSuppressed === "number" ? raw.echoSuppressed : 0,
+    ...(Array.isArray(raw.chat) ? { chat: raw.chat.filter(isChatEntry) } : {}),
+    // A null (or invalid) value drops the field — that's how "move back to
+    // My notes" (folderId: null) and "restore from trash" (trashedAt: null)
+    // clear state through the { ...existing, ...patch } merge above.
+    ...(typeof raw.folderId === "string" && raw.folderId.length > 0
+      ? { folderId: raw.folderId }
+      : {}),
+    ...(isIsoString(raw.trashedAt) ? { trashedAt: raw.trashedAt } : {}),
+    // Graph event ids are opaque and can be long — validate shape, cap length.
+    ...(typeof raw.calendarEventId === "string" &&
+    raw.calendarEventId.length > 0 &&
+    raw.calendarEventId.length <= 512
+      ? { calendarEventId: raw.calendarEventId }
+      : {}),
+  };
+}
+
+function isIsoString(value: unknown): value is string {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+function isChatEntry(entry: unknown): entry is MeetingChatEntry {
+  if (typeof entry !== "object" || entry === null) return false;
+  const e = entry as Partial<MeetingChatEntry>;
+  return (
+    typeof e.question === "string" &&
+    typeof e.answer === "string" &&
+    typeof e.askedAt === "string"
+  );
+}
+
+/**
+ * Segments as anything outside the app should see them: echo-flagged ones
+ * dropped (the store already excludes them on write, but every reader
+ * filters defensively — the app's display layer does the same), ordered by
+ * wall clock across the two channels.
+ */
+export function spokenSegments(record: MeetingRecord): TranscriptSegment[] {
+  return record.segments
+    .filter((s) => !s.echo)
+    .slice()
+    .sort(
+      (a, b) =>
+        (a.absoluteStartMs ?? a.startMs) - (b.absoluteStartMs ?? b.startMs),
+    );
+}
+
+export function durationMinOf(record: MeetingRecord): number | undefined {
+  if (record.startedAt && record.endedAt) {
+    const ms = Date.parse(record.endedAt) - Date.parse(record.startedAt);
+    if (Number.isFinite(ms) && ms > 0)
+      return Math.max(1, Math.round(ms / 60_000));
+  }
+  if (record.segments.length > 0) {
+    const ms = Math.max(...record.segments.map((s) => s.endMs));
+    if (Number.isFinite(ms) && ms > 0)
+      return Math.max(1, Math.round(ms / 60_000));
+  }
+  return undefined;
+}

--- a/packages/meetings-store/src/types.ts
+++ b/packages/meetings-store/src/types.ts
@@ -1,0 +1,98 @@
+/**
+ * The meeting data model shared by every process that touches the store:
+ * the Electron app (main + preload + renderer), cloud sync, the standalone
+ * MCP server, and connector exports. Extracted from the desktop app so
+ * non-Electron consumers never import Electron code.
+ */
+
+/** Which capture channel a segment came from. */
+export type MeetingChannel = "mic" | "system";
+
+export interface TranscriptSegment {
+  id: string;
+  channel: MeetingChannel;
+  speaker: "You" | "Them";
+  text: string;
+  /** Milliseconds relative to this channel's stream start. */
+  startMs: number;
+  endMs: number;
+  /** Mean token confidence 0..1. */
+  confidence: number;
+  /** Wall-clock ms (channel epoch + startMs); present once channel_start arrived. */
+  absoluteStartMs?: number;
+  /** True when the segment was judged to be far-side audio bleeding into the mic. */
+  echo?: boolean;
+}
+
+/** One persisted "ask anything" exchange. */
+export interface MeetingChatEntry {
+  question: string;
+  answer: string;
+  /** ISO timestamp of when the question was asked. */
+  askedAt: string;
+}
+
+/** Full meeting document as stored on disk. */
+export interface MeetingRecord {
+  id: string;
+  /**
+   * What this document is: a meeting (default when absent) or a standalone
+   * quick note ("+ New note" — same editor and optional recording, but
+   * created without a meeting context and never auto-recorded).
+   */
+  kind?: "meeting" | "note";
+  title: string;
+  /** ISO timestamp of creation ("+ New meeting"). */
+  createdAt: string;
+  /** ISO timestamp of the first live-capture start, if any. */
+  startedAt?: string;
+  /** ISO timestamp of the last live-capture end, if any. */
+  endedAt?: string;
+  /** The user's rough notes (TipTap doc serialized to markdown). */
+  rawNotesMarkdown: string;
+  /** AI-merged notes, present after a successful Enhance run. */
+  enhancedMarkdown?: string;
+  /** Which notes engine produced enhancedMarkdown (e.g. "local:…"). */
+  engine?: string;
+  /** Note template used for Generate notes; absent = "general". */
+  templateId?: string;
+  /** Interleaved You/Them transcript segments (echo-flagged ones excluded). */
+  segments: TranscriptSegment[];
+  /** How many echo segments were suppressed across the session(s). */
+  echoSuppressed: number;
+  /** "Ask anything" conversation for this meeting, oldest first. */
+  chat?: MeetingChatEntry[];
+  /** Folder assignment; null/absent = unfiled ("My notes"). */
+  folderId?: string | null;
+  /** ISO timestamp of the move to trash; null/absent = not trashed. */
+  trashedAt?: string | null;
+  /** Microsoft 365 event id when created from a calendar prompt (dedupe key). */
+  calendarEventId?: string;
+}
+
+/** Lightweight row for the Home list, sorted newest-first. */
+export interface MeetingSummary {
+  id: string;
+  /** "note" marks standalone quick notes; absent = meeting. */
+  kind?: "meeting" | "note";
+  title: string;
+  createdAt: string;
+  startedAt?: string;
+  /** Recorded length in whole minutes, when derivable. */
+  durationMin?: number;
+  /** Folder assignment; null/absent = unfiled ("My notes"). */
+  folderId?: string | null;
+  /** ISO timestamp of the move to trash; null/absent = not trashed. */
+  trashedAt?: string | null;
+  /** Microsoft 365 event id when created from a calendar prompt (dedupe key). */
+  calendarEventId?: string;
+}
+
+/** Partial update; `id` is required, omitted fields keep their stored value. */
+export type MeetingUpsert = Partial<Omit<MeetingRecord, "id">> & { id: string };
+
+/** Where a full-text search query matched (strongest field reported). */
+export interface MeetingSearchHit {
+  id: string;
+  field: "title" | "notes" | "transcript";
+}

--- a/packages/meetings-store/tsconfig.json
+++ b/packages/meetings-store/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       '@repo/ai':
         specifier: workspace:*
         version: link:../../packages/ai
+      '@repo/connectors':
+        specifier: workspace:*
+        version: link:../../packages/connectors
+      '@repo/meetings-store':
+        specifier: workspace:*
+        version: link:../../packages/meetings-store
       '@tiptap/extension-image':
         specifier: ^3.27.2
         version: 3.27.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
@@ -118,6 +124,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@repo/agent-contract':
+        specifier: workspace:*
+        version: link:../../packages/agent-contract
       '@repo/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -171,6 +180,18 @@ importers:
         specifier: ^5
         version: 5.9.3
 
+  packages/agent-contract:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.1
+        version: 22.20.0
+      tsx:
+        specifier: ^4.23.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/ai:
     dependencies:
       '@ai-sdk/anthropic':
@@ -185,6 +206,22 @@ importers:
       node-llama-cpp:
         specifier: ^3.19.0
         version: 3.19.0(typescript@5.9.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.1
+        version: 22.20.0
+      tsx:
+        specifier: ^4.23.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/connectors:
+    dependencies:
+      '@repo/meetings-store':
+        specifier: workspace:*
+        version: link:../meetings-store
     devDependencies:
       '@types/node':
         specifier: ^22.19.1
@@ -214,6 +251,43 @@ importers:
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
+      tsx:
+        specifier: ^4.23.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/doodle-note-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.17.0
+        version: 1.29.0(zod@4.4.3)
+      '@repo/agent-contract':
+        specifier: workspace:*
+        version: link:../agent-contract
+      '@repo/meetings-store':
+        specifier: workspace:*
+        version: link:../meetings-store
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.1
+        version: 22.20.0
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
+      tsx:
+        specifier: ^4.23.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/meetings-store:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.1
+        version: 22.20.0
       tsx:
         specifier: ^4.23.0
         version: 4.23.0
@@ -1017,6 +1091,12 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@huggingface/jinja@0.5.9':
     resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
     engines: {node: '>=18'}
@@ -1227,6 +1307,16 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -2235,6 +2325,10 @@ packages:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2254,6 +2348,14 @@ packages:
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
@@ -2461,6 +2563,10 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -2638,11 +2744,35 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
@@ -2718,6 +2848,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2857,6 +2991,9 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -2907,6 +3044,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -2987,6 +3128,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -3140,11 +3284,19 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
@@ -3153,6 +3305,16 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -3211,6 +3373,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -3229,6 +3395,14 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -3389,6 +3563,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hono@4.12.28:
+    resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -3398,6 +3576,10 @@ packages:
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -3414,6 +3596,10 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -3447,6 +3633,14 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   ipull@3.9.5:
     resolution: {integrity: sha512-5w/yZB5lXmTfsvNawmvkCjYo4SJNuKQz/av8TC1UiOyfOHyaM+DReqbpU2XpWYfmY+NIUbRRH8PUAWsxaS+IfA==}
@@ -3559,6 +3753,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -3667,6 +3864,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -3912,6 +4112,14 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -3990,9 +4198,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -4069,6 +4285,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   next@16.2.10:
     resolution: {integrity: sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==}
@@ -4176,6 +4396,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -4233,6 +4457,10 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -4248,6 +4476,9 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pe-library@0.4.1:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
     engines: {node: '>=12', npm: '>=6'}
@@ -4262,6 +4493,10 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkijs@3.4.0:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
@@ -4376,6 +4611,10 @@ packages:
   prosemirror-view@1.42.0:
     resolution: {integrity: sha512-N54DF3OXNWDuP81G1kbfCys8ZzIjuL1VnvJ2mk5STSu/fNxWIcX/EutQLA3s9KR/2wVhgDi4hzBB/1fINVxk0A==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -4390,12 +4629,24 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -4519,6 +4770,10 @@ packages:
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4536,6 +4791,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sanitize-filename@1.6.4:
     resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
@@ -4568,9 +4826,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-cookie-parser@3.1.1:
     resolution: {integrity: sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==}
@@ -4586,6 +4852,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -4696,6 +4965,10 @@ packages:
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   stdin-discarder@0.3.2:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
@@ -4865,6 +5138,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -4902,6 +5179,10 @@ packages:
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -4975,6 +5256,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
@@ -5007,6 +5292,10 @@ packages:
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -5143,6 +5432,11 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -5810,6 +6104,10 @@ snapshots:
   '@floating-ui/utils@0.2.11':
     optional: true
 
+  '@hono/node-server@1.19.14(hono@4.12.28)':
+    dependencies:
+      hono: 4.12.28
+
   '@huggingface/jinja@0.5.9': {}
 
   '@humanfs/core@0.19.2':
@@ -5966,6 +6264,28 @@ snapshots:
       fs-extra: 9.1.0
       lodash: 4.18.1
       tmp-promise: 3.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.28)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.28
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6798,6 +7118,11 @@ snapshots:
 
   abbrev@4.0.0: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -6812,6 +7137,10 @@ snapshots:
       '@ai-sdk/provider': 4.0.2
       '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
       zod: 4.4.3
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@6.15.0:
     dependencies:
@@ -7040,6 +7369,20 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolean@3.2.0:
     optional: true
 
@@ -7221,9 +7564,24 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-dirname@0.1.0:
     optional: true
@@ -7294,6 +7652,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -7356,6 +7716,8 @@ snapshots:
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.1.2
+
+  ee-first@1.1.1: {}
 
   ejs@3.1.10:
     dependencies:
@@ -7452,6 +7814,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -7668,6 +8032,8 @@ snapshots:
       '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -7892,9 +8258,15 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   eventemitter3@5.0.4: {}
 
   eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
 
   execa@5.1.1:
     dependencies:
@@ -7909,6 +8281,44 @@ snapshots:
       strip-final-newline: 2.0.0
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -7958,6 +8368,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -7981,6 +8402,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -8188,6 +8613,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hono@4.12.28: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -8195,6 +8622,14 @@ snapshots:
   html-url-attributes@3.0.1: {}
 
   http-cache-semantics@4.2.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -8216,6 +8651,10 @@ snapshots:
       - supports-color
 
   human-signals@2.1.0: {}
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -8244,6 +8683,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.1
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   ipull@3.9.5:
     dependencies:
@@ -8371,6 +8814,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-promise@4.0.0: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -8462,6 +8907,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -8744,6 +9191,10 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -8888,9 +9339,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@2.6.0: {}
 
@@ -8941,6 +9398,8 @@ snapshots:
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
 
   next@16.2.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -9103,6 +9562,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -9173,6 +9636,8 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -9181,6 +9646,8 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-to-regexp@8.4.2: {}
+
   pe-library@0.4.1: {}
 
   picocolors@1.1.1: {}
@@ -9188,6 +9655,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkijs@3.4.0:
     dependencies:
@@ -9340,6 +9809,11 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -9353,9 +9827,23 @@ snapshots:
 
   pvutils@1.1.5: {}
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   queue-microtask@1.2.3: {}
 
   quick-lru@5.1.1: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -9540,6 +10028,16 @@ snapshots:
 
   rou3@0.7.12: {}
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9565,6 +10063,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
   sanitize-filename@1.6.4:
     dependencies:
       truncate-utf8-bytes: 1.0.2
@@ -9584,10 +10084,35 @@ snapshots:
 
   semver@7.8.5: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
     optional: true
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   set-cookie-parser@3.1.1: {}
 
@@ -9612,6 +10137,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -9753,6 +10280,8 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stat-mode@1.0.0: {}
+
+  statuses@2.0.2: {}
 
   stdin-discarder@0.3.2: {}
 
@@ -9941,6 +10470,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -9983,6 +10514,12 @@ snapshots:
 
   type-fest@0.13.1:
     optional: true
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -10083,6 +10620,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   unrs-resolver@1.12.2:
     dependencies:
       napi-postinstall: 0.3.4
@@ -10139,6 +10678,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   validate-npm-package-name@7.0.2: {}
+
+  vary@1.1.2: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -10272,6 +10813,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
## What

Lets users connect AI tools and agents (Claude Desktop/Code/web, Codex, and any MCP client) to their DoodleNote meetings, notes, and transcripts — locally and remotely — plus a generic connector layer for exporting finalized meetings to external knowledge systems, with GBrain as the first connector.

DoodleNote remains the canonical meeting system; no external system is a core dependency.

## Surfaces (one shared contract)

`@repo/agent-contract` defines five read-only tools (`list_recent_meetings`, `search_meetings`, `get_meeting`, `get_meeting_notes`, `get_meeting_transcript`) as plain JSON Schema with `schema_version` on every response, plus a `MeetingSource` interface. Both servers register it verbatim:

- **Local**: `doodle-note-mcp` stdio server over the on-disk store (`@repo/meetings-store`, extracted from Electron). Opt-in only — refuses to start unless Settings → Integrations writes `~/.doodlenote/mcp.json`; works with the app closed; trashed meetings invisible; echo segments filtered.
- **Hosted**: `POST /api/mcp` — stateless MCP streamable-HTTP JSON-RPC over cloud-synced meetings via `CloudMeetingSource` (org-scoped, tenant-isolated). Auth = revocable read-only `dnag_` agent tokens (SHA-256-only storage, mirroring sync's device tokens), minted/revoked in Workspaces → **AI agents**, entitlement-gated like sync.

## Connectors

`@repo/connectors`: finalized-meeting events (AI notes generated + not trashed), content-hash idempotency, exponential-backoff retries, per-meeting status in Settings. The GBrain connector renders deterministic markdown (frontmatter, `<date>-<slug>-<id>` filenames) and POSTs to an authenticated ingestion endpoint that performs the Git writeback server-side — clients never hold Git credentials. Endpoint contract: `packages/connectors/GBRAIN_ENDPOINT_SPEC.md`. iOS meetings reach connectors via sync pull → desktop dispatch.

## Schema

Migration `0007`: `agent_tokens` table + `meetings.kind`; `kind` now round-trips through sync push/pull (quick notes no longer import as meetings).

## Security

- Everything opt-in; MCP surfaces are read-only; revocation is immediate (toggle/file locally, token delete remotely).
- Connector credentials safeStorage-encrypted; hosted access tenant-isolated and entitlement-gated.
- Fixed in passing: `engine-events.log` was persisting transcript text verbatim — now redacted to lengths.

## Tests

106 across the workspace: store parity, contract validation, dispatcher idempotency/backoff, GBrain markdown determinism, echo/trash filtering, CloudMeetingSource tenant isolation, and route-level JSON-RPC coverage of `/api/mcp` (401s, protocol negotiation, cross-workspace invisibility). Web + desktop production builds pass.

## Deploy notes

- Migration 0007 must be applied to Neon before this deploys (`cd packages/db && npx tsx scripts/migrate.ts`).
- `doodle-note-mcp` npm publish is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)