### PR TITLE
Release DoodleNote v0.4.9

### DIFF
--- a/RELEASE-v0.4.9.md
+++ b/RELEASE-v0.4.9.md
@@ -1,0 +1,35 @@
+# DoodleNote v0.4.9 release candidate
+
+## Included
+
+- [x] Replace the desktop icon assets with the corrected full-bleed DoodleNote artwork
+- [x] Keep the macOS, Windows, and iOS app icons visually consistent
+- [x] Bump the desktop version from 0.4.8 to 0.4.9
+- [x] Add the v0.4.9 changelog entry
+
+## Verification
+
+- [x] Desktop tests and typechecks
+- [x] Production Electron build
+- [x] Signed and notarized arm64 package
+- [x] Gatekeeper accepts the extracted application
+- [x] Stapled notarization ticket validates in the extracted application
+- [ ] Live update feed reports 0.4.9
+- [x] Published artifact checksum matches the uploaded update manifest
+
+## Release gates
+
+- [x] Corrected iOS icon verified on the simulator Home Screen
+- [x] Corrected desktop icon verified from the packaged source asset
+- [x] User authorizes the production desktop update
+
+## Package
+
+- Artifact: `DoodleNote-0.4.9-arm64-mac.zip`
+- Size: `166656809` bytes
+- SHA-256: `03cebd36d31a62c9a3c45713a3ed36d6b287b1815aad167be450c40772ae409d`
+- SHA-512: `8wm16SnCJkuK9nJFpsbl2S6arN4//wUVvfErYKkHbpIylBgFx9Oogl++abbfi11QJCBGyUOIqHiSl7SWl5CkqA==`
+- Apple notarization: `e176c91f-7395-41f4-bfd3-0733654f6d1d` (`Accepted`)
+- Developer ID: `SEAN INMAN (VTZW6K32K4)`
+- Gatekeeper: `accepted` (`Notarized Developer ID`)
+- Stapled ticket: validated in the archive after extraction

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "private": true,
   "description": "Doodle Note desktop app \u2014 spawns the Swift transcription sidecar and shows its live transcript stream",
   "main": "./out/main/index.js",

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,13 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.9",
+    date: "August 2, 2026",
+    highlights: [
+      "The Mac app icon now fills its rounded shape cleanly, with no pale side gutters",
+    ],
+  },
+  {
     version: "0.4.8",
     date: "August 1, 2026",
     highlights: [

--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,8 +1,8 @@
-version: 0.4.8
+version: 0.4.9
 files:
-  - url: DoodleNote-0.4.8-arm64-mac.zip
-    sha512: iQ+GjUhbUgB8wXXc4NOnPvewWsY1zJTaFfi9FPrZWla/Nzh8FkbcneVSZc8OI+jVt82D8gFjEDz7mKrX0qyxkQ==
-    size: 168029009
-path: DoodleNote-0.4.8-arm64-mac.zip
-sha512: iQ+GjUhbUgB8wXXc4NOnPvewWsY1zJTaFfi9FPrZWla/Nzh8FkbcneVSZc8OI+jVt82D8gFjEDz7mKrX0qyxkQ==
-releaseDate: '2026-08-01T19:46:53.507Z'
+  - url: DoodleNote-0.4.9-arm64-mac.zip
+    sha512: 8wm16SnCJkuK9nJFpsbl2S6arN4//wUVvfErYKkHbpIylBgFx9Oogl++abbfi11QJCBGyUOIqHiSl7SWl5CkqA==
+    size: 166656809
+path: DoodleNote-0.4.9-arm64-mac.zip
+sha512: 8wm16SnCJkuK9nJFpsbl2S6arN4//wUVvfErYKkHbpIylBgFx9Oogl++abbfi11QJCBGyUOIqHiSl7SWl5CkqA==
+releaseDate: '2026-08-02T18:04:41.512Z'


### PR DESCRIPTION
## Summary

- publish the corrected full-bleed DoodleNote icon in the macOS app
- bump the desktop app to v0.4.9 and add its changelog entry
- update the production macOS updater manifest to the signed and notarized v0.4.9 artifact

## Verification

- 105 desktop tests passed; 3 audio-fixture tests skipped as expected
- desktop node and renderer typechecks passed
- production Electron build completed
- Apple notarization accepted: `e176c91f-7395-41f4-bfd3-0733654f6d1d`
- extracted app passed strict code-signature, Gatekeeper, and stapler validation
- uploaded artifact downloaded back with matching size and SHA-256

## Artifact

- `DoodleNote-0.4.9-arm64-mac.zip`
- 166,656,809 bytes
- SHA-256 `03cebd36d31a62c9a3c45713a3ed36d6b287b1815aad167be450c40772ae409d`