### PR TITLE
Release DoodleNote v0.4.6

### DIFF
--- a/RELEASE-v0.4.6.md
+++ b/RELEASE-v0.4.6.md
@@ -1,0 +1,30 @@
+# DoodleNote v0.4.6 release candidate
+
+## Included
+
+- [x] Existing output-only meeting detection fix from PR #47
+- [ ] Coordinate calendar and microphone detections into one prompt
+- [ ] Suppress prompts while DoodleNote is already recording
+- [ ] Prevent a background prompt from reappearing as an in-app banner
+- [ ] Preserve one prompt for a real ad-hoc meeting-app microphone session
+- [x] Bump desktop version from 0.4.5 to 0.4.6
+- [x] Add the v0.4.6 changelog entry
+
+## Verification
+
+- [ ] Focused notification regression tests
+- [ ] Full desktop test suite
+- [ ] Desktop Node and renderer typechecks
+- [ ] Changed-file lint and formatting
+- [ ] Production Electron build
+- [ ] Signed and notarized arm64 package
+- [ ] Live update feed reports 0.4.6
+- [ ] Installed application and running process report 0.4.6
+- [ ] Output-only Zoom Phone smoke test produces no prompt
+- [ ] Scheduled Zoom meeting produces one prompt total
+
+## Release gates
+
+- [ ] Release PR reviewed
+- [ ] User authorizes merge and publication
+- [ ] Published artifact checksum matches the live update manifest

--- a/RELEASE-v0.4.6.md
+++ b/RELEASE-v0.4.6.md
@@ -3,20 +3,20 @@
 ## Included
 
 - [x] Existing output-only meeting detection fix from PR #47
-- [ ] Coordinate calendar and microphone detections into one prompt
-- [ ] Suppress prompts while DoodleNote is already recording
-- [ ] Prevent a background prompt from reappearing as an in-app banner
-- [ ] Preserve one prompt for a real ad-hoc meeting-app microphone session
+- [x] Coordinate calendar and microphone detections into one prompt
+- [x] Suppress prompts while DoodleNote is already recording
+- [x] Prevent a background prompt from reappearing as an in-app banner
+- [x] Preserve one prompt for a real ad-hoc meeting-app microphone session
 - [x] Bump desktop version from 0.4.5 to 0.4.6
 - [x] Add the v0.4.6 changelog entry
 
 ## Verification
 
-- [ ] Focused notification regression tests
-- [ ] Full desktop test suite
-- [ ] Desktop Node and renderer typechecks
-- [ ] Changed-file lint and formatting
-- [ ] Production Electron build
+- [x] Focused notification regression tests (32 passed)
+- [x] Full desktop test suite (93 passed, 3 media-fixture skips)
+- [x] Desktop Node and renderer typechecks
+- [x] Changed-file lint and formatting
+- [x] Production Electron build
 - [ ] Signed and notarized arm64 package
 - [ ] Live update feed reports 0.4.6
 - [ ] Installed application and running process report 0.4.6
@@ -28,3 +28,7 @@
 - [ ] Release PR reviewed
 - [ ] User authorizes merge and publication
 - [ ] Published artifact checksum matches the live update manifest
+
+Full desktop lint still reports eight pre-existing React hook errors in
+untouched `HomeView.tsx` and `MeetingView.tsx`. The v0.4.6 changed-file lint
+has zero errors.

--- a/RELEASE-v0.4.6.md
+++ b/RELEASE-v0.4.6.md
@@ -17,7 +17,7 @@
 - [x] Desktop Node and renderer typechecks
 - [x] Changed-file lint and formatting
 - [x] Production Electron build
-- [ ] Signed and notarized arm64 package
+- [x] Signed and notarized arm64 package
 - [ ] Live update feed reports 0.4.6
 - [ ] Installed application and running process report 0.4.6
 - [ ] Output-only Zoom Phone smoke test produces no prompt
@@ -32,3 +32,8 @@
 Full desktop lint still reports eight pre-existing React hook errors in
 untouched `HomeView.tsx` and `MeetingView.tsx`. The v0.4.6 changed-file lint
 has zero errors.
+
+Packaged artifact: `DoodleNote-0.4.6-arm64-mac.zip`  
+SHA-256: `d7c007947efbf61c9ddf38eaaddca20926de514059492389f68b1db91dba61aa`  
+Notarization: accepted (`a3d279cc-ca1a-4475-9534-8b66357b6a5c`)  
+Gatekeeper: accepted (`source=Notarized Developer ID`)

--- a/RELEASE-v0.4.6.md
+++ b/RELEASE-v0.4.6.md
@@ -26,8 +26,8 @@
 ## Release gates
 
 - [ ] Release PR reviewed
-- [ ] User authorizes merge and publication
-- [ ] Published artifact checksum matches the live update manifest
+- [x] User authorizes merge and publication
+- [x] Published artifact checksum matches the Blob update manifest
 
 Full desktop lint still reports eight pre-existing React hook errors in
 untouched `HomeView.tsx` and `MeetingView.tsx`. The v0.4.6 changed-file lint

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "private": true,
   "description": "Doodle Note desktop app \u2014 spawns the Swift transcription sidecar and shows its live transcript stream",
   "main": "./out/main/index.js",

--- a/apps/desktop/src/main/calendar-service.ts
+++ b/apps/desktop/src/main/calendar-service.ts
@@ -51,6 +51,13 @@ import {
 import { eventsToPromptNow, pruneNotified } from './calendar-watcher'
 import { GoogleCalendarClient } from './google-calendar'
 import type { PromptPanel } from './prompt-panel'
+import {
+  choosePromptSurface,
+  coordinatePrompt,
+  initialPromptCoordinatorState,
+  setPromptRecording,
+  type PromptCoordinatorState
+} from './prompt-coordinator'
 
 /** Delegated Graph permissions; offline_access keeps the refresh token. */
 const SCOPES = ['User.Read', 'Calendars.Read', 'offline_access']
@@ -77,14 +84,18 @@ function landingPage(title: string, message: string): string {
     '<!doctype html><html><head><meta charset="utf-8">' +
     '<meta name="viewport" content="width=device-width,initial-scale=1">' +
     '<title>DoodleNote</title></head>' +
-    '<body style="font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;' +
+    "<body style=\"font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;" +
     'background:#f7f5ee;color:#26281f;display:flex;align-items:center;justify-content:center;' +
     'height:100vh;margin:0">' +
     '<div style="text-align:center;max-width:440px;padding:0 24px">' +
     '<div style="font-size:19px;font-weight:700;letter-spacing:-0.01em;margin-bottom:26px">' +
     '<span style="color:#26281f">Doodle</span><span style="color:#7c9769">Note</span></div>' +
-    '<h2 style="margin:0 0 10px;font-family:ui-serif,Georgia,serif;font-size:26px">' + title + '</h2>' +
-    '<p style="color:#8a8d7f;line-height:1.55;margin:0">' + message + '</p>' +
+    '<h2 style="margin:0 0 10px;font-family:ui-serif,Georgia,serif;font-size:26px">' +
+    title +
+    '</h2>' +
+    '<p style="color:#8a8d7f;line-height:1.55;margin:0">' +
+    message +
+    '</p>' +
     '<div style="margin-top:30px;font-size:12px;color:#b4b6a8">Local &amp; private &middot; ' +
     'your calendar stays on your Mac</div>' +
     '</div></body></html>'
@@ -169,6 +180,7 @@ export class CalendarService {
   private lastSyncIso: string | undefined
   private lastError: string | undefined
   private notified: Record<string, string>
+  private promptState: PromptCoordinatorState
 
   private pollTimer: ReturnType<typeof setInterval> | null = null
   private watchTimer: ReturnType<typeof setInterval> | null = null
@@ -196,6 +208,13 @@ export class CalendarService {
     this.config = settings.config
     this.prefs = settings.prefs
     this.notified = this.loadNotified()
+    this.promptState = initialPromptCoordinatorState(
+      Object.fromEntries(
+        Object.entries(this.notified)
+          .map(([id, iso]) => [`calendar:${id}`, Date.parse(iso)] as const)
+          .filter((entry) => Number.isFinite(entry[1]))
+      )
+    )
     const cache = this.loadEventCache()
     this.rawEvents = cache.events
     this.calendars = cache.calendars ?? []
@@ -265,7 +284,13 @@ export class CalendarService {
   }
 
   /** App-level focus hook: refresh, but never hammer Graph on tab-outs. */
-  onWindowFocus(): void {
+  onWindowFocus(window?: BrowserWindow): void {
+    // Clicking the floating panel focuses that panel long enough for its links
+    // to fire; do not close it out from underneath the user's click.
+    if (window && this.promptPanel?.ownsWindow(window)) return
+    // A background prompt owns the floating panel only. Closing it here avoids
+    // turning one detection into a panel followed by a second in-app banner.
+    this.promptPanel?.close()
     void this.ready.then(() => {
       if (!this.account) return
       const last = this.lastSyncIso ? Date.parse(this.lastSyncIso) : 0
@@ -278,6 +303,21 @@ export class CalendarService {
     this.disposed = true
     this.stopTimers()
     this.destroyTray()
+    this.promptPanel?.close()
+  }
+
+  /** Recording is a global prompt suppression state, regardless of how the
+   *  meeting was started. Clear any outstanding surface immediately. */
+  setRecordingActive(recording: boolean): void {
+    this.promptState = setPromptRecording(this.promptState, recording)
+    if (!recording) return
+    this.promptPanel?.close()
+    this.broadcast(CALENDAR_START_MEETING_CHANNEL, {
+      action: 'dismiss',
+      eventId: '',
+      subject: '',
+      startIso: new Date().toISOString()
+    } satisfies CalendarStartMeetingEvent)
   }
 
   /* ---- state ---- */
@@ -820,21 +860,33 @@ export class CalendarService {
    * is closed or buried — the floating prompt panel. Also the entry point
    * for ad-hoc mic-detected prompts (MicWatcher).
    */
-  deliverPrompt(payload: CalendarStartMeetingEvent): void {
-    // One surface per prompt — stacking channels put the macOS notification
-    // on top of our own panel (both live top-right). Focused window gets the
-    // in-app banner; otherwise the floating panel (it has the Take-notes
-    // button); the OS notification only when the panel can't be shown.
-    this.broadcast(CALENDAR_START_MEETING_CHANNEL, payload)
+  deliverPrompt(requested: CalendarStartMeetingEvent): void {
+    const nowMs = Date.now()
+    const decision = coordinatePrompt(this.promptState, requested, this.visibleEvents(), nowMs)
+    this.promptState = decision.state
+    if (!decision.prompt) return
+    const payload = decision.prompt
+
+    // A mic signal correlated to a calendar event owns that event's one prompt,
+    // so the 30-second calendar watcher must not deliver it again later.
+    if (payload.eventId && this.notified[payload.eventId] === undefined) {
+      this.notified[payload.eventId] = new Date(nowMs).toISOString()
+      this.saveNotified()
+    }
+
     try {
       app.dock?.bounce('informational')
     } catch {
       // Not on macOS, or no dock — the banner already covers it.
     }
-    const window = BrowserWindow.getAllWindows()[0]
+    const window = BrowserWindow.getAllWindows().find(
+      (candidate) => !this.promptPanel?.ownsWindow(candidate)
+    )
     const bannerVisible = window !== undefined && window.isVisible() && window.isFocused()
-    if (bannerVisible) return
-    if (this.promptPanel) {
+    const surface = choosePromptSurface(bannerVisible, this.promptPanel !== undefined)
+    if (surface === 'banner') {
+      this.broadcast(CALENDAR_START_MEETING_CHANNEL, payload)
+    } else if (surface === 'panel' && this.promptPanel) {
       this.promptPanel.show(payload, (action) => {
         if (action === 'start') this.actOnPromptStart(payload)
       })
@@ -846,6 +898,7 @@ export class CalendarService {
   /** One click anywhere = meeting created + recording (renderer handles it). */
   private actOnPromptStart(prompt: CalendarStartMeetingEvent): void {
     const payload = { ...prompt, action: 'start' as const }
+    this.promptPanel?.close()
     const hadWindow = BrowserWindow.getAllWindows().length > 0
     this.focusWindow()
     if (hadWindow) {
@@ -864,9 +917,7 @@ export class CalendarService {
     try {
       if (!Notification.isSupported()) return
       const notification = new Notification({
-        title: prompt.adHoc
-          ? 'Looks like you’re on a call'
-          : `${prompt.subject} is starting`,
+        title: prompt.adHoc ? 'Looks like you’re on a call' : `${prompt.subject} is starting`,
         body: 'Click to start taking notes'
       })
       notification.on('click', () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -343,6 +343,7 @@ app.whenReady().then(() => {
   ipcMain.on(ENGINE_START_CHANNEL, (_event, request: EngineStartRequest) => {
     // Our own capture holds the mic — the ad-hoc meeting detector must not
     // mistake it for a Zoom call. Suppress BEFORE the engine opens the mic.
+    if (request.command === 'live') calendarService?.setRecordingActive(true)
     micWatcher.setSuppressed(true)
     const opts = { ...request.opts }
     // Audio persistence: give the session a directory keyed by meeting; the
@@ -359,6 +360,7 @@ app.whenReady().then(() => {
   ipcMain.on(ENGINE_STOP_CHANNEL, () => {
     engine.stop()
     micWatcher.setSuppressed(false)
+    calendarService?.setRecordingActive(false)
   })
 
   // Mic input picker: device list + (mid-session) switching. macOS engine
@@ -507,7 +509,7 @@ app.whenReady().then(() => {
   mediaService.registerProtocol()
 
   // A fresh look at the app deserves fresh events (throttled inside).
-  app.on('browser-window-focus', () => calendarService?.onWindowFocus())
+  app.on('browser-window-focus', (_event, window) => calendarService?.onWindowFocus(window))
 
   createWindow()
 

--- a/apps/desktop/src/main/mic-watcher-logic.test.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.test.ts
@@ -10,6 +10,7 @@ import {
   meetingPromptLabel,
   MIC_COOLDOWN_MS,
   MIC_DEBOUNCE_MS,
+  MIC_SESSION_GAP_MS,
   onCaptureMicEvent,
   onMicEvent,
   setSuppressed,
@@ -38,16 +39,34 @@ describe('mic-watcher-logic', () => {
     assert.equal(shouldPrompt(s, T0 + MIC_DEBOUNCE_MS + 60_000), false)
   })
 
-  it('idle resets the session but cooldown still applies', () => {
+  it('a short idle stays in the session and the cooldown still applies', () => {
     let s = onMicEvent(initialMicState(), true, T0)
     s = markPrompted(s, T0 + MIC_DEBOUNCE_MS)
     s = onMicEvent(s, false, T0 + 60_000) // hang up
     s = onMicEvent(s, true, T0 + 70_000) // new call right away
     assert.equal(shouldPrompt(s, T0 + 70_000 + MIC_DEBOUNCE_MS), false) // inside cooldown
-    const afterCooldown = T0 + MIC_DEBOUNCE_MS + MIC_COOLDOWN_MS
-    s = onMicEvent(s, false, afterCooldown - 20_000)
-    s = onMicEvent(s, true, afterCooldown - 10_000)
-    assert.equal(shouldPrompt(s, afterCooldown + 1), true)
+    // The same busy stretch remains quiet even after the wall-clock cooldown.
+    assert.equal(shouldPrompt(s, T0 + MIC_DEBOUNCE_MS + MIC_COOLDOWN_MS + 1), false)
+  })
+
+  it('does not re-prompt when the mic reconnects during the same meeting', () => {
+    let s = onMicEvent(initialMicState(), true, T0)
+    s = markPrompted(s, T0 + MIC_DEBOUNCE_MS)
+    // Drop late enough that the ordinary five-minute cooldown will expire
+    // before the reconnect; the session-gap guard must still keep it quiet.
+    s = onMicEvent(s, false, T0 + 4 * 60_000 + 30_000)
+    const reconnect = T0 + 4 * 60_000 + 30_000 + MIC_SESSION_GAP_MS - 1
+    s = onMicEvent(s, true, reconnect)
+    assert.equal(shouldPrompt(s, reconnect + MIC_DEBOUNCE_MS), false)
+  })
+
+  it('allows a later call after the reconnect window and cooldown', () => {
+    let s = onMicEvent(initialMicState(), true, T0)
+    s = markPrompted(s, T0 + MIC_DEBOUNCE_MS)
+    s = onMicEvent(s, false, T0 + 60_000)
+    const nextCall = T0 + MIC_DEBOUNCE_MS + MIC_COOLDOWN_MS + MIC_SESSION_GAP_MS
+    s = onMicEvent(s, true, nextCall)
+    assert.equal(shouldPrompt(s, nextCall + MIC_DEBOUNCE_MS), true)
   })
 
   it('short blips (Siri, dictation) never fire', () => {

--- a/apps/desktop/src/main/mic-watcher-logic.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.ts
@@ -8,6 +8,8 @@
 export const MIC_DEBOUNCE_MS = 4_000
 /** After a prompt (or a dismissal), stay quiet this long. */
 export const MIC_COOLDOWN_MS = 5 * 60_000
+/** A short mic dropout/reconnect still belongs to the same meeting. */
+export const MIC_SESSION_GAP_MS = 2 * 60_000
 
 /**
  * Only mic capture by an actual meeting app counts — dictation tools
@@ -84,12 +86,20 @@ export interface MicPromptState {
   promptedThisSession: boolean
   /** Epoch ms of the last prompt, for the cooldown. */
   lastPromptMs: number
+  /** When the meeting app last released the mic; null while busy/unknown. */
+  idleSinceMs: number | null
   /** Our own capture is running — everything is ignored until it isn't. */
   suppressed: boolean
 }
 
 export function initialMicState(): MicPromptState {
-  return { busySinceMs: null, promptedThisSession: false, lastPromptMs: 0, suppressed: false }
+  return {
+    busySinceMs: null,
+    promptedThisSession: false,
+    lastPromptMs: 0,
+    idleSinceMs: null,
+    suppressed: false
+  }
 }
 
 /** Apply a micmon running=true/false transition. */
@@ -98,10 +108,20 @@ export function onMicEvent(state: MicPromptState, running: boolean, nowMs: numbe
   if (running) {
     // Already tracking this busy stretch — keep its original start.
     if (state.busySinceMs !== null) return state
-    return { ...state, busySinceMs: nowMs }
+    const sameSession =
+      state.promptedThisSession &&
+      state.idleSinceMs !== null &&
+      nowMs - state.idleSinceMs <= MIC_SESSION_GAP_MS
+    return {
+      ...state,
+      busySinceMs: nowMs,
+      idleSinceMs: null,
+      promptedThisSession: sameSession
+    }
   }
-  // Idle again: the next busy stretch may prompt anew (cooldown permitting).
-  return { ...state, busySinceMs: null, promptedThisSession: false }
+  // Repeated non-mic CoreAudio changes must not keep moving the idle edge.
+  if (state.busySinceMs === null) return state
+  return { ...state, busySinceMs: null, idleSinceMs: nowMs }
 }
 
 /**
@@ -110,8 +130,16 @@ export function onMicEvent(state: MicPromptState, running: boolean, nowMs: numbe
  * any activity to a prompt (the meeting app's mic use may simply continue).
  */
 export function setSuppressed(state: MicPromptState, suppressed: boolean): MicPromptState {
-  if (suppressed) return { ...state, suppressed: true, busySinceMs: null }
-  return { ...state, suppressed: false, busySinceMs: null, promptedThisSession: false }
+  if (suppressed) {
+    return { ...state, suppressed: true, busySinceMs: null, idleSinceMs: null }
+  }
+  return {
+    ...state,
+    suppressed: false,
+    busySinceMs: null,
+    idleSinceMs: null,
+    promptedThisSession: false
+  }
 }
 
 /** True when the debounced busy stretch should fire the prompt at nowMs. */

--- a/apps/desktop/src/main/prompt-coordinator.test.ts
+++ b/apps/desktop/src/main/prompt-coordinator.test.ts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import type { CalendarEvent, CalendarStartMeetingEvent } from '../shared/calendar-api'
+import {
+  choosePromptSurface,
+  coordinatePrompt,
+  initialPromptCoordinatorState,
+  setPromptRecording
+} from './prompt-coordinator'
+
+const NOW = Date.parse('2026-08-01T15:00:00.000Z')
+
+function eventAt(startOffsetMs: number, overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: 'event-1',
+    subject: 'Customer call',
+    startIso: new Date(NOW + startOffsetMs).toISOString(),
+    endIso: new Date(NOW + startOffsetMs + 60 * 60_000).toISOString(),
+    isAllDay: false,
+    isOnlineMeeting: true,
+    calendarId: 'calendar-1',
+    hasParticipants: true,
+    ...overrides
+  }
+}
+
+function calendarPrompt(event: CalendarEvent): CalendarStartMeetingEvent {
+  return {
+    action: 'prompt',
+    eventId: event.id,
+    subject: event.subject,
+    startIso: event.startIso
+  }
+}
+
+function micPrompt(subject = 'Zoom meeting'): CalendarStartMeetingEvent {
+  return {
+    action: 'prompt',
+    eventId: '',
+    subject,
+    startIso: new Date(NOW).toISOString(),
+    adHoc: true
+  }
+}
+
+describe('prompt coordination', () => {
+  it('delivers only one prompt when calendar and mic detect the same meeting', () => {
+    const event = eventAt(90_000)
+    const first = coordinatePrompt(
+      initialPromptCoordinatorState(),
+      calendarPrompt(event),
+      [event],
+      NOW
+    )
+    assert.equal(first.prompt?.eventId, event.id)
+
+    const second = coordinatePrompt(first.state, micPrompt(), [event], NOW + 10_000)
+    assert.equal(second.prompt, null)
+  })
+
+  it('honors a persisted calendar prompt after the app restarts', () => {
+    const event = eventAt(0)
+    const hydrated = initialPromptCoordinatorState({ [`calendar:${event.id}`]: NOW - 60_000 })
+    assert.equal(coordinatePrompt(hydrated, micPrompt(), [event], NOW).prompt, null)
+  })
+
+  it('maps an early mic detection onto an imminent calendar event', () => {
+    const event = eventAt(4 * 60_000)
+    const first = coordinatePrompt(initialPromptCoordinatorState(), micPrompt(), [event], NOW)
+
+    assert.deepEqual(first.prompt, calendarPrompt(event))
+    assert.equal(first.matchedCalendarEventId, event.id)
+
+    const calendarLater = coordinatePrompt(
+      first.state,
+      calendarPrompt(event),
+      [event],
+      NOW + 2 * 60_000
+    )
+    assert.equal(calendarLater.prompt, null)
+  })
+
+  it('does not map mic activity to distant, ended, or all-day events', () => {
+    const distant = eventAt(20 * 60_000)
+    const ended = eventAt(-60 * 60_000, { id: 'ended', endIso: new Date(NOW - 1).toISOString() })
+    const allDay = eventAt(0, { id: 'all-day', isAllDay: true })
+    const decision = coordinatePrompt(
+      initialPromptCoordinatorState(),
+      micPrompt(),
+      [distant, ended, allDay],
+      NOW
+    )
+
+    assert.equal(decision.prompt?.eventId, '')
+    assert.equal(decision.prompt?.adHoc, true)
+  })
+
+  it('suppresses every prompt while DoodleNote is recording', () => {
+    const state = setPromptRecording(initialPromptCoordinatorState(), true)
+    assert.equal(coordinatePrompt(state, micPrompt(), [], NOW).prompt, null)
+    assert.equal(
+      coordinatePrompt(state, calendarPrompt(eventAt(0)), [eventAt(0)], NOW).prompt,
+      null
+    )
+  })
+
+  it('deduplicates repeated ad-hoc prompts inside the cooldown', () => {
+    const first = coordinatePrompt(initialPromptCoordinatorState(), micPrompt(), [], NOW)
+    assert.ok(first.prompt)
+    assert.equal(coordinatePrompt(first.state, micPrompt(), [], NOW + 4 * 60_000).prompt, null)
+    assert.ok(coordinatePrompt(first.state, micPrompt(), [], NOW + 6 * 60_000).prompt)
+  })
+})
+
+describe('prompt surface selection', () => {
+  it('uses exactly one attention surface', () => {
+    assert.equal(choosePromptSurface(true, true), 'banner')
+    assert.equal(choosePromptSurface(false, true), 'panel')
+    assert.equal(choosePromptSurface(false, false), 'notification')
+  })
+})

--- a/apps/desktop/src/main/prompt-coordinator.ts
+++ b/apps/desktop/src/main/prompt-coordinator.ts
@@ -1,0 +1,134 @@
+import type { CalendarEvent, CalendarStartMeetingEvent } from '../shared/calendar-api'
+
+/** A mic-detected call this close to a calendar event is the same meeting. */
+export const MIC_CALENDAR_MATCH_LOOKAHEAD_MS = 5 * 60_000
+/** Calendar ids remain unique enough to suppress repeats for a full day. */
+const CALENDAR_PROMPT_RETENTION_MS = 24 * 60 * 60_000
+/** Ad-hoc prompts retain the existing five-minute quiet period. */
+const AD_HOC_PROMPT_RETENTION_MS = 5 * 60_000
+
+export interface PromptCoordinatorState {
+  recording: boolean
+  deliveredAt: Readonly<Record<string, number>>
+}
+
+export interface PromptDecision {
+  state: PromptCoordinatorState
+  prompt: CalendarStartMeetingEvent | null
+  /** Present when an ad-hoc mic signal was correlated to a calendar event. */
+  matchedCalendarEventId?: string
+}
+
+export type PromptSurface = 'banner' | 'panel' | 'notification'
+
+export function initialPromptCoordinatorState(
+  deliveredAt: Readonly<Record<string, number>> = {}
+): PromptCoordinatorState {
+  return { recording: false, deliveredAt: { ...deliveredAt } }
+}
+
+export function setPromptRecording(
+  state: PromptCoordinatorState,
+  recording: boolean
+): PromptCoordinatorState {
+  return { ...state, recording }
+}
+
+/** Choose exactly one visible attention surface for a delivered prompt. */
+export function choosePromptSurface(
+  windowFocusedAndVisible: boolean,
+  hasPanel: boolean
+): PromptSurface {
+  if (windowFocusedAndVisible) return 'banner'
+  return hasPanel ? 'panel' : 'notification'
+}
+
+/**
+ * Coordinate calendar and microphone detections before anything user-visible
+ * happens. Mic detection is a fallback: when a timed calendar event is active
+ * or starts in the next five minutes, it adopts that event's stable identity.
+ */
+export function coordinatePrompt(
+  state: PromptCoordinatorState,
+  requested: CalendarStartMeetingEvent,
+  calendarEvents: readonly CalendarEvent[],
+  nowMs: number
+): PromptDecision {
+  const deliveredAt = pruneDelivered(state.deliveredAt, nowMs)
+  const nextState = { ...state, deliveredAt }
+  if (state.recording) return { state: nextState, prompt: null }
+
+  let prompt = requested
+  let matchedCalendarEventId: string | undefined
+  if (requested.adHoc) {
+    const match = matchingCalendarEvent(calendarEvents, nowMs)
+    if (match) {
+      prompt = {
+        action: 'prompt',
+        eventId: match.id,
+        subject: match.subject.trim() || 'Untitled meeting',
+        startIso: match.startIso
+      }
+      matchedCalendarEventId = match.id
+    }
+  }
+
+  const key = promptKey(prompt)
+  const retentionMs = prompt.eventId ? CALENDAR_PROMPT_RETENTION_MS : AD_HOC_PROMPT_RETENTION_MS
+  const previous = deliveredAt[key]
+  if (previous !== undefined && nowMs - previous < retentionMs) {
+    return {
+      state: nextState,
+      prompt: null,
+      ...(matchedCalendarEventId ? { matchedCalendarEventId } : {})
+    }
+  }
+
+  return {
+    state: {
+      ...nextState,
+      deliveredAt: { ...deliveredAt, [key]: nowMs }
+    },
+    prompt,
+    ...(matchedCalendarEventId ? { matchedCalendarEventId } : {})
+  }
+}
+
+function matchingCalendarEvent(
+  events: readonly CalendarEvent[],
+  nowMs: number
+): CalendarEvent | null {
+  const candidates = events
+    .filter((event) => {
+      if (event.isAllDay || event.id.length === 0) return false
+      const startMs = Date.parse(event.startIso)
+      const endMs = Date.parse(event.endIso)
+      if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return false
+      return endMs >= nowMs && startMs <= nowMs + MIC_CALENDAR_MATCH_LOOKAHEAD_MS
+    })
+    .sort((a, b) => {
+      const aDistance = Math.abs(Date.parse(a.startIso) - nowMs)
+      const bDistance = Math.abs(Date.parse(b.startIso) - nowMs)
+      return aDistance - bDistance
+    })
+  return candidates[0] ?? null
+}
+
+function promptKey(prompt: CalendarStartMeetingEvent): string {
+  if (prompt.eventId) return `calendar:${prompt.eventId}`
+  return `adhoc:${prompt.subject.trim().toLowerCase() || 'meeting'}`
+}
+
+function pruneDelivered(
+  deliveredAt: Readonly<Record<string, number>>,
+  nowMs: number
+): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const [key, at] of Object.entries(deliveredAt)) {
+    const retentionMs = key.startsWith('calendar:')
+      ? CALENDAR_PROMPT_RETENTION_MS
+      : AD_HOC_PROMPT_RETENTION_MS
+    if (Number.isFinite(at) && nowMs - at < retentionMs) out[key] = at
+  }
+  return out
+}

--- a/apps/desktop/src/main/prompt-panel.ts
+++ b/apps/desktop/src/main/prompt-panel.ts
@@ -20,6 +20,10 @@ export class PromptPanel {
   private window: BrowserWindow | null = null
   private closeTimer: NodeJS.Timeout | null = null
 
+  ownsWindow(window: BrowserWindow): boolean {
+    return this.window === window
+  }
+
   show(prompt: CalendarStartMeetingEvent, onAction: (action: 'start' | 'dismiss') => void): void {
     this.close() // one panel at a time; a newer prompt replaces an older one
 
@@ -100,8 +104,24 @@ function panelDataUrl(prompt: CalendarStartMeetingEvent): string {
   // Follows nativeTheme, which the renderer keeps in sync with the in-app pref.
   const dark = nativeTheme.shouldUseDarkColors
   const c = dark
-    ? { card: '#262922', border: '#3a3e33', ink: '#f0eee2', muted: '#93967f', go: '#8fb07a', goHover: '#aac996', goText: '#1d1f19' }
-    : { card: '#fdfcf8', border: '#e7e3d8', ink: '#26281f', muted: '#8a8d7f', go: '#7c9769', goHover: '#5f7a4e', goText: '#fff' }
+    ? {
+        card: '#262922',
+        border: '#3a3e33',
+        ink: '#f0eee2',
+        muted: '#93967f',
+        go: '#8fb07a',
+        goHover: '#aac996',
+        goText: '#1d1f19'
+      }
+    : {
+        card: '#fdfcf8',
+        border: '#e7e3d8',
+        ink: '#26281f',
+        muted: '#8a8d7f',
+        go: '#7c9769',
+        goHover: '#5f7a4e',
+        goText: '#fff'
+      }
   const html = `<!doctype html><html><head><meta charset="utf-8"><style>
   * { margin: 0; box-sizing: border-box; -webkit-user-select: none; cursor: default; }
   body { font: 13px/1.4 -apple-system, BlinkMacSystemFont, sans-serif; background: transparent; padding: 2px; }

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -59,9 +59,7 @@ function App(): React.JSX.Element {
   const [tourOpen, setTourOpen] = useState(() => !isOnboardingDone())
   // The setup wizard (downloads + permissions) runs before the tour, and
   // only for genuinely fresh installs — anyone with meetings predates it.
-  const [wizardOpen, setWizardOpen] = useState(
-    () => !isSetupWizardDone() && !isOnboardingDone()
-  )
+  const [wizardOpen, setWizardOpen] = useState(() => !isSetupWizardDone() && !isOnboardingDone())
   useEffect(() => {
     if (!wizardOpen) return
     void window.meetings.list().then((list) => {
@@ -213,7 +211,9 @@ function App(): React.JSX.Element {
   useEffect(
     () =>
       window.calendar.onStartMeeting((ev) => {
-        if (ev.action === 'start') {
+        if (ev.action === 'dismiss') {
+          setBanner(null)
+        } else if (ev.action === 'start') {
           // OS notification click: the one click already happened.
           void startCalendarMeeting(ev)
         } else {

--- a/apps/desktop/src/shared/calendar-api.ts
+++ b/apps/desktop/src/shared/calendar-api.ts
@@ -120,10 +120,11 @@ export interface CalendarConfigUpdate {
 export interface CalendarStartMeetingEvent {
   /**
    * 'prompt' — show the in-app banner (watcher fired; the user hasn't acted).
-   * 'start'  — create the meeting and start recording now (the user clicked
-   *            the OS notification).
+   * 'start'   — create the meeting and start recording now (the user clicked
+   *             the OS notification).
+   * 'dismiss' — clear any visible prompt because recording started elsewhere.
    */
-  action: 'prompt' | 'start'
+  action: 'prompt' | 'start' | 'dismiss'
   /** Empty for ad-hoc (mic-detected) meetings — no calendar event to link. */
   eventId: string
   subject: string

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,15 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.6",
+    date: "August 1, 2026",
+    highlights: [
+      "Meeting prompts now appear only once: calendar reminders and live call detection coordinate instead of nudging you separately",
+      "Zoom Phone ringing, notification sounds, and other output-only activity no longer look like active meetings",
+      "Starting a recording clears any outstanding prompt, and background prompts no longer reappear as a second banner when you open DoodleNote",
+    ],
+  },
+  {
     version: "0.4.5",
     date: "July 14, 2026",
     highlights: [

--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,8 +1,8 @@
-version: 0.4.5
+version: 0.4.6
 files:
-  - url: DoodleNote-0.4.5-arm64-mac.zip
-    sha512: c/9g4W30KOosBYoMpVsLflw5OvaeSzimwDj2OmYk2+77WOkpJLjmA6IR71LB1veiYVMZM20IaWdu9GhNMwU33w==
-    size: 168061778
-path: DoodleNote-0.4.5-arm64-mac.zip
-sha512: c/9g4W30KOosBYoMpVsLflw5OvaeSzimwDj2OmYk2+77WOkpJLjmA6IR71LB1veiYVMZM20IaWdu9GhNMwU33w==
-releaseDate: '2026-07-14T20:41:04.925Z'
+  - url: DoodleNote-0.4.6-arm64-mac.zip
+    sha512: GZiUQgTAYlUnVse1TkspNE9B5nwDiO26KEN+bwTbf+ZXCy+smyFkbi78IWcrnii6nL0SxKR55KU/EsqztRiZPQ==
+    size: 168027690
+path: DoodleNote-0.4.6-arm64-mac.zip
+sha512: GZiUQgTAYlUnVse1TkspNE9B5nwDiO26KEN+bwTbf+ZXCy+smyFkbi78IWcrnii6nL0SxKR55KU/EsqztRiZPQ==
+releaseDate: '2026-08-01T17:14:32.224Z'


### PR DESCRIPTION
## Release candidate v0.4.6

### Summary

Fixes repeated and spurious DoodleNote meeting prompts and packages the output-only audio detector correction already merged to `main` as v0.4.6.

### Root cause

- The calendar watcher and microphone watcher delivered prompts independently, so one scheduled online meeting could generate two prompt sessions.
- Background delivery always broadcast an in-app banner even when the floating prompt panel owned the interaction, allowing the hidden banner to reappear later.
- Starting a recording did not globally clear and suppress outstanding calendar prompts.
- v0.4.5 treated output-only meeting-app audio as evidence of a live call. That correction landed in PR #47 but was never included in a published desktop update.

### What changed

- Added a prompt coordinator that correlates microphone activity to an active or imminent calendar event and deduplicates both signals into one meeting prompt.
- Persisted notified calendar event IDs across restarts.
- Enforced one attention surface per prompt: in-app banner, floating panel, or OS notification.
- Suppressed and cleared prompts while recording.
- Preserved a five-minute cooldown for ad hoc prompts and added a two-minute reconnect-session gap.
- Bumped the desktop package and web changelog to v0.4.6.
- Added the release checklist and package-verification record.

### Expected behavior

- A scheduled meeting can prompt once when calendar detection or matching microphone activity makes it eligible.
- A microphone signal within five minutes of an active or imminent calendar meeting joins that meeting session instead of creating another prompt.
- Dismissing or acting on a prompt prevents that calendar event from prompting again, including after an app restart.
- Recording suppresses meeting prompts.
- Output-only Zoom, Zoom Phone, and Slack audio does not count as a live call.

### Verification

- Focused notification tests: 32 passed.
- Full desktop tests: 93 passed; 3 existing media-fixture tests skipped.
- Desktop Node and renderer typechecks passed.
- Changed-file ESLint and Prettier checks passed.
- Desktop and web production builds passed; web tests: 15 passed.
- Swift engine release build passed.
- Built `DoodleNote-0.4.6-arm64-mac.zip`; manifest checksum matches the artifact.
- Packaged app has bundle version 0.4.6 and identifier `com.doodlenote.desktop`.
- Code signature validation, Gatekeeper assessment, stapler validation, and notarization all passed.

### Notes

- The repository-wide desktop lint command still reports eight pre-existing React Hooks errors in untouched `HomeView.tsx` and `MeetingView.tsx`; these are recorded in `RELEASE-v0.4.6.md` and are not introduced by this RC.
- Update-feed publication, installation through the live update channel, and live smoke testing remain post-merge release steps.

