### PR TITLE
Fix iOS recording reliability and UX

### DIFF
--- a/apps/ios/DoodleNote/Calendar/CalendarService.swift
+++ b/apps/ios/DoodleNote/Calendar/CalendarService.swift
@@ -3,7 +3,7 @@ import EventKit
 import Observation
 
 /// Snapshot of an upcoming calendar event for the "Coming up" section.
-struct UpcomingEvent: Identifiable, Equatable {
+struct UpcomingEvent: Identifiable, Equatable, Sendable {
     var id: String
     var title: String
     var start: Date
@@ -23,37 +23,59 @@ struct UpcomingEvent: Identifiable, Equatable {
 final class CalendarService {
     static let shared = CalendarService()
 
-    enum Access { case unknown, granted, denied }
+    enum Access: Equatable { case unknown, granted, denied }
 
     private(set) var access: Access = .unknown
     private(set) var upcoming: [UpcomingEvent] = []
 
-    private let store = EKEventStore()
+    private let loader = CalendarEventLoader()
 
-    func requestAndLoad() async {
-        if access == .unknown {
-            switch EKEventStore.authorizationStatus(for: .event) {
-            case .fullAccess:
-                access = .granted
-            case .denied, .restricted, .writeOnly:
+    /// Refreshes the current system authorization every time the app becomes
+    /// active. The system prompt is only shown after an explicit user action.
+    func refresh(promptIfNeeded: Bool) async {
+        let status = await loader.authorizationStatus()
+        switch status {
+        case .fullAccess:
+            access = .granted
+        case .denied, .restricted, .writeOnly:
+            access = .denied
+            upcoming = []
+        default:
+            guard promptIfNeeded else {
+                access = .unknown
+                upcoming = []
+                return
+            }
+            do {
+                access = try await loader.requestAccess() ? .granted : .denied
+            } catch {
                 access = .denied
-            default:
-                do {
-                    access = try await store.requestFullAccessToEvents() ? .granted : .denied
-                } catch {
-                    access = .denied
-                }
             }
         }
+
         guard access == .granted else { return }
-        load()
+        upcoming = await loader.loadUpcoming()
+    }
+}
+
+/// EventKit performs a synchronous fetch. Keeping its store inside an actor
+/// prevents calendar reads and sorting from blocking SwiftUI's main actor.
+private actor CalendarEventLoader {
+    private let store = EKEventStore()
+
+    func authorizationStatus() -> EKAuthorizationStatus {
+        EKEventStore.authorizationStatus(for: .event)
     }
 
-    func load() {
+    func requestAccess() async throws -> Bool {
+        try await store.requestFullAccessToEvents()
+    }
+
+    func loadUpcoming() -> [UpcomingEvent] {
         let start = Date().addingTimeInterval(-30 * 60)
-        guard let end = Calendar.current.date(byAdding: .day, value: 7, to: .now) else { return }
+        guard let end = Calendar.current.date(byAdding: .day, value: 7, to: .now) else { return [] }
         let predicate = store.predicateForEvents(withStart: start, end: end, calendars: nil)
-        upcoming = store.events(matching: predicate)
+        return store.events(matching: predicate)
             .filter { !$0.isAllDay && $0.endDate > .now }
             .sorted { $0.startDate < $1.startDate }
             .prefix(12)

--- a/apps/ios/DoodleNote/Calendar/NotificationRouter.swift
+++ b/apps/ios/DoodleNote/Calendar/NotificationRouter.swift
@@ -17,6 +17,13 @@ final class NotificationRouter: NSObject, UNUserNotificationCenterDelegate {
     /// Set when the user taps "Start notes" on a notification; HomeView
     /// observes this and opens a recording meeting.
     var pendingStart: PendingStart?
+    private(set) var authorization: Authorization = .unknown
+
+    enum Authorization: Equatable {
+        case unknown
+        case granted
+        case denied
+    }
 
     private static let categoryId = "MEETING_START"
     private static let actionId = "START_NOTES"
@@ -37,16 +44,41 @@ final class NotificationRouter: NSObject, UNUserNotificationCenterDelegate {
         center.setNotificationCategories([category])
     }
 
+    func refreshAuthorization() async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        authorization = Self.authorization(from: settings.authorizationStatus)
+    }
+
+    /// Requests notification access after the user explicitly enables meeting
+    /// reminders, then schedules the current calendar snapshot.
+    func requestAuthorizationAndSchedule(for events: [UpcomingEvent]) async -> Bool {
+        let center = UNUserNotificationCenter.current()
+        let granted = (try? await center.requestAuthorization(options: [.alert, .sound])) ?? false
+        await refreshAuthorization()
+        guard granted || authorization == .granted else { return false }
+        await schedule(for: events)
+        return true
+    }
+
+    func disableNotifications() {
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+    }
+
     /// Reschedules one notification per upcoming event (next 24h), replacing
-    /// the previous schedule. Call after each calendar load.
+    /// the previous schedule. Never prompts; prompting belongs to an explicit
+    /// user action in Settings.
     func schedule(for events: [UpcomingEvent]) async {
         let center = UNUserNotificationCenter.current()
-        guard UserDefaults.standard.object(forKey: "meetingNotifications") as? Bool ?? true else {
+        guard UserDefaults.standard.bool(forKey: "meetingNotifications") else {
             center.removeAllPendingNotificationRequests()
             return
         }
-        let granted = (try? await center.requestAuthorization(options: [.alert, .sound])) ?? false
-        guard granted else { return }
+        let settings = await center.notificationSettings()
+        authorization = Self.authorization(from: settings.authorizationStatus)
+        guard authorization == .granted else {
+            center.removeAllPendingNotificationRequests()
+            return
+        }
 
         center.removeAllPendingNotificationRequests()
         for event in events {
@@ -67,6 +99,15 @@ final class NotificationRouter: NSObject, UNUserNotificationCenterDelegate {
                 trigger: trigger
             )
             try? await center.add(request)
+        }
+    }
+
+    private static func authorization(from status: UNAuthorizationStatus) -> Authorization {
+        switch status {
+        case .authorized, .provisional, .ephemeral: .granted
+        case .denied: .denied
+        case .notDetermined: .unknown
+        @unknown default: .unknown
         }
     }
 

--- a/apps/ios/DoodleNote/Calls/DoodleAudioDevice.swift
+++ b/apps/ios/DoodleNote/Calls/DoodleAudioDevice.swift
@@ -202,7 +202,7 @@ final class DoodleAudioDevice: NSObject, AudioDevice, @unchecked Sendable {
     ) {
         guard let unit = audioUnit else { return }
         let byteCount = Int(frames) * 2
-        var buffer = AudioBuffer(
+        let buffer = AudioBuffer(
             mNumberChannels: 1,
             mDataByteSize: UInt32(byteCount),
             mData: malloc(byteCount)
@@ -223,7 +223,6 @@ final class DoodleAudioDevice: NSObject, AudioDevice, @unchecked Sendable {
         if let onCapturedAudio, let pcm = Self.makePCMBuffer(copying: data, frames: frames) {
             onCapturedAudio(pcm)
         }
-        _ = buffer
     }
 
     private static func makePCMBuffer(copying data: UnsafeMutableRawPointer, frames: UInt32) -> AVAudioPCMBuffer? {

--- a/apps/ios/DoodleNote/DoodleNoteApp.swift
+++ b/apps/ios/DoodleNote/DoodleNoteApp.swift
@@ -6,6 +6,18 @@ struct DoodleNoteApp: App {
     @AppStorage("hasOnboarded") private var hasOnboarded = false
 
     let container: ModelContainer = {
+        if ProcessInfo.processInfo.arguments.contains("-uiTesting") {
+            let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+            do {
+                return try ModelContainer(
+                    for: Meeting.self, Segment.self, Folder.self,
+                    configurations: configuration
+                )
+            } catch {
+                fatalError("Failed to create UI-test model container: \(error)")
+            }
+        }
+
         do {
             return try ModelContainer(for: Meeting.self, Segment.self, Folder.self)
         } catch {

--- a/apps/ios/DoodleNote/Info.plist
+++ b/apps/ios/DoodleNote/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>
 	<string>DoodleNote shows your upcoming meetings so you can start notes with one tap. Calendar data stays on your phone.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/apps/ios/DoodleNote/Models.swift
+++ b/apps/ios/DoodleNote/Models.swift
@@ -65,6 +65,25 @@ final class Meeting {
         return isNote ? "Untitled note" : "Untitled meeting"
     }
 
+    var hasMeaningfulContent: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !roughNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !(generatedNotes?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+            || !segments.isEmpty
+            || startedAt != nil
+    }
+
+    /// Content that can actually be sent to the note generator. A title or a
+    /// recording timestamp keeps a meeting from being discarded, but neither
+    /// gives the generator useful source material.
+    var hasNoteSourceContent: Bool {
+        !roughNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !(generatedNotes?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+            || !segments.isEmpty
+    }
+
+    var isEmptyDraft: Bool { !hasMeaningfulContent }
+
     var durationMs: Int? {
         guard let startedAt, let endedAt else { return nil }
         return Int(endedAt.timeIntervalSince(startedAt) * 1000)

--- a/apps/ios/DoodleNote/PrivacyInfo.xcprivacy
+++ b/apps/ios/DoodleNote/PrivacyInfo.xcprivacy
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherUserContent</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePhoneNumber</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeEmailAddress</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+		</dict>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/apps/ios/DoodleNote/Recording/AppleSpeechProvider.swift
+++ b/apps/ios/DoodleNote/Recording/AppleSpeechProvider.swift
@@ -120,16 +120,10 @@ final class AppleSpeechProvider: TranscriptionProvider, @unchecked Sendable {
         guard let converted = AVAudioPCMBuffer(pcmFormat: analyzerFormat, frameCapacity: capacity) else {
             return
         }
-        var fed = false
         var conversionError: NSError?
+        let source = ConverterInput(buffer: buffer)
         converter.convert(to: converted, error: &conversionError) { _, status in
-            if fed {
-                status.pointee = .noDataNow
-                return nil
-            }
-            fed = true
-            status.pointee = .haveData
-            return buffer
+            source.next(status: status)
         }
         if conversionError == nil, converted.frameLength > 0 {
             inputBuilder.yield(AnalyzerInput(buffer: converted))
@@ -156,6 +150,31 @@ final class AppleSpeechProvider: TranscriptionProvider, @unchecked Sendable {
         eventsCont.finish()
         analyzer = nil
         converter = nil
+    }
+}
+
+/// AVAudioConverter's input closure is `@Sendable`, while AVAudioPCMBuffer is
+/// not. This synchronized ownership box makes the one-shot handoff explicit
+/// and avoids capturing mutable local state across concurrency domains.
+private final class ConverterInput: @unchecked Sendable {
+    private let lock = NSLock()
+    private let buffer: AVAudioPCMBuffer
+    private var hasProvidedBuffer = false
+
+    init(buffer: AVAudioPCMBuffer) {
+        self.buffer = buffer
+    }
+
+    func next(status: UnsafeMutablePointer<AVAudioConverterInputStatus>) -> AVAudioBuffer? {
+        lock.withLock {
+            guard !hasProvidedBuffer else {
+                status.pointee = .noDataNow
+                return nil
+            }
+            hasProvidedBuffer = true
+            status.pointee = .haveData
+            return buffer
+        }
     }
 }
 

--- a/apps/ios/DoodleNote/Recording/RecordingController.swift
+++ b/apps/ios/DoodleNote/Recording/RecordingController.swift
@@ -47,6 +47,11 @@ final class RecordingController {
         guard state == .idle || !isActive else { return }
         let gen = generation
 
+        if ProcessInfo.processInfo.environment["UITEST_RECORDING_MODE"] == "failure" {
+            state = .failed("Recording is unavailable in this simulator test. Try again on a device.")
+            return
+        }
+
         state = .preparing("Requesting microphone…")
         guard await AVAudioApplication.requestRecordPermission() else {
             if gen == generation {
@@ -130,7 +135,7 @@ final class RecordingController {
         eventsTask = nil
         provider = nil
         livePartial = ""
-        meeting.endedAt = .now
+        if meeting.startedAt != nil { meeting.endedAt = .now }
         try? context.save()
         state = .idle
     }
@@ -186,13 +191,24 @@ final class RecordingController {
 /// Run an async operation but give up waiting after `seconds`. The operation
 /// itself is cancelled on timeout; either way this function returns.
 func withTimeout(seconds: Double, _ operation: @escaping @Sendable () async -> Void) async {
-    await withTaskGroup(of: Void.self) { group in
-        group.addTask { await operation() }
-        group.addTask {
-            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+    let operationTask = Task { await operation() }
+    await withTaskCancellationHandler {
+        await withCheckedContinuation { continuation in
+            let gate = TimeoutGate()
+            Task {
+                await operationTask.value
+                if gate.claim() { continuation.resume() }
+            }
+            Task {
+                try? await Task.sleep(for: .seconds(seconds))
+                if gate.claim() {
+                    operationTask.cancel()
+                    continuation.resume()
+                }
+            }
         }
-        await group.next() // whichever finishes first
-        group.cancelAll()
+    } onCancel: {
+        operationTask.cancel()
     }
 }
 
@@ -202,15 +218,41 @@ func withThrowingTimeout<T: Sendable>(
     seconds: Double,
     _ operation: @escaping @Sendable () async throws -> T
 ) async throws -> T {
-    try await withThrowingTaskGroup(of: T.self) { group in
-        group.addTask { try await operation() }
-        group.addTask {
-            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-            throw TimeoutError()
+    let operationTask = Task { try await operation() }
+    return try await withTaskCancellationHandler {
+        try await withCheckedThrowingContinuation { continuation in
+            let gate = TimeoutGate()
+            Task {
+                do {
+                    let result = try await operationTask.value
+                    if gate.claim() { continuation.resume(returning: result) }
+                } catch {
+                    if gate.claim() { continuation.resume(throwing: error) }
+                }
+            }
+            Task {
+                try? await Task.sleep(for: .seconds(seconds))
+                if gate.claim() {
+                    operationTask.cancel()
+                    continuation.resume(throwing: TimeoutError())
+                }
+            }
         }
-        guard let first = try await group.next() else { throw TimeoutError() }
-        group.cancelAll()
-        return first
+    } onCancel: {
+        operationTask.cancel()
+    }
+}
+
+private final class TimeoutGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var finished = false
+
+    func claim() -> Bool {
+        lock.withLock {
+            guard !finished else { return false }
+            finished = true
+            return true
+        }
     }
 }
 

--- a/apps/ios/DoodleNote/Sync/SyncAPI.swift
+++ b/apps/ios/DoodleNote/Sync/SyncAPI.swift
@@ -25,7 +25,7 @@ struct SyncAPI: Sendable {
 
     // MARK: Wire shapes (match apps/web/app/api/sync routes)
 
-    struct PushSegment: Codable {
+    struct PushSegment: Codable, Sendable {
         var channel: String
         var speaker: String
         var text: String
@@ -34,7 +34,7 @@ struct SyncAPI: Sendable {
         var confidence: Double?
     }
 
-    struct PushMeeting: Codable {
+    struct PushMeeting: Codable, Sendable {
         var id: String
         var title: String
         /// "meeting" or "note" (standalone quick note); omitted = meeting.
@@ -49,19 +49,19 @@ struct SyncAPI: Sendable {
         var segments: [PushSegment]
     }
 
-    struct PushFolder: Codable {
+    struct PushFolder: Codable, Sendable {
         var id: String
         var name: String
         var createdAt: String?
     }
 
-    struct PushResult: Codable {
+    struct PushResult: Codable, Sendable {
         var id: String
         var ok: Bool
         var error: String?
     }
 
-    struct RemoteMeeting: Codable {
+    struct RemoteMeeting: Codable, Sendable {
         var id: String
         var title: String
         var kind: String?
@@ -76,13 +76,13 @@ struct SyncAPI: Sendable {
         var segments: [PushSegment]
     }
 
-    struct RemoteFolder: Codable {
+    struct RemoteFolder: Codable, Sendable {
         var id: String
         var name: String
         var createdAt: String
     }
 
-    struct PullResponse: Codable {
+    struct PullResponse: Codable, Sendable {
         var allIds: [String]
         var folders: [RemoteFolder]
         var changed: [RemoteMeeting]

--- a/apps/ios/DoodleNote/Sync/SyncEngine.swift
+++ b/apps/ios/DoodleNote/Sync/SyncEngine.swift
@@ -199,23 +199,22 @@ final class SyncEngine: NSObject {
 
     private func pushDirty(api: SyncAPI, context: ModelContext) async throws {
         let meetings = try context.fetch(FetchDescriptor<Meeting>())
-        // Hashing every transcript is CPU-heavy and this runs on @MainActor;
-        // yield every few meetings so an in-progress scroll isn't frozen.
-        var dirty: [Meeting] = []
-        for (i, meeting) in meetings.enumerated() {
-            if contentHash(of: meeting) != meeting.lastPushedHash { dirty.append(meeting) }
-            if i % 8 == 7 { await Task.yield() }
+        let preparedByID = await prepareMeetings(meetings)
+        let dirty = meetings.compactMap { meeting -> DirtyMeeting? in
+            guard let prepared = preparedByID[meeting.id],
+                  prepared.hash != meeting.lastPushedHash else { return nil }
+            return DirtyMeeting(meeting: meeting, prepared: prepared)
         }
         guard !dirty.isEmpty else { return }
 
         for batch in dirty.chunked(into: 20) {
-            let payload = batch.map { wireMeeting(from: $0) }
+            let payload = batch.map(\.prepared.wire)
             let results = try await api.push(meetings: payload)
             for result in results where result.ok {
-                if let meeting = batch.first(where: {
-                    $0.id.uuidString.lowercased() == result.id.lowercased()
+                if let item = batch.first(where: {
+                    $0.meeting.id.uuidString.lowercased() == result.id.lowercased()
                 }) {
-                    meeting.lastPushedHash = contentHash(of: meeting)
+                    item.meeting.lastPushedHash = item.prepared.hash
                 }
             }
         }
@@ -226,6 +225,9 @@ final class SyncEngine: NSObject {
         var cursor = pullCursor
         var latestAllIds: Set<String>?
         var remoteFolders: [SyncAPI.RemoteFolder] = []
+        let initialMeetings = try context.fetch(FetchDescriptor<Meeting>())
+        var localByID = Dictionary(uniqueKeysWithValues: initialMeetings.map { ($0.id, $0) })
+        var localHashes = await prepareMeetings(initialMeetings).mapValues(\.hash)
 
         var didChange = false
         for _ in 0..<40 {
@@ -234,8 +236,19 @@ final class SyncEngine: NSObject {
             remoteFolders = page.folders
 
             if !page.changed.isEmpty { didChange = true }
+            let remoteHashes = await prepareRemoteHashes(page.changed)
             for remote in page.changed {
-                apply(remote: remote, context: context)
+                guard let id = UUID(uuidString: remote.id), let remoteHash = remoteHashes[id] else {
+                    continue
+                }
+                apply(
+                    remote: remote,
+                    id: id,
+                    remoteHash: remoteHash,
+                    localByID: &localByID,
+                    localHashes: &localHashes,
+                    context: context
+                )
                 cursor = max(cursor ?? "", remote.updatedAt)
             }
             if !page.hasMore { break }
@@ -250,15 +263,15 @@ final class SyncEngine: NSObject {
         // this per-meeting hash scan doesn't freeze the UI.
         if let cloudIds = latestAllIds {
             let meetings = try context.fetch(FetchDescriptor<Meeting>())
-            for (i, meeting) in meetings.enumerated() {
+            let prepared = await prepareMeetings(meetings)
+            for meeting in meetings {
                 let id = meeting.id.uuidString.lowercased()
                 let wasSynced = meeting.lastPushedHash != nil
-                let isDirty = contentHash(of: meeting) != meeting.lastPushedHash
+                let isDirty = prepared[meeting.id]?.hash != meeting.lastPushedHash
                 if wasSynced, !isDirty, !cloudIds.contains(id) {
                     context.delete(meeting)
                     didChange = true
                 }
-                if i % 8 == 7 { await Task.yield() }
             }
         }
         // Only save (and republish @Query → relist) when something changed —
@@ -271,6 +284,7 @@ final class SyncEngine: NSObject {
     /// renames have already won.
     private func applyFolders(_ remote: [SyncAPI.RemoteFolder], context: ModelContext) {
         let locals = (try? context.fetch(FetchDescriptor<Folder>())) ?? []
+        let meetings = (try? context.fetch(FetchDescriptor<Meeting>())) ?? []
         let remoteById = Dictionary(
             uniqueKeysWithValues: remote.compactMap { folder in
                 UUID(uuidString: folder.id).map { ($0, folder) }
@@ -282,8 +296,7 @@ final class SyncEngine: NSObject {
                 if local.name != match.name { local.name = match.name }
                 local.synced = true
             } else if local.synced {
-                for meeting in (try? context.fetch(FetchDescriptor<Meeting>())) ?? []
-                where meeting.folderId == local.id {
+                for meeting in meetings where meeting.folderId == local.id {
                     meeting.folderId = nil
                 }
                 context.delete(local)
@@ -300,24 +313,35 @@ final class SyncEngine: NSObject {
         }
     }
 
-    private func apply(remote: SyncAPI.RemoteMeeting, context: ModelContext) {
-        guard let uuid = UUID(uuidString: remote.id) else { return }
-        let meetings = (try? context.fetch(FetchDescriptor<Meeting>())) ?? []
-        let existing = meetings.first { $0.id == uuid }
-
+    private func apply(
+        remote: SyncAPI.RemoteMeeting,
+        id: UUID,
+        remoteHash: String,
+        localByID: inout [UUID: Meeting],
+        localHashes: inout [UUID: String],
+        context: ModelContext
+    ) {
+        let existing = localByID[id]
         if let existing {
             // Local edits win until pushed.
-            let isDirty = contentHash(of: existing) != existing.lastPushedHash
+            let isDirty = localHashes[id] != existing.lastPushedHash
             if isDirty { return }
-            update(meeting: existing, from: remote, context: context)
+            update(meeting: existing, from: remote, hash: remoteHash, context: context)
         } else {
-            let meeting = Meeting(id: uuid, origin: "cloud")
+            let meeting = Meeting(id: id, origin: "cloud")
             context.insert(meeting)
-            update(meeting: meeting, from: remote, context: context)
+            localByID[id] = meeting
+            update(meeting: meeting, from: remote, hash: remoteHash, context: context)
         }
+        localHashes[id] = remoteHash
     }
 
-    private func update(meeting: Meeting, from remote: SyncAPI.RemoteMeeting, context: ModelContext) {
+    private func update(
+        meeting: Meeting,
+        from remote: SyncAPI.RemoteMeeting,
+        hash: String,
+        context: ModelContext
+    ) {
         meeting.title = remote.title
         meeting.kind = remote.kind == "note" ? "note" : nil
         meeting.createdAt = parseISO(remote.createdAt) ?? meeting.createdAt
@@ -344,53 +368,64 @@ final class SyncEngine: NSObject {
             segment.meeting = meeting
             context.insert(segment)
         }
-        meeting.lastPushedHash = contentHash(of: meeting)
+        meeting.lastPushedHash = hash
     }
 
     // MARK: Helpers
 
-    private func wireMeeting(from meeting: Meeting) -> SyncAPI.PushMeeting {
-        SyncAPI.PushMeeting(
-            id: meeting.id.uuidString.lowercased(),
-            title: meeting.displayTitle,
-            kind: meeting.isNote ? "note" : nil,
-            createdAt: isoString(meeting.createdAt),
-            startedAt: meeting.startedAt.map(isoString),
-            endedAt: meeting.endedAt.map(isoString),
-            calendarEventId: meeting.calendarEventId,
-            folderId: meeting.folderId?.uuidString.lowercased(),
-            rawNotesMarkdown: meeting.roughNotes.isEmpty ? nil : meeting.roughNotes,
-            enhancedMarkdown: meeting.generatedNotes,
-            segments: meeting.sortedSegments.prefix(5000).map {
-                SyncAPI.PushSegment(
-                    channel: $0.channel == "system" ? "system" : "mic",
-                    speaker: $0.speaker,
-                    text: String($0.text.prefix(10_000)),
-                    startMs: $0.startMs,
-                    endMs: $0.endMs,
-                    confidence: $0.confidence
-                )
-            }
-        )
+    /// Capture SwiftData values quickly on the main actor, then do transcript
+    /// sorting, string joining, SHA-256, and payload construction off-main.
+    private func prepareMeetings(_ meetings: [Meeting]) async -> [UUID: PreparedMeeting] {
+        let snapshots = meetings.map { meeting in
+            MeetingSnapshot(
+                id: meeting.id,
+                title: meeting.displayTitle,
+                kind: meeting.kind,
+                createdAt: isoString(meeting.createdAt),
+                startedAt: meeting.startedAt.map(isoString),
+                endedAt: meeting.endedAt.map(isoString),
+                calendarEventId: meeting.calendarEventId,
+                folderId: meeting.folderId?.uuidString.lowercased(),
+                roughNotes: meeting.roughNotes,
+                generatedNotes: meeting.generatedNotes,
+                segments: meeting.segments.map(SegmentSnapshot.init)
+            )
+        }
+        return await Task.detached(priority: .utility) {
+            Dictionary(uniqueKeysWithValues: snapshots.map { ($0.id, $0.prepared()) })
+        }.value
     }
 
-    /// Local change-detection hash over the same fields the desktop hashes.
-    private func contentHash(of meeting: Meeting) -> String {
-        var parts: [String] = [
-            meeting.displayTitle,
-            meeting.kind ?? "",
-            meeting.startedAt.map(isoString) ?? "",
-            meeting.endedAt.map(isoString) ?? "",
-            meeting.calendarEventId ?? "",
-            meeting.folderId?.uuidString.lowercased() ?? "",
-            meeting.roughNotes,
-            meeting.generatedNotes ?? "",
-        ]
-        for segment in meeting.sortedSegments {
-            parts.append("\(segment.channel)|\(segment.speaker)|\(segment.text)|\(segment.startMs)|\(segment.endMs)")
-        }
-        let digest = SHA256.hash(data: Data(parts.joined(separator: "\u{1F}").utf8))
-        return digest.map { String(format: "%02x", $0) }.joined()
+    private func prepareRemoteHashes(_ meetings: [SyncAPI.RemoteMeeting]) async -> [UUID: String] {
+        return await Task.detached(priority: .utility) {
+            let pairs: [(UUID, String)] = meetings.compactMap { remote -> (UUID, String)? in
+                guard let id = UUID(uuidString: remote.id) else { return nil }
+                let snapshot = MeetingSnapshot(
+                    id: id,
+                    title: remote.title,
+                    kind: remote.kind == "note" ? "note" : nil,
+                    createdAt: remote.createdAt,
+                    startedAt: remote.startedAt,
+                    endedAt: remote.endedAt,
+                    calendarEventId: remote.calendarEventId,
+                    folderId: remote.folderId?.lowercased(),
+                    roughNotes: remote.rawNotesMarkdown,
+                    generatedNotes: remote.enhancedMarkdown,
+                    segments: remote.segments.map {
+                        SegmentSnapshot(
+                            channel: $0.channel,
+                            speaker: $0.channel == "mic" ? "You" : "Them",
+                            text: $0.text,
+                            startMs: $0.startMs,
+                            endMs: $0.endMs,
+                            confidence: $0.confidence
+                        )
+                    }
+                )
+                return (id, snapshot.prepared().hash)
+            }
+            return Dictionary(uniqueKeysWithValues: pairs)
+        }.value
     }
 
     private func isoString(_ date: Date) -> String {
@@ -401,6 +436,106 @@ final class SyncEngine: NSObject {
         (try? Date.ISO8601FormatStyle(includingFractionalSeconds: true).parse(string))
             ?? (try? Date.ISO8601FormatStyle().parse(string))
     }
+}
+
+private struct DirtyMeeting {
+    let meeting: Meeting
+    let prepared: PreparedMeeting
+}
+
+private struct SegmentSnapshot: Sendable {
+    let channel: String
+    let speaker: String
+    let text: String
+    let startMs: Int
+    let endMs: Int
+    let confidence: Double?
+
+    init(_ segment: Segment) {
+        channel = segment.channel
+        speaker = segment.speaker
+        text = segment.text
+        startMs = segment.startMs
+        endMs = segment.endMs
+        confidence = segment.confidence
+    }
+
+    init(
+        channel: String,
+        speaker: String,
+        text: String,
+        startMs: Int,
+        endMs: Int,
+        confidence: Double?
+    ) {
+        self.channel = channel
+        self.speaker = speaker
+        self.text = text
+        self.startMs = startMs
+        self.endMs = endMs
+        self.confidence = confidence
+    }
+}
+
+private struct MeetingSnapshot: Sendable {
+    let id: UUID
+    let title: String
+    let kind: String?
+    let createdAt: String
+    let startedAt: String?
+    let endedAt: String?
+    let calendarEventId: String?
+    let folderId: String?
+    let roughNotes: String
+    let generatedNotes: String?
+    let segments: [SegmentSnapshot]
+
+    func prepared() -> PreparedMeeting {
+        let sorted = segments.sorted { $0.startMs < $1.startMs }
+        var parts = [
+            title,
+            kind ?? "",
+            startedAt ?? "",
+            endedAt ?? "",
+            calendarEventId ?? "",
+            folderId ?? "",
+            roughNotes,
+            generatedNotes ?? "",
+        ]
+        parts.append(contentsOf: sorted.map {
+            "\($0.channel)|\($0.speaker)|\($0.text)|\($0.startMs)|\($0.endMs)"
+        })
+        let digest = SHA256.hash(data: Data(parts.joined(separator: "\u{1F}").utf8))
+        let hash = digest.map { String(format: "%02x", $0) }.joined()
+        let wire = SyncAPI.PushMeeting(
+            id: id.uuidString.lowercased(),
+            title: title,
+            kind: kind == "note" ? "note" : nil,
+            createdAt: createdAt,
+            startedAt: startedAt,
+            endedAt: endedAt,
+            calendarEventId: calendarEventId,
+            folderId: folderId,
+            rawNotesMarkdown: roughNotes.isEmpty ? nil : roughNotes,
+            enhancedMarkdown: generatedNotes,
+            segments: sorted.prefix(5000).map {
+                SyncAPI.PushSegment(
+                    channel: $0.channel == "system" ? "system" : "mic",
+                    speaker: $0.speaker,
+                    text: String($0.text.prefix(10_000)),
+                    startMs: $0.startMs,
+                    endMs: $0.endMs,
+                    confidence: $0.confidence
+                )
+            }
+        )
+        return PreparedMeeting(hash: hash, wire: wire)
+    }
+}
+
+private struct PreparedMeeting: Sendable {
+    let hash: String
+    let wire: SyncAPI.PushMeeting
 }
 
 

--- a/apps/ios/DoodleNote/Theme.swift
+++ b/apps/ios/DoodleNote/Theme.swift
@@ -10,9 +10,9 @@ extension Color {
     static let sand = adaptive(light: 0xE7E3D8, dark: 0x3A3E33)
     static let ink = adaptive(light: 0x26281F, dark: 0xF0EEE2)
     static let bark = adaptive(light: 0x3A3D33, dark: 0xCFCDBE)
-    static let stone = adaptive(light: 0x8A8D7F, dark: 0x93967F)
+    static let stone = adaptive(light: 0x686D61, dark: 0xA4A88F)
     static let sage = adaptive(light: 0x7C9769, dark: 0x8FB07A)
-    static let sageDeep = adaptive(light: 0x5F7A4E, dark: 0xAAC996)
+    static let sageDeep = adaptive(light: 0x526E43, dark: 0xAAC996)
     static let sageFill = adaptive(light: 0xE9EFE0, dark: 0x34402B)
 
     private static func adaptive(light: UInt32, dark: UInt32) -> Color {
@@ -43,5 +43,7 @@ struct Wordmark: View {
             Text("Note").foregroundStyle(Color.sage)
         }
         .font(font.weight(.bold))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("DoodleNote")
     }
 }

--- a/apps/ios/DoodleNote/Views/HomeView.swift
+++ b/apps/ios/DoodleNote/Views/HomeView.swift
@@ -4,11 +4,13 @@ import SwiftData
 struct HomeView: View {
     @Environment(\.modelContext) private var context
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.openURL) private var openURL
     @Query(sort: \Meeting.createdAt, order: .reverse) private var meetings: [Meeting]
     @Query(sort: \Folder.createdAt) private var folders: [Folder]
 
     @State private var path: [Meeting] = []
-    @State private var autoRecordMeeting: Meeting?
+    @State private var autoRecordMeetingID: UUID?
+    @State private var draftMeetingIDs: Set<UUID> = []
     @State private var calendar = CalendarService.shared
     @State private var router = NotificationRouter.shared
     @State private var sync = SyncEngine.shared
@@ -25,8 +27,15 @@ struct HomeView: View {
             List {
                 Section {
                     titleRow
-                    if calendar.access == .granted, !calendar.upcoming.isEmpty, searchText.isEmpty {
-                        comingUpSection
+                    if searchText.isEmpty {
+                        switch calendar.access {
+                        case .unknown:
+                            calendarAccessCard
+                        case .denied:
+                            calendarDeniedCard
+                        case .granted:
+                            if !calendar.upcoming.isEmpty { comingUpSection }
+                        }
                     }
                 }
                 .listRowInsets(EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16))
@@ -59,7 +68,12 @@ struct HomeView: View {
                     meeting: meeting,
                     // Only a brand-new, never-recorded meeting auto-starts. Re-opening
                     // a finished meeting to read its notes must NOT record again.
-                    startRecordingOnAppear: meeting === autoRecordMeeting && meeting.startedAt == nil
+                    startRecordingOnAppear: meeting.id == autoRecordMeetingID && meeting.startedAt == nil,
+                    discardEmptyDraftOnExit: draftMeetingIDs.contains(meeting.id),
+                    onDraftResolved: {
+                        draftMeetingIDs.remove(meeting.id)
+                        if autoRecordMeetingID == meeting.id { autoRecordMeetingID = nil }
+                    }
                 )
             }
             .toolbar {
@@ -70,6 +84,7 @@ struct HomeView: View {
                         Image(systemName: selectedFolderId == nil ? "folder" : "folder.fill")
                             .foregroundStyle(Color.bark)
                     }
+                    .accessibilityLabel("Folders")
                 }
                 ToolbarItem(placement: .principal) { Wordmark(font: .subheadline) }
                 ToolbarItem(placement: .topBarTrailing) {
@@ -79,6 +94,7 @@ struct HomeView: View {
                         Image(systemName: "phone")
                             .foregroundStyle(Color.bark)
                     }
+                    .accessibilityLabel("Phone calls")
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     NavigationLink {
@@ -87,12 +103,13 @@ struct HomeView: View {
                         Image(systemName: "gearshape")
                             .foregroundStyle(Color.bark)
                     }
+                    .accessibilityLabel("Settings")
                 }
             }
             .searchable(
                 text: $searchText,
                 placement: .navigationBarDrawer(displayMode: .always),
-                prompt: "Search meetings, notes, transcripts"
+                prompt: "Search meetings and notes"
             )
             .safeAreaInset(edge: .bottom) { bottomBar }
             .sheet(isPresented: $showFolders) {
@@ -109,7 +126,8 @@ struct HomeView: View {
         }
         .tint(Color.sageDeep)
         .task {
-            await calendar.requestAndLoad()
+            await calendar.refresh(promptIfNeeded: false)
+            await router.refreshAuthorization()
             await router.schedule(for: calendar.upcoming)
             if sync.isLinked {
                 await sync.syncNow(context: context)
@@ -118,7 +136,8 @@ struct HomeView: View {
         .onChange(of: scenePhase) { _, phase in
             if phase == .active {
                 Task {
-                    await calendar.requestAndLoad()
+                    await calendar.refresh(promptIfNeeded: false)
+                    await router.refreshAuthorization()
                     await router.schedule(for: calendar.upcoming)
                     if sync.isLinked { await sync.syncNow(context: context) }
                 }
@@ -146,7 +165,7 @@ struct HomeView: View {
 
     private var titleRow: some View {
         Text(selectedFolderName ?? "My notes")
-            .font(.system(size: 34, weight: .medium, design: .serif))
+            .font(.system(.largeTitle, design: .serif).weight(.medium))
             .foregroundStyle(Color.ink)
             .padding(.top, 4)
     }
@@ -156,6 +175,65 @@ struct HomeView: View {
     }
 
     // MARK: Coming up
+
+    private var calendarAccessCard: some View {
+        integrationCard(
+            icon: "calendar.badge.plus",
+            title: "See upcoming meetings",
+            message: "Connect your calendar to start notes from the right meeting with one tap.",
+            actionTitle: "Connect calendar"
+        ) {
+            Task {
+                await calendar.refresh(promptIfNeeded: true)
+                await router.schedule(for: calendar.upcoming)
+            }
+        }
+    }
+
+    private var calendarDeniedCard: some View {
+        integrationCard(
+            icon: "calendar.badge.exclamationmark",
+            title: "Calendar access is off",
+            message: "DoodleNote still works without it. You can enable access in Settings anytime.",
+            actionTitle: "Open Settings"
+        ) {
+            guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+            openURL(url)
+        }
+    }
+
+    private func integrationCard(
+        icon: String,
+        title: String,
+        message: String,
+        actionTitle: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundStyle(Color.sageDeep)
+                .frame(width: 36, height: 36)
+                .background(Color.sageFill, in: RoundedRectangle(cornerRadius: 10))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.ink)
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(Color.bark)
+                Button(actionTitle, action: action)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color.sageDeep)
+                    .padding(.top, 2)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Color.card, in: RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).stroke(Color.sand))
+    }
 
     private var comingUpSection: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -312,11 +390,11 @@ struct HomeView: View {
             Image(systemName: searchText.isEmpty ? "waveform.badge.mic" : "magnifyingglass")
                 .font(.system(size: 44))
                 .foregroundStyle(Color.sage)
-            Text(searchText.isEmpty ? "No meetings yet" : "No matches")
+            Text(searchText.isEmpty ? "No notes yet" : "No matches")
                 .font(.title3.weight(.semibold))
                 .foregroundStyle(Color.ink)
             if searchText.isEmpty {
-                Text("Tap the + button when you sit down with someone. DoodleNote records, transcribes on your phone, and writes the notes.")
+                Text("Use the + button to record a meeting or jot down a quick note. DoodleNote transcribes recordings and helps write the notes.")
                     .font(.subheadline)
                     .foregroundStyle(Color.bark)
                     .multilineTextAlignment(.center)
@@ -391,7 +469,8 @@ struct HomeView: View {
         meeting.folderId = selectedFolderId
         context.insert(meeting)
         try? context.save()
-        autoRecordMeeting = meeting
+        autoRecordMeetingID = meeting.id
+        draftMeetingIDs.insert(meeting.id)
         path.append(meeting)
     }
 
@@ -401,6 +480,7 @@ struct HomeView: View {
         note.folderId = selectedFolderId
         context.insert(note)
         try? context.save()
+        draftMeetingIDs.insert(note.id)
         path.append(note)
     }
 }
@@ -445,9 +525,3 @@ private struct MeetingRow: View {
         .background(Color.card, in: RoundedRectangle(cornerRadius: 12))
     }
 }
-
-/// A row that reveals Move + Delete when swiped left, since the home list is
-/// a styled ScrollView (native List `.swipeActions` don't apply here). Tap the
-/// content to open; swipe to act. Only one row opens at a time via a shared
-/// binding would be ideal, but per-row state keeps it self-contained — a new
-/// swipe on another row leaves this one open until tapped, which is fine.

--- a/apps/ios/DoodleNote/Views/MarkdownText.swift
+++ b/apps/ios/DoodleNote/Views/MarkdownText.swift
@@ -7,7 +7,7 @@ struct MarkdownText: View {
     let markdown: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        LazyVStack(alignment: .leading, spacing: 6) {
             ForEach(Array(markdown.components(separatedBy: "\n").enumerated()), id: \.offset) { _, line in
                 render(line: line)
             }

--- a/apps/ios/DoodleNote/Views/MeetingView.swift
+++ b/apps/ios/DoodleNote/Views/MeetingView.swift
@@ -4,8 +4,11 @@ import SwiftData
 struct MeetingView: View {
     @Bindable var meeting: Meeting
     var startRecordingOnAppear = false
+    var discardEmptyDraftOnExit = false
+    var onDraftResolved: (() -> Void)?
 
     @Environment(\.modelContext) private var context
+    @Environment(\.openURL) private var openURL
     @Query(sort: \Folder.createdAt) private var folders: [Folder]
     @State private var recorder = RecordingController()
     @State private var tab: Tab = .notes
@@ -27,9 +30,7 @@ struct MeetingView: View {
                 // transcript tab (there is nothing to transcribe).
                 notesTab
             } else {
-                if recorder.isActive {
-                    recordingBanner
-                }
+                recordingControls
 
                 Picker("View", selection: $tab) {
                     ForEach(Tab.allCases, id: \.self) { Text($0.rawValue) }
@@ -65,6 +66,7 @@ struct MeetingView: View {
                 } label: {
                     Image(systemName: meeting.folderId == nil ? "folder" : "folder.fill")
                 }
+                .accessibilityLabel("Move to folder")
             }
         }
         .sheet(isPresented: $showChat) {
@@ -76,8 +78,11 @@ struct MeetingView: View {
             }
         }
         .onDisappear {
-            if recorder.isActive {
-                Task { await recorder.stop(meeting: meeting, context: context) }
+            Task {
+                if recorder.isActive {
+                    await recorder.stop(meeting: meeting, context: context)
+                }
+                resolveDraftOnExit()
             }
         }
     }
@@ -100,52 +105,96 @@ struct MeetingView: View {
 
     // MARK: Recording
 
-    private var recordingBanner: some View {
-        HStack(spacing: 10) {
-            switch recorder.state {
-            case .preparing(let status):
-                ProgressView().tint(Color.sageDeep)
-                Text(status)
-                    .font(.footnote)
-                    .foregroundStyle(Color.bark)
-                    .lineLimit(2)
-            case .recording:
-                Circle()
-                    .fill(.red)
-                    .frame(width: 10, height: 10)
-                if let started = recorder.recordingStartedAt {
-                    ElapsedTimeText(since: started)
-                        .font(.footnote.monospacedDigit().weight(.medium))
-                        .foregroundStyle(Color.ink)
+    @ViewBuilder private var recordingControls: some View {
+        switch recorder.state {
+        case .idle:
+            recordingBar(
+                icon: "record.circle",
+                message: meeting.startedAt == nil ? "Ready to record" : "Recording finished"
+            ) {
+                if meeting.startedAt == nil {
+                    Button("Start recording") { Task { await startRecording() } }
+                        .buttonStyle(RecordingActionButtonStyle())
+                        .accessibilityIdentifier("recording.start")
                 }
-                Text("Recording")
-                    .font(.footnote)
-                    .foregroundStyle(Color.bark)
-            default:
+            }
+        case .preparing(let status):
+            recordingBar(icon: "waveform", message: status, showsProgress: true) {
+                Button("Cancel") {
+                    Task { await recorder.stop(meeting: meeting, context: context) }
+                }
+                .buttonStyle(RecordingActionButtonStyle())
+                .accessibilityIdentifier("recording.cancel")
+            }
+        case .recording:
+            recordingBar(icon: "record.circle.fill", message: "Recording", isRecording: true) {
+                Button("Stop") { Task { await stopRecording() } }
+                    .buttonStyle(RecordingActionButtonStyle())
+                    .accessibilityIdentifier("recording.stop")
+            }
+        case .stopping:
+            recordingBar(icon: "stop.circle", message: "Finishing transcript…", showsProgress: true) {
                 EmptyView()
             }
-
-            Spacer()
-
-            Button {
-                Task {
-                    await recorder.stop(meeting: meeting, context: context)
-                    if SyncEngine.shared.isLinked {
-                        await SyncEngine.shared.syncNow(context: context)
+        case .failed(let message):
+            VStack(alignment: .leading, spacing: 10) {
+                Label("Recording unavailable", systemImage: "exclamationmark.triangle.fill")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.orange)
+                Text(message)
+                    .font(.footnote)
+                    .foregroundStyle(Color.bark)
+                HStack(spacing: 10) {
+                    Button("Retry recording") { Task { await startRecording() } }
+                        .buttonStyle(RecordingActionButtonStyle())
+                        .accessibilityIdentifier("recording.retry")
+                    Button("Open Settings") {
+                        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                        openURL(url)
                     }
-                }
-            } label: {
-                Label("Stop", systemImage: "stop.fill")
                     .font(.footnote.weight(.semibold))
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(Color.ink, in: Capsule())
-                    .foregroundStyle(Color.cream)
+                }
             }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.card, in: RoundedRectangle(cornerRadius: 12))
+            .overlay(RoundedRectangle(cornerRadius: 12).stroke(.orange.opacity(0.45)))
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .accessibilityIdentifier("recording.failed")
+        }
+    }
+
+    private func recordingBar<Actions: View>(
+        icon: String,
+        message: String,
+        showsProgress: Bool = false,
+        isRecording: Bool = false,
+        @ViewBuilder actions: () -> Actions
+    ) -> some View {
+        HStack(spacing: 10) {
+            if showsProgress {
+                ProgressView().tint(Color.sageDeep)
+            } else {
+                Image(systemName: icon)
+                    .foregroundStyle(isRecording ? Color.red : Color.sageDeep)
+            }
+            if isRecording, let started = recorder.recordingStartedAt {
+                ElapsedTimeText(since: started)
+                    .font(.footnote.monospacedDigit().weight(.medium))
+                    .foregroundStyle(Color.ink)
+            }
+            Text(message)
+                .font(.footnote)
+                .foregroundStyle(Color.bark)
+                .lineLimit(2)
+            Spacer()
+            actions()
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
         .background(Color.sageFill)
+        .accessibilityIdentifier("recording.status")
     }
 
     // MARK: Notes tab
@@ -220,7 +269,7 @@ struct MeetingView: View {
                     .background(Color.sageDeep, in: Capsule())
                     .foregroundStyle(Color.cream)
                 }
-                .disabled(isGenerating || recorder.isActive)
+                .disabled(isGenerating || recorder.isActive || !meeting.hasNoteSourceContent)
 
                 Picker("Template", selection: $meeting.templateId) {
                     ForEach(NotePrompt.templates) { template in
@@ -295,7 +344,7 @@ struct MeetingView: View {
 
     private var transcriptTab: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 10) {
+            LazyVStack(alignment: .leading, spacing: 10) {
                 if meeting.segments.isEmpty && recorder.livePartial.isEmpty {
                     Text(recorder.isActive
                         ? "Listening…"
@@ -332,6 +381,37 @@ struct MeetingView: View {
             .padding(16)
         }
         .defaultScrollAnchor(.bottom)
+    }
+
+    private func startRecording() async {
+        await recorder.start(meeting: meeting, context: context)
+    }
+
+    private func stopRecording() async {
+        await recorder.stop(meeting: meeting, context: context)
+        if SyncEngine.shared.isLinked {
+            await SyncEngine.shared.syncNow(context: context)
+        }
+    }
+
+    private func resolveDraftOnExit() {
+        guard discardEmptyDraftOnExit else { return }
+        if meeting.isEmptyDraft {
+            context.delete(meeting)
+            try? context.save()
+        }
+        onDraftResolved?()
+    }
+}
+
+private struct RecordingActionButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.footnote.weight(.semibold))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(Color.ink.opacity(configuration.isPressed ? 0.75 : 1), in: Capsule())
+            .foregroundStyle(Color.cream)
     }
 }
 

--- a/apps/ios/DoodleNote/Views/SettingsView.swift
+++ b/apps/ios/DoodleNote/Views/SettingsView.swift
@@ -1,11 +1,15 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @Environment(\.openURL) private var openURL
     @AppStorage("transcriptionEngine") private var transcriptionEngine = TranscriptionEngine.apple.rawValue
     @AppStorage("notesEngine") private var notesEngine = NotesEngineChoice.onDevice.rawValue
     @AppStorage("byokModel") private var byokModel = AnthropicEngine.defaultModel
+    @AppStorage("meetingNotifications") private var meetingNotifications = false
 
     @State private var apiKey = Keychain.read(key: .anthropicAPIKey) ?? ""
+    @State private var calendar = CalendarService.shared
+    @State private var router = NotificationRouter.shared
 
     var body: some View {
         Form {
@@ -50,6 +54,8 @@ struct SettingsView: View {
                     : "Notes are generated with your own Anthropic API key. The key is stored in the Keychain and sent only to Anthropic.")
             }
 
+            calendarSection
+
             SyncSettingsSection()
 
             CallerIdSection()
@@ -67,5 +73,55 @@ struct SettingsView: View {
         .navigationTitle("Settings")
         .scrollContentBackground(.hidden)
         .background(Color.cream)
+        .task {
+            await calendar.refresh(promptIfNeeded: false)
+            await router.refreshAuthorization()
+        }
+        .onChange(of: meetingNotifications) { _, enabled in
+            Task {
+                if enabled {
+                    let granted = await router.requestAuthorizationAndSchedule(for: calendar.upcoming)
+                    if !granted { meetingNotifications = false }
+                } else {
+                    router.disableNotifications()
+                }
+            }
+        }
+    }
+
+    private var calendarSection: some View {
+        Section {
+            switch calendar.access {
+            case .unknown:
+                Button {
+                    Task { await calendar.refresh(promptIfNeeded: true) }
+                } label: {
+                    Label("Connect calendar", systemImage: "calendar.badge.plus")
+                }
+            case .denied:
+                Button {
+                    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                    openURL(url)
+                } label: {
+                    Label("Calendar access is off", systemImage: "calendar.badge.exclamationmark")
+                }
+            case .granted:
+                LabeledContent("Calendar") { Text("Connected") }
+            }
+
+            Toggle("Meeting reminders", isOn: $meetingNotifications)
+                .disabled(calendar.access != .granted)
+
+            if router.authorization == .denied {
+                Button("Enable notifications in Settings") {
+                    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                    openURL(url)
+                }
+            }
+        } header: {
+            Text("Calendar & reminders")
+        } footer: {
+            Text("Optional. Calendar events stay on this phone. Reminders are only scheduled after you turn them on.")
+        }
     }
 }

--- a/apps/ios/DoodleNote/Views/WelcomeView.swift
+++ b/apps/ios/DoodleNote/Views/WelcomeView.swift
@@ -8,78 +8,83 @@ struct WelcomeView: View {
     @State private var sync = SyncEngine.shared
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(spacing: 0) {
+                    Spacer(minLength: 32)
 
-            Image("Mascot")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 88, height: 88)
-                .clipShape(RoundedRectangle(cornerRadius: 20))
-            Wordmark(font: .largeTitle)
-                .padding(.top, 14)
+                    Image("Mascot")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 88, height: 88)
+                        .clipShape(RoundedRectangle(cornerRadius: 20))
+                    Wordmark(font: .largeTitle)
+                        .padding(.top, 14)
 
-            Text("The AI notepad for\nin-person meetings.")
-                .font(.system(.largeTitle, design: .serif).weight(.medium))
-                .foregroundStyle(Color.ink)
-                .multilineTextAlignment(.center)
-                .padding(.top, 28)
-
-            Text("Records on your phone, transcribes on your phone, writes the notes on your phone. No bot, no cloud, no account needed.")
-                .font(.subheadline)
-                .foregroundStyle(Color.bark)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 36)
-                .padding(.top, 12)
-
-            Spacer()
-
-            VStack(spacing: 10) {
-                Button {
-                    onDone()
-                } label: {
-                    Text("Get started")
-                        .font(.headline)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 14)
-                        .background(Color.ink, in: RoundedRectangle(cornerRadius: 14))
-                        .foregroundStyle(Color.cream)
-                }
-
-                Button {
-                    Task { await sync.link() }
-                } label: {
-                    HStack {
-                        if sync.isLinking { ProgressView().tint(Color.ink) }
-                        Text(sync.isLinking
-                            ? "Finish signing in with Safari…"
-                            : "Sign in & sync my meetings")
-                    }
-                    .font(.headline)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 14)
-                    .background(Color.card, in: RoundedRectangle(cornerRadius: 14))
-                    .overlay(RoundedRectangle(cornerRadius: 14).stroke(Color.sand))
-                    .foregroundStyle(Color.ink)
-                }
-                .disabled(sync.isLinking)
-                .onChange(of: sync.isLinked) { _, linked in
-                    if linked { onDone() }
-                }
-
-                if let error = sync.lastError {
-                    Text(error)
-                        .font(.footnote)
-                        .foregroundStyle(.red)
+                    Text("The AI notepad for\nin-person meetings.")
+                        .font(.system(.largeTitle, design: .serif).weight(.medium))
+                        .foregroundStyle(Color.ink)
                         .multilineTextAlignment(.center)
-                }
+                        .padding(.top, 28)
 
-                Text("Sync is optional — you can link your account anytime in Settings.")
-                    .font(.caption)
-                    .foregroundStyle(Color.stone)
+                    Text("Records on your phone, transcribes on your phone, writes the notes on your phone. No bot, no cloud, no account needed.")
+                        .font(.subheadline)
+                        .foregroundStyle(Color.bark)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 36)
+                        .padding(.top, 12)
+
+                    Spacer(minLength: 36)
+
+                    VStack(spacing: 10) {
+                        Button {
+                            onDone()
+                        } label: {
+                            Text("Get started")
+                                .font(.headline)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 14)
+                                .background(Color.ink, in: RoundedRectangle(cornerRadius: 14))
+                                .foregroundStyle(Color.cream)
+                        }
+
+                        Button {
+                            Task { await sync.link() }
+                        } label: {
+                            HStack {
+                                if sync.isLinking { ProgressView().tint(Color.ink) }
+                                Text(sync.isLinking
+                                    ? "Finish signing in with Safari…"
+                                    : "Sign in & sync my meetings")
+                            }
+                            .font(.headline)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                            .background(Color.card, in: RoundedRectangle(cornerRadius: 14))
+                            .overlay(RoundedRectangle(cornerRadius: 14).stroke(Color.sand))
+                            .foregroundStyle(Color.ink)
+                        }
+                        .disabled(sync.isLinking)
+                        .onChange(of: sync.isLinked) { _, linked in
+                            if linked { onDone() }
+                        }
+
+                        if let error = sync.lastError {
+                            Text(error)
+                                .font(.footnote)
+                                .foregroundStyle(.red)
+                                .multilineTextAlignment(.center)
+                        }
+
+                        Text("Sync is optional — you can link your account anytime in Settings.")
+                            .font(.caption)
+                            .foregroundStyle(Color.stone)
+                    }
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 24)
+                }
+                .frame(maxWidth: .infinity, minHeight: proxy.size.height)
             }
-            .padding(.horizontal, 24)
-            .padding(.bottom, 24)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.cream)

--- a/apps/ios/DoodleNoteTests/TimeoutTests.swift
+++ b/apps/ios/DoodleNoteTests/TimeoutTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import DoodleNote
+
+final class TimeoutTests: XCTestCase {
+    func testNonCooperativeOperationDoesNotBlockTimeout() async {
+        let clock = ContinuousClock()
+        let elapsed = await clock.measure {
+            await withTimeout(seconds: 0.05) {
+                await withCheckedContinuation { (_: CheckedContinuation<Void, Never>) in
+                    // Intentionally never resumed: models a wedged framework await.
+                }
+            }
+        }
+
+        XCTAssertLessThan(elapsed, .milliseconds(500))
+    }
+
+    func testThrowingTimeoutReturnsPromptly() async {
+        let clock = ContinuousClock()
+        let started = clock.now
+
+        do {
+            let _: Int = try await withThrowingTimeout(seconds: 0.05) {
+                try await withCheckedThrowingContinuation {
+                    (_: CheckedContinuation<Int, Error>) in
+                    // Intentionally never resumed.
+                }
+            }
+            XCTFail("Expected a timeout")
+        } catch is TimeoutError {
+            XCTAssertLessThan(started.duration(to: clock.now), .milliseconds(500))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}

--- a/apps/ios/DoodleNoteUITests/SmokeTests.swift
+++ b/apps/ios/DoodleNoteUITests/SmokeTests.swift
@@ -1,24 +1,26 @@
 import XCTest
 
-/// Smoke tests for the core loops. Run on the simulator where speech assets
-/// may be unavailable, so the recording test accepts either the recording
-/// banner or the failure banner — the assertion is that the flow never hangs
-/// or crashes.
+/// Smoke tests for the core loops. Speech assets are not deterministic in the
+/// simulator, so the recording test injects a known failure and verifies the
+/// recovery UI instead of silently accepting a timeout.
 final class SmokeTests: XCTestCase {
     @MainActor
-    private func launch() -> XCUIApplication {
+    private func launch(recordingMode: String? = nil) -> XCUIApplication {
         let app = XCUIApplication()
-        // Skip onboarding and notification-permission prompts for the test.
-        app.launchArguments += ["-hasOnboarded", "YES", "-meetingNotifications", "NO"]
+        // Use an in-memory store and skip onboarding for deterministic tests.
+        app.launchArguments += ["-uiTesting", "YES", "-hasOnboarded", "YES", "-meetingNotifications", "NO"]
+        if let recordingMode {
+            app.launchEnvironment["UITEST_RECORDING_MODE"] = recordingMode
+        }
         app.launch()
         return app
     }
 
-    /// Launch → + → Record meeting → recording starts (or fails gracefully)
-    /// → stop → notes editor is present.
+    /// Launch → + → Record meeting → visible failure/retry path → back without
+    /// leaving an empty draft behind.
     @MainActor
     func testNewMeetingFlow() throws {
-        let app = launch()
+        let app = launch(recordingMode: "failure")
 
         XCTAssertTrue(app.buttons["New"].waitForExistence(timeout: 10))
         app.buttons["New"].tap()
@@ -28,17 +30,15 @@ final class SmokeTests: XCTestCase {
         // Meeting view: the Notes/Transcript switcher must appear.
         XCTAssertTrue(app.buttons["Notes"].waitForExistence(timeout: 10))
 
-        // Recording either reaches the Stop button or surfaces an error;
-        // give asset download a generous window.
-        let stop = app.buttons["Stop"]
-        if stop.waitForExistence(timeout: 60) {
-            stop.tap()
-            XCTAssertTrue(stop.waitForNonExistence(timeout: 30))
-        }
+        // Simulator/device failures must be visible and recoverable. Never let
+        // this test fall through when neither Stop nor a failure state exists.
+        XCTAssertTrue(app.buttons["Retry recording"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Recording unavailable"].exists)
+        XCTAssertTrue(app.buttons["Open Settings"].exists)
 
-        // Notes tab content is reachable either way.
-        app.buttons["Notes"].tap()
-        XCTAssertTrue(app.staticTexts["Your rough notes"].waitForExistence(timeout: 5))
+        // Leaving a failed, untouched recording must not litter Home.
+        app.buttons["Back"].tap()
+        XCTAssertTrue(app.staticTexts["Untitled meeting"].waitForNonExistence(timeout: 5))
     }
 
     /// Launch → + → New note → the plain editor appears with no recording
@@ -64,5 +64,23 @@ final class SmokeTests: XCTestCase {
         XCTAssertTrue(app.textFields.containing(
             NSPredicate(format: "value CONTAINS %@", "Buy sage green paint")
         ).firstMatch.exists)
+
+        app.buttons["Back"].tap()
+        XCTAssertTrue(app.staticTexts["Untitled note"].waitForExistence(timeout: 5))
+    }
+
+    /// Launch → + → New note → back without typing → no empty list item.
+    @MainActor
+    func testEmptyQuickNoteIsDiscarded() throws {
+        let app = launch()
+
+        XCTAssertTrue(app.buttons["New"].waitForExistence(timeout: 10))
+        app.buttons["New"].tap()
+        XCTAssertTrue(app.buttons["New note"].waitForExistence(timeout: 5))
+        app.buttons["New note"].tap()
+        XCTAssertTrue(app.staticTexts["Your note"].waitForExistence(timeout: 10))
+
+        app.buttons["Back"].tap()
+        XCTAssertTrue(app.staticTexts["Untitled note"].waitForNonExistence(timeout: 5))
     }
 }

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -23,7 +23,7 @@ workspace.
   and `SyncEngine` (push-then-pull cycle, local-edits-win conflict rule,
   `allIds` deletion reconciliation — a simplified port of
   `apps/desktop/src/main/sync-service.ts`). Linking uses
-  `ASWebAuthenticationSession` → `/link-device?scheme=doodlenote` →
+  system Safari → `/link-device?scheme=doodlenote` →
   `doodlenote://link?token=…` (web-side support in
   `apps/web/app/link-device`).
 

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -23,8 +23,23 @@ schemes:
     test:
       config: Debug
       targets:
+        - DoodleNoteTests
         - DoodleNoteUITests
 targets:
+  DoodleNoteTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - DoodleNoteTests
+    dependencies:
+      - target: DoodleNote
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.doodlenote.ios.tests
+        DEVELOPMENT_TEAM: VTZW6K32K4
+        CODE_SIGN_STYLE: Automatic
+        GENERATE_INFOPLIST_FILE: true
+        SWIFT_VERSION: "6.0"
   DoodleNoteUITests:
     type: bundle.ui-testing
     platform: iOS
@@ -53,6 +68,8 @@ targets:
       path: DoodleNote/Info.plist
       properties:
         CFBundleDisplayName: DoodleNote
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         UILaunchScreen: {}
         UISupportedInterfaceOrientations: [UIInterfaceOrientationPortrait]
         NSMicrophoneUsageDescription: DoodleNote records your meetings so it can transcribe them on this device. Audio never leaves your phone.
@@ -68,7 +85,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.doodlenote.ios
         PRODUCT_NAME: DoodleNote
-        MARKETING_VERSION: 0.1.0
+        MARKETING_VERSION: 0.4.8
         CURRENT_PROJECT_VERSION: 1
         DEVELOPMENT_TEAM: VTZW6K32K4
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary

- Make recording preparation and failures visible with cancel, retry, and Settings recovery actions.
- Replace cooperative pseudo-timeouts with hard UI-returning bounds and add regression tests.
- Discard untouched meeting/note drafts instead of littering Home with untitled rows.
- Make calendar and notification permissions explicitly user-driven, with status and recovery controls in Settings.
- Move calendar fetching plus transcript hashing/payload preparation off the main actor and use lazy transcript/Markdown stacks.
- Improve Dynamic Type behavior, accessibility labels, contrast, search/empty-state copy, version metadata, and privacy declarations.
- Make UI tests deterministic with an in-memory store and a simulated recording failure that cannot silently pass.

## Root cause

The simulator cannot reliably provide the physical microphone and on-device speech assets needed by the production recording path. The app then entered a failed/inactive recorder state that MeetingView did not render, while the old smoke test waited for Stop and still passed when it never appeared. The previous task-group timeout also still waited for a non-cooperative framework operation after cancellation.

## Verification

- Simulator build and launch: passed on iPhone 17 Pro / iOS 26.5.
- Test suite: 5 passed, 0 failed (2 unit, 3 UI).
- Generic arm64 iOS device build with signing disabled: passed.
- Generated app bundle contains a valid PrivacyInfo.xcprivacy and reports version 0.4.8 (build 1).
- Source build warnings from the audit are resolved; Xcode only emits the expected no-AppIntents metadata notice.

## Physical-device follow-up

A real iPhone is still required to validate live microphone capture, SpeechAnalyzer asset download, transcription quality, interruptions, and background audio. The simulator can validate the UI and recovery behavior but cannot prove the physical recording pipeline.