### PR TITLE
Fix output-only meeting detection prompts

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -264,8 +264,10 @@ app.whenReady().then(() => {
     optimizer.watchWindowShortcuts(window)
   })
 
-  // Ad-hoc meeting detection: engine micmon watches for other apps holding
+  // Ad-hoc meeting detection: engine micmon watches for meeting apps holding
   // the mic open (Zoom/Teams/Meet) and prompts even without a calendar event.
+  // Audio output alone is intentionally ignored: it cannot distinguish an
+  // incoming call from ordinary playback, notifications, or phone tones.
   const micWatcher = new MicWatcher(
     resolveEngineBinary(),
     app.getPath('userData'),

--- a/apps/desktop/src/main/mic-watcher-logic.test.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.test.ts
@@ -1,21 +1,17 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import {
-  armedRingLabel,
   initialEndState,
   initialMicState,
-  initialRingEdgeState,
   markEnded,
   markPrompted,
   MEETING_END_DEBOUNCE_MS,
   meetingAppLabel,
-  meetingRingLabel,
-  meetingRingLabels,
+  meetingPromptLabel,
   MIC_COOLDOWN_MS,
   MIC_DEBOUNCE_MS,
   onCaptureMicEvent,
   onMicEvent,
-  onRingLabels,
   setSuppressed,
   shouldAutoStop,
   shouldPrompt
@@ -85,8 +81,7 @@ describe('mic-watcher-logic', () => {
     )
     // DoodleNote's own capture shows up in the ConsentStore — never a meeting.
     assert.equal(meetingAppLabel(['c:#program files#doodlenote#doodlenote.exe']), null)
-    // Windows browsers are excluded from ring labels like mac ones.
-    assert.equal(meetingRingLabel(['c:#...#msedge.exe']), null)
+    assert.equal(meetingAppLabel(['c:#program files#microsoft#edge#msedge.exe']), 'browser')
   })
 
   it('suppression swallows events and requires a fresh edge after lifting', () => {
@@ -140,56 +135,34 @@ describe('meeting-end watch', () => {
   })
 })
 
-describe('meetingRingLabel', () => {
-  it('rings only for native meeting apps, never browsers', () => {
-    assert.equal(meetingRingLabel(['us.zoom.xos']), 'Zoom')
-    assert.equal(meetingRingLabel(['com.apple.FaceTime']), 'FaceTime')
-    assert.equal(meetingRingLabel(['com.google.Chrome']), null) // YouTube ≠ meeting
-    assert.equal(meetingRingLabel(['com.spotify.client']), null)
-    assert.equal(meetingRingLabel([]), null)
-  })
-})
-
-describe('ring edge tracking', () => {
-  it('an app already holding output at watcher start never arms (idle Zoom)', () => {
-    // The 2026-07-11 incident: Zoom open in the background holds a permanent
-    // output session; every audio-client churn (TV app, Discord ding)
-    // re-evaluated it as "ringing" and re-prompted after each cooldown.
-    let s = onRingLabels(initialRingEdgeState(), meetingRingLabels(['us.zoom.xos']))
-    assert.equal(armedRingLabel(s), null)
-    // TV audio churns the client list for hours; Zoom persists throughout.
-    for (let i = 0; i < 50; i++) {
-      s = onRingLabels(s, meetingRingLabels(['us.zoom.xos']))
-    }
-    assert.equal(armedRingLabel(s), null)
+describe('meetingPromptLabel', () => {
+  it('never promotes output-only audio into a recording prompt', () => {
+    assert.equal(
+      meetingPromptLabel({
+        inputRunning: false,
+        inputBundles: [],
+        outputBundles: ['us.zoom.ZoomPhone']
+      }),
+      null
+    )
+    assert.equal(
+      meetingPromptLabel({
+        inputRunning: false,
+        inputBundles: [],
+        outputBundles: ['com.tinyspeck.slackmacgap.helper', 'com.hnc.Discord.helper']
+      }),
+      null
+    )
   })
 
-  it('output appearing after watcher start arms, and stays armed while present', () => {
-    let s = onRingLabels(initialRingEdgeState(), []) // quiet baseline
-    s = onRingLabels(s, meetingRingLabels(['us.zoom.xos'])) // real ring starts
-    assert.equal(armedRingLabel(s), 'Zoom')
-    s = onRingLabels(s, meetingRingLabels(['us.zoom.xos'])) // still ringing
-    assert.equal(armedRingLabel(s), 'Zoom')
-  })
-
-  it('a baseline app becomes armable once it has gone absent', () => {
-    let s = onRingLabels(initialRingEdgeState(), meetingRingLabels(['us.zoom.xos']))
-    s = onRingLabels(s, []) // Zoom quit / released output
-    s = onRingLabels(s, meetingRingLabels(['us.zoom.xos'])) // fresh ring later
-    assert.equal(armedRingLabel(s), 'Zoom')
-  })
-
-  it('a fresh ring arms even while another app is baseline noise', () => {
-    let s = onRingLabels(initialRingEdgeState(), meetingRingLabels(['us.zoom.xos']))
-    s = onRingLabels(s, meetingRingLabels(['us.zoom.xos', 'com.hnc.Discord.helper']))
-    assert.equal(armedRingLabel(s), 'Discord') // Discord edged in; Zoom still baseline
-    s = onRingLabels(s, meetingRingLabels(['us.zoom.xos']))
-    assert.equal(armedRingLabel(s), null) // Discord gone; back to baseline only
-  })
-
-  it('browsers never count as ring output', () => {
-    let s = onRingLabels(initialRingEdgeState(), [])
-    s = onRingLabels(s, meetingRingLabels(['com.google.Chrome']))
-    assert.equal(armedRingLabel(s), null)
+  it('still recognizes a meeting app that is actively using the microphone', () => {
+    assert.equal(
+      meetingPromptLabel({
+        inputRunning: true,
+        inputBundles: ['us.zoom.xos'],
+        outputBundles: ['us.zoom.xos']
+      }),
+      'Zoom'
+    )
   })
 })

--- a/apps/desktop/src/main/mic-watcher-logic.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.ts
@@ -4,8 +4,7 @@
  * feeds it micmon events and asks when the debounce timer lands.
  */
 
-/** Meeting-app audio must persist this long before we prompt — long enough
- *  to outlive chat dings (1-2s), short enough to land early in a ring. */
+/** Meeting-app microphone use must persist this long before we prompt. */
 export const MIC_DEBOUNCE_MS = 4_000
 /** After a prompt (or a dismissal), stay quiet this long. */
 export const MIC_COOLDOWN_MS = 5 * 60_000
@@ -61,68 +60,21 @@ export function meetingAppLabel(bundles: readonly string[]): string | null {
   return null
 }
 
-/**
- * Ring detection works on audio OUTPUT — an incoming call rings long before
- * the mic engages. Browsers are excluded here (any tab playing audio would
- * read as a meeting); only native meeting apps count, and the debounce
- * filters their short notification dings.
- */
-export function meetingRingLabel(bundles: readonly string[]): string | null {
-  const label = meetingAppLabel(bundles)
-  return label === 'browser' ? null : label
+export interface MeetingPromptSignals {
+  inputRunning: boolean
+  inputBundles: readonly string[]
+  outputBundles: readonly string[]
 }
-
-/** Every distinct meeting-app label holding audio output (browsers excluded). */
-export function meetingRingLabels(bundles: readonly string[]): string[] {
-  const labels = new Set<string>()
-  for (const bundle of bundles) {
-    const lower = bundle.toLowerCase()
-    const match = MEETING_BUNDLE_PATTERNS.find((m) => lower.includes(m.pattern))
-    if (match && match.label !== 'browser') labels.add(match.label)
-  }
-  return [...labels]
-}
-
-/* ---- ring edge tracking (kills the idle-Zoom false positive) ---- */
 
 /**
- * A ring must be an EDGE, not a state. An idle Zoom keeps a permanent audio
- * output session, so "meeting app holds output" fired a fresh prompt every
- * cooldown whenever anything (a TV app, a Discord ding) churned the audio
- * client list. Only an app whose output NEWLY APPEARS counts as ringing;
- * whatever was already holding output when watching began is baseline noise
- * until it has gone absent once. A real call on an idle-open Zoom still
- * prompts via the mic path seconds after joining.
+ * Return the app label that is strong enough to justify a recording prompt.
+ * Output activity is deliberately context-only: CoreAudio reports an open
+ * output session, not an actual incoming call, so Zoom Phone tones, Slack
+ * clips, Discord streams, and ordinary playback must never prompt alone.
  */
-export interface RingEdgeState {
-  /** Labels present on the first observed event are baseline, never armed. */
-  sawFirstEvent: boolean
-  /** Ring labels currently holding output → armed (appeared via an edge)? */
-  present: ReadonlyMap<string, boolean>
-}
-
-export function initialRingEdgeState(): RingEdgeState {
-  return { sawFirstEvent: false, present: new Map() }
-}
-
-/** Apply one micmon event's set of output ring labels. */
-export function onRingLabels(state: RingEdgeState, labels: readonly string[]): RingEdgeState {
-  const present = new Map<string, boolean>()
-  for (const label of labels) {
-    const alreadyArmed = state.present.get(label)
-    // Sticky while continuously present; fresh appearances arm only after
-    // the first event (labels in the very first snapshot are baseline).
-    present.set(label, alreadyArmed ?? state.sawFirstEvent)
-  }
-  return { sawFirstEvent: true, present }
-}
-
-/** The label to treat as "ringing now", or null. */
-export function armedRingLabel(state: RingEdgeState): string | null {
-  for (const [label, armed] of state.present) {
-    if (armed) return label
-  }
-  return null
+export function meetingPromptLabel(signals: MeetingPromptSignals): string | null {
+  if (!signals.inputRunning) return null
+  return meetingAppLabel(signals.inputBundles)
 }
 
 export interface MicPromptState {

--- a/apps/desktop/src/main/mic-watcher.ts
+++ b/apps/desktop/src/main/mic-watcher.ts
@@ -3,25 +3,20 @@ import { appendFileSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { WIN_MICMON_ARGS } from './win-micmon'
 import {
-  armedRingLabel,
   initialEndState,
   initialMicState,
-  initialRingEdgeState,
   markEnded,
   markPrompted,
   MEETING_END_DEBOUNCE_MS,
-  meetingAppLabel,
-  meetingRingLabels,
+  meetingPromptLabel,
   MIC_DEBOUNCE_MS,
   onCaptureMicEvent,
   onMicEvent,
-  onRingLabels,
   setSuppressed,
   shouldAutoStop,
   shouldPrompt,
   type MeetingEndState,
-  type MicPromptState,
-  type RingEdgeState
+  type MicPromptState
 } from './mic-watcher-logic'
 
 /** Crashed child restarts after this (engine updates, transient failures). */
@@ -38,12 +33,13 @@ interface MicWatcherConfig {
  * Ad-hoc meeting detection: watches which apps hold the microphone and
  * prompts when a meeting app keeps it open past the debounce — a
  * Zoom/Teams/Meet call that never made it onto the calendar. The signal
- * source is per-platform (same NDJSON contract): macOS runs the engine's
- * `micmon` command (CoreAudio process attribution); Windows runs a
- * PowerShell poll of the ConsentStore registry (win-micmon.ts). Ring
- * detection (audio OUTPUT) exists only in the macOS source. Decision logic
- * is pure and tested (mic-watcher-logic.ts); this class owns the child
- * process and timers.
+ * source is per-platform: macOS runs the engine's `micmon` command (CoreAudio
+ * process attribution); Windows runs a PowerShell poll of the ConsentStore
+ * registry (win-micmon.ts). Decision logic is pure and tested
+ * (mic-watcher-logic.ts); this class owns the child process and timers.
+ * macOS output activity is logged as context but never creates
+ * a prompt by itself because CoreAudio cannot distinguish a ring from normal
+ * playback within Zoom, Slack, Discord, or another meeting-shaped app.
  */
 export class MicWatcher {
   private config: MicWatcherConfig
@@ -65,9 +61,6 @@ export class MicWatcher {
    * recording started from a ring prompt auto-stop after exactly 12s.
    */
   private currentInputLabel: string | null = null
-
-  /** Output-edge tracker: idle meeting apps holding audio forever are noise. */
-  private ringEdge: RingEdgeState = initialRingEdgeState()
 
   /** Meeting-end watch, alive only while our own capture runs (suppressed). */
   private capturing = false
@@ -219,23 +212,24 @@ export class MicWatcher {
             outputBundles?: string[]
           }
           if (event.event === 'micmon' && typeof event.running === 'boolean') {
-            // Only capture by an actual meeting app counts as "busy" —
-            // dictation tools like FluidVoice must never prompt. Sustained
-            // meeting-app OUTPUT (an incoming call ringing) counts too, so
-            // the prompt lands before the call is even answered.
+            // Only microphone capture by an actual meeting app counts as
+            // "busy". Output remains useful diagnostic context, but an open
+            // output session is not proof of a call and must never prompt.
             const bundles = Array.isArray(event.bundles) ? event.bundles.map(String) : []
             const output = Array.isArray(event.outputBundles) ? event.outputBundles.map(String) : []
-            const inputLabel = event.running ? meetingAppLabel(bundles) : null
-            this.ringEdge = onRingLabels(this.ringEdge, meetingRingLabels(output))
-            const ringLabel = armedRingLabel(this.ringEdge)
-            this.currentAppLabel = inputLabel ?? ringLabel
+            const inputLabel = meetingPromptLabel({
+              inputRunning: event.running,
+              inputBundles: bundles,
+              outputBundles: output
+            })
+            this.currentAppLabel = inputLabel
             this.currentInputLabel = inputLabel
             this.diag(
               `event running=${event.running} in=[${bundles.join(',')}] out=[${output.join(',')}] ` +
-                `inputLabel=${inputLabel} ringLabel=${ringLabel} suppressed=${this.state.suppressed}`
+                `inputLabel=${inputLabel} outputOnlyIgnored=${inputLabel === null && output.length > 0} ` +
+                `suppressed=${this.state.suppressed}`
             )
-            this.handleMicEvent(inputLabel !== null || ringLabel !== null)
-            // The end watch keys on the MIC only — output lingers on dings.
+            this.handleMicEvent(inputLabel !== null)
             this.handleEndWatch(inputLabel !== null)
           }
         } catch {


### PR DESCRIPTION
## Bug
DoodleNote offered to record when Zoom Phone, Zoom, Slack, or Discord merely opened an audio-output session.

## Root cause
The macOS watcher promoted CoreAudio output activity into the same busy signal as confirmed meeting-app microphone capture. CoreAudio output state cannot distinguish an incoming call from tones, clips, streams, notifications, or ordinary playback.

## Fix
- require recognized meeting-app microphone use before starting the prompt debounce
- keep output bundle activity in the diagnostic log, marked as ignored when it is output-only
- remove the obsolete ring-edge prompt branch
- retain calendar-start prompts and microphone-based ad-hoc detection

## Verification
- TDD regression: output-only Zoom Phone, Slack, and Discord signals return no prompt; Zoom microphone use remains eligible
- desktop tests: 84 passed, 0 failed, 3 skipped
- desktop node and renderer TypeScript checks passed
- changed-file ESLint passed
- changed-file Prettier check passed
- production Electron build passed

## Baseline note
The repository-wide desktop lint command still reports pre-existing React hook errors in HomeView.tsx and MeetingView.tsx. None of those files are changed by this PR.

## Risk
Incoming-call prompts will no longer appear before the meeting app activates its microphone. Calendar prompts are unaffected, and ad-hoc detection begins once a recognized app is actually using the mic.