### PR TITLE
Fix meeting action menu layering in v0.4.7

### DIFF
--- a/RELEASE-v0.4.7.md
+++ b/RELEASE-v0.4.7.md
@@ -1,0 +1,39 @@
+# DoodleNote v0.4.7 hotfix
+
+## Included
+
+- [x] Keep an open meeting action menu above every neighboring date group and row
+- [x] Prevent older-date fading from making the action menu translucent
+- [x] Preserve the subdued appearance of older meeting content
+- [x] Apply the same open-row layer ownership to the folder picker
+- [x] Bump the desktop version from 0.4.6 to 0.4.7
+- [x] Add the v0.4.7 changelog entry
+
+## Verification
+
+- [x] Action-menu CSS regression tests
+- [x] Full desktop test suite
+- [x] Desktop Node and renderer typechecks
+- [x] Changed-file lint and formatting
+- [x] Production Electron build
+- [x] Visual action-menu smoke test
+- [x] Signed and notarized arm64 package
+- [ ] Live update feed reports 0.4.7
+- [ ] Installed application and running process report 0.4.7
+
+## Release gates
+
+- [ ] Bug PR reviewed
+- [x] User authorizes a versioned update
+- [ ] Published artifact checksum matches the live update manifest
+
+## Package
+
+- Artifact: `DoodleNote-0.4.7-arm64-mac.zip`
+- Size: `168019131` bytes
+- SHA-256: `846c5f0e47933d4d6163844ecc7cc8102b56368b9fa949af8b8f0a16f3251dfb`
+- SHA-512: `dEBVpYKdte1fWPDK4E/A/lnFI2XpZqSO7hwJXraOfQ3F1hS7SBW/whHtYcKpkxQsfFEkfkd5uynF1DcvMl3TjQ==`
+- Notarization submission: `a8740285-6ede-43ed-8cff-676eb544f005` (`Accepted`)
+- Developer ID: `SEAN INMAN (VTZW6K32K4)`
+- Gatekeeper: `accepted` (`Notarized Developer ID`)
+- Stapled ticket: validated in the archive after extraction

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "private": true,
   "description": "Doodle Note desktop app \u2014 spawns the Swift transcription sidecar and shows its live transcript stream",
   "main": "./out/main/index.js",

--- a/apps/desktop/src/main/home-menu-layering.test.ts
+++ b/apps/desktop/src/main/home-menu-layering.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const css = readFileSync(new URL('../renderer/src/assets/main.css', import.meta.url), 'utf8')
+
+function rule(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`))
+  assert.ok(match, `Missing CSS rule for ${selector}`)
+  return match[1]
+}
+
+test('older date groups do not trap row popovers in an opacity stacking context', () => {
+  assert.doesNotMatch(css, /\.day-group\.older\s*\{[^}]*\bopacity\s*:/s)
+})
+
+test('the row owning an open action surface sits above surrounding rows', () => {
+  assert.match(rule('.meeting-row.actions-open'), /\bz-index\s*:\s*[1-9]\d*\s*;/)
+})

--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -760,7 +760,13 @@ a,
   margin-bottom: 18px;
 }
 
-.day-group.older {
+/* Fade the older row content without fading the group container itself.
+   Group-level opacity creates a stacking context that traps row popovers
+   underneath later date groups. */
+.day-group.older > .day-label,
+.day-group.older > .meeting-row > .row-icon,
+.day-group.older > .meeting-row > .row-main,
+.day-group.older > .meeting-row > .row-time {
   opacity: 0.78;
 }
 
@@ -780,6 +786,11 @@ a,
   padding: 9px 10px;
   border-radius: 10px;
   cursor: pointer;
+}
+
+/* The row owns any open menu/picker and must paint above every later row. */
+.meeting-row.actions-open {
+  z-index: 50;
 }
 
 .meeting-row:hover {

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,13 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.7",
+    date: "August 1, 2026",
+    highlights: [
+      "Meeting action menus now stay above every note row, so Move to trash, exports, and folder actions cannot be obscured or intercepted by another meeting",
+    ],
+  },
+  {
     version: "0.4.6",
     date: "August 1, 2026",
     highlights: [

--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,8 +1,8 @@
-version: 0.4.6
+version: 0.4.7
 files:
-  - url: DoodleNote-0.4.6-arm64-mac.zip
-    sha512: GZiUQgTAYlUnVse1TkspNE9B5nwDiO26KEN+bwTbf+ZXCy+smyFkbi78IWcrnii6nL0SxKR55KU/EsqztRiZPQ==
-    size: 168027690
-path: DoodleNote-0.4.6-arm64-mac.zip
-sha512: GZiUQgTAYlUnVse1TkspNE9B5nwDiO26KEN+bwTbf+ZXCy+smyFkbi78IWcrnii6nL0SxKR55KU/EsqztRiZPQ==
-releaseDate: '2026-08-01T17:14:32.224Z'
+  - url: DoodleNote-0.4.7-arm64-mac.zip
+    sha512: dEBVpYKdte1fWPDK4E/A/lnFI2XpZqSO7hwJXraOfQ3F1hS7SBW/whHtYcKpkxQsfFEkfkd5uynF1DcvMl3TjQ==
+    size: 168019131
+path: DoodleNote-0.4.7-arm64-mac.zip
+sha512: dEBVpYKdte1fWPDK4E/A/lnFI2XpZqSO7hwJXraOfQ3F1hS7SBW/whHtYcKpkxQsfFEkfkd5uynF1DcvMl3TjQ==
+releaseDate: '2026-08-01T18:22:29.857Z'


### PR DESCRIPTION
## What changed

- keep the active meeting row above neighboring date groups while its action menu or folder picker is open
- preserve the subdued appearance of older meetings without applying opacity to the entire date-group stacking context
- add focused CSS regression coverage
- ship the fix as DoodleNote v0.4.7 with changelog, release checklist, and updater manifest

## Root cause

`.day-group.older { opacity: 0.78; }` created a stacking context around each older date group. A menu inside one group could not escape that context, so later groups painted above the menu even though the menu itself had a high z-index.

## User impact

Meeting actions such as **Move to trash**, exports, and folder selection now stay fully opaque and on top of every meeting row. Underlying rows no longer visually interfere with the action surface.

## Validation

- desktop tests: 98 total, 95 passed, 3 existing media-fixture skips, 0 failed
- desktop Node and renderer typechecks
- changed-file ESLint and Prettier checks
- production Electron build
- isolated visual smoke test for the action menu and folder picker across date groups
- web typecheck and production build
- v0.4.7 arm64 ZIP built, Developer ID signed, notarized, stapled, Gatekeeper accepted, and verified again after extraction
- published artifact size and generated SHA-512 match the updater manifest

## Release artifact

- `DoodleNote-0.4.7-arm64-mac.zip`
- SHA-256: `846c5f0e47933d4d6163844ecc7cc8102b56368b9fa949af8b8f0a16f3251dfb`
- Apple notarization: `a8740285-6ede-43ed-8cff-676eb544f005` (Accepted)
