### PR TITLE
Allow a smaller DoodleNote window

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -32,6 +32,7 @@ import { MicWatcher } from './mic-watcher'
 import { NotesService } from './notes-service'
 import { PromptPanel } from './prompt-panel'
 import { SyncService } from './sync-service'
+import { MAIN_WINDOW_SIZE } from './window-sizing'
 import {
   DETECT_GET_STATE_CHANNEL,
   DETECT_MEETING_ENDED_CHANNEL,
@@ -146,10 +147,10 @@ function broadcastEngineEvent(event: EngineEvent): void {
 
 function createWindow(): void {
   const mainWindow = new BrowserWindow({
-    width: 1180,
-    height: 760,
-    minWidth: 980,
-    minHeight: 680,
+    width: MAIN_WINDOW_SIZE.defaultWidth,
+    height: MAIN_WINDOW_SIZE.defaultHeight,
+    minWidth: MAIN_WINDOW_SIZE.minWidth,
+    minHeight: MAIN_WINDOW_SIZE.minHeight,
     // Matches the active palette so launch never flashes the wrong color.
     backgroundColor: nativeTheme.shouldUseDarkColors ? '#1d1f19' : '#f7f5ee',
     show: false,

--- a/apps/desktop/src/main/window-sizing.test.ts
+++ b/apps/desktop/src/main/window-sizing.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import { MAIN_WINDOW_SIZE } from './window-sizing'
+
+const css = readFileSync(new URL('../renderer/src/assets/main.css', import.meta.url), 'utf8')
+
+test('the main window supports a compact 800 by 560 layout', () => {
+  assert.deepEqual(MAIN_WINDOW_SIZE, {
+    defaultWidth: 1180,
+    defaultHeight: 760,
+    minWidth: 800,
+    minHeight: 560
+  })
+  assert.ok(MAIN_WINDOW_SIZE.minWidth < MAIN_WINDOW_SIZE.defaultWidth)
+  assert.ok(MAIN_WINDOW_SIZE.minHeight < MAIN_WINDOW_SIZE.defaultHeight)
+})
+
+test('the sidebar remains accessible when compact height needs scrolling', () => {
+  const sidebar = css.match(/\.sidebar\s*\{([^}]*)\}/)
+  assert.ok(sidebar, 'Missing .sidebar CSS rule')
+  assert.match(sidebar[1], /\boverflow-y\s*:\s*auto\s*;/)
+})

--- a/apps/desktop/src/main/window-sizing.ts
+++ b/apps/desktop/src/main/window-sizing.ts
@@ -1,0 +1,10 @@
+/**
+ * Main-window bounds in CSS pixels. The default keeps the roomy desktop
+ * layout, while the minimum supports compact laptop and side-by-side setups.
+ */
+export const MAIN_WINDOW_SIZE = {
+  defaultWidth: 1180,
+  defaultHeight: 760,
+  minWidth: 800,
+  minHeight: 560
+} as const

--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -158,6 +158,7 @@ a,
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
   border-right: 1px solid var(--border);
   padding: 0 10px 12px;
   min-height: 0;


### PR DESCRIPTION
## Bug

The desktop window could not be resized below 980×680, which is larger than some compact and side-by-side setups need.

## Root cause

The main Electron BrowserWindow hard-coded `minWidth: 980` and `minHeight: 680`. The sidebar also had no vertical overflow behavior if the window became shorter.

## Fix

- lower the supported minimum window size to 800×560 while keeping the 1180×760 default
- centralize the default and minimum dimensions in a tested window-sizing module
- let the sidebar scroll at compact heights so bottom controls remain reachable

## Verification

- focused window-sizing regression tests: 2 passed
- full desktop suite: 107 passed, 3 existing fixture skips, 0 failed
- desktop Node and renderer typechecks
- production Electron build
- changed TypeScript ESLint and Prettier checks
- foreground Electron smoke: requesting 700×500 correctly clamps to 800×560
- visual Home smoke at 800×560: sidebar, New menu, content, and bottom action bar remain visible without overlap

## Risk

The default launch size is unchanged. Only the user-selectable minimum is smaller; overflow behavior is limited to the sidebar.