### PR TITLE
Hide iOS phone calls for MVP

### DIFF
--- a/apps/ios/DoodleNote/PrivacyInfo.xcprivacy
+++ b/apps/ios/DoodleNote/PrivacyInfo.xcprivacy
@@ -29,18 +29,6 @@
 		</dict>
 		<dict>
 			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypePhoneNumber</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<true/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
-			</array>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-		</dict>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
 			<string>NSPrivacyCollectedDataTypeEmailAddress</string>
 			<key>NSPrivacyCollectedDataTypeLinked</key>
 			<true/>

--- a/apps/ios/DoodleNote/Support/AppFeatures.swift
+++ b/apps/ios/DoodleNote/Support/AppFeatures.swift
@@ -1,0 +1,5 @@
+/// MVP feature gates. Keep unfinished work compiled and easy to restore while
+/// ensuring customers cannot enter flows that are not ready to support yet.
+enum AppFeatures {
+    static let phoneCalls = false
+}

--- a/apps/ios/DoodleNote/Views/HomeView.swift
+++ b/apps/ios/DoodleNote/Views/HomeView.swift
@@ -87,14 +87,16 @@ struct HomeView: View {
                     .accessibilityLabel("Folders")
                 }
                 ToolbarItem(placement: .principal) { Wordmark(font: .subheadline) }
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        showDialer = true
-                    } label: {
-                        Image(systemName: "phone")
-                            .foregroundStyle(Color.bark)
+                if AppFeatures.phoneCalls {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            showDialer = true
+                        } label: {
+                            Image(systemName: "phone")
+                                .foregroundStyle(Color.bark)
+                        }
+                        .accessibilityLabel("Phone calls")
                     }
-                    .accessibilityLabel("Phone calls")
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     NavigationLink {
@@ -119,8 +121,10 @@ struct HomeView: View {
                 ChatView(scope: .global)
             }
             .sheet(isPresented: $showDialer) {
-                DialerView { meeting in
-                    path.append(meeting)
+                if AppFeatures.phoneCalls {
+                    DialerView { meeting in
+                        path.append(meeting)
+                    }
                 }
             }
         }

--- a/apps/ios/DoodleNote/Views/SettingsView.swift
+++ b/apps/ios/DoodleNote/Views/SettingsView.swift
@@ -58,7 +58,9 @@ struct SettingsView: View {
 
             SyncSettingsSection()
 
-            CallerIdSection()
+            if AppFeatures.phoneCalls {
+                CallerIdSection()
+            }
 
             Section {
                 LabeledContent("Version") {

--- a/apps/ios/DoodleNoteUITests/SmokeTests.swift
+++ b/apps/ios/DoodleNoteUITests/SmokeTests.swift
@@ -83,4 +83,17 @@ final class SmokeTests: XCTestCase {
         app.buttons["Back"].tap()
         XCTAssertTrue(app.staticTexts["Untitled note"].waitForNonExistence(timeout: 5))
     }
+
+    /// The unfinished phone-call recorder must not be discoverable in the MVP.
+    @MainActor
+    func testPhoneCallsAreHiddenForMVP() throws {
+        let app = launch()
+
+        XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 10))
+        XCTAssertFalse(app.buttons["Phone calls"].exists)
+
+        app.buttons["Settings"].tap()
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.staticTexts["Caller ID"].exists)
+    }
 }


### PR DESCRIPTION
## Summary

- Add a single MVP feature gate for the unfinished iOS phone-call recorder.
- Hide the Home phone button and dialer sheet entry point.
- Hide Verified Caller ID from Settings.
- Remove the inactive phone-number collection declaration from the iOS privacy manifest.
- Keep the underlying phone implementation compiled and intact so it can be re-enabled later.

## Verification

- Simulator build and launch passed on iPhone 17 Pro / iOS 26.5.
- Runtime accessibility snapshot shows no Phone calls toolbar entry.
- Settings snapshot shows no Caller ID surface.
- 6 tests passed, 0 failed, including the regular meeting-recording flow and a new MVP phone-visibility regression test.
- Packaged PrivacyInfo.xcprivacy is valid and contains no phone-number collection declaration.

## Risk and follow-up

The Twilio/phone implementation remains in the binary but has no customer-accessible entry point. Re-enabling it later is a one-line feature-gate change plus restoration of the phone-number privacy declaration after the flow is production-ready.