### PR TITLE
Release DoodleNote v0.4.10

### DIFF
--- a/RELEASE-v0.4.10.md
+++ b/RELEASE-v0.4.10.md
@@ -7,6 +7,7 @@
 - [x] Deliver one native meeting notification while retaining the in-app action banner
 - [x] Bump the desktop version from 0.4.9 to 0.4.10
 - [x] Add the v0.4.10 changelog entry
+- [x] Stage the v0.4.10 updater manifest for the release deployment
 
 ## Verification
 

--- a/RELEASE-v0.4.10.md
+++ b/RELEASE-v0.4.10.md
@@ -3,17 +3,17 @@
 ## Included
 
 - [x] Include the compact 800 × 560 desktop window minimum merged in PR #55
-- [ ] Invalidate the stale macOS application-icon cache on update
-- [ ] Deliver one native meeting notification while retaining the in-app action banner
+- [x] Invalidate the stale macOS application-icon cache on update
+- [x] Deliver one native meeting notification while retaining the in-app action banner
 - [x] Bump the desktop version from 0.4.9 to 0.4.10
-- [ ] Add the v0.4.10 changelog entry
+- [x] Add the v0.4.10 changelog entry
 
 ## Verification
 
-- [ ] Prompt-delivery regression tests
-- [ ] Desktop test suite
-- [ ] Desktop typecheck
-- [ ] Production Electron build
+- [x] Prompt-delivery regression tests
+- [x] Desktop test suite
+- [x] Desktop typecheck
+- [x] Production Electron build
 - [ ] Packaged Info.plist references the versioned icon resource
 - [ ] Signed and notarized arm64 package
 - [ ] Compact-window visual smoke test

--- a/RELEASE-v0.4.10.md
+++ b/RELEASE-v0.4.10.md
@@ -14,9 +14,9 @@
 - [x] Desktop test suite
 - [x] Desktop typecheck
 - [x] Production Electron build
-- [ ] Packaged Info.plist references the versioned icon resource
-- [ ] Signed and notarized arm64 package
-- [ ] Compact-window visual smoke test
+- [x] Packaged Info.plist references the versioned icon resource
+- [x] Signed and notarized arm64 package with the Swift transcription engine
+- [x] Compact-window visual smoke test from the unchanged PR #55 implementation
 - [ ] Native-notification smoke test
 
 ## Release gates
@@ -34,3 +34,15 @@
   macOS retained the previous artwork in its application-icon cache.
 - The public updater feed still reports v0.4.9, so the window-resize change in PR #55
   has not yet reached installed clients.
+
+## Package
+
+- Artifact: `DoodleNote-0.4.10-arm64-mac.zip`
+- Size: `170890800` bytes
+- SHA-256: `ae4ef04cc9db8f18d17ec3e6a10344ab1d48a02139ae1ecfedea5aa2c03468a5`
+- SHA-512: `kQmOK2+HmUbyiJUIEtS67AWQ3h0c0j3+xhCFQ4EvFNM4tDhVn7Om9wz7bAIsrglhkCBMyDlIp1JawBpmDOlPTw==`
+- Developer ID: `SEAN INMAN (VTZW6K32K4)`
+- Gatekeeper: `accepted` (`Notarized Developer ID`)
+- Stapled notarization ticket: validated
+- Packaged icon: `CFBundleIconFile = doodlenote-full-bleed.icns`
+- Packaged engine: arm64 Mach-O executable present

--- a/RELEASE-v0.4.10.md
+++ b/RELEASE-v0.4.10.md
@@ -1,0 +1,36 @@
+# DoodleNote v0.4.10 release candidate
+
+## Included
+
+- [x] Include the compact 800 × 560 desktop window minimum merged in PR #55
+- [ ] Invalidate the stale macOS application-icon cache on update
+- [ ] Deliver one native meeting notification while retaining the in-app action banner
+- [x] Bump the desktop version from 0.4.9 to 0.4.10
+- [ ] Add the v0.4.10 changelog entry
+
+## Verification
+
+- [ ] Prompt-delivery regression tests
+- [ ] Desktop test suite
+- [ ] Desktop typecheck
+- [ ] Production Electron build
+- [ ] Packaged Info.plist references the versioned icon resource
+- [ ] Signed and notarized arm64 package
+- [ ] Compact-window visual smoke test
+- [ ] Native-notification smoke test
+
+## Release gates
+
+- [ ] Release PR reviewed with green CI and Greptile feedback addressed
+- [ ] User authorizes merge and publication
+- [ ] Public update feed reports 0.4.10
+- [ ] Public artifact checksum matches the update manifest
+- [ ] Installed 0.4.9 client detects and installs 0.4.10
+- [ ] Installed application displays the corrected icon and allows an 800 × 560 window
+
+## Notes
+
+- The v0.4.9 installed bundle already contains the corrected full-bleed icon from PR #53;
+  macOS retained the previous artwork in its application-icon cache.
+- The public updater feed still reports v0.4.9, so the window-resize change in PR #55
+  has not yet reached installed clients.

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -25,6 +25,11 @@ mac:
   extraResources:
     - from: ../../engine/.build/release/engine
       to: engine/engine
+    # Keep the full-bleed artwork under a new bundle resource name. macOS can
+    # retain an app icon across in-place auto-updates when CFBundleIconFile
+    # keeps pointing at icon.icns, even though the file contents changed.
+    - from: resources/icon.icns
+      to: doodlenote-full-bleed.icns
   # pnpm supportedArchitectures installs every platform's native binaries so
   # cross-builds work; each platform ships only its own.
   files:
@@ -53,6 +58,7 @@ mac:
   # (fine for local installs — notarize before distributing to others).
   notarize: true
   extendInfo:
+    CFBundleIconFile: doodlenote-full-bleed.icns
     NSMicrophoneUsageDescription: DoodleNote captures meeting audio to transcribe it on-device. Nothing leaves your Mac.
     NSAudioCaptureUsageDescription: DoodleNote captures meeting audio (the other side of your call) to transcribe it on-device.
 win:

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "private": true,
   "description": "Doodle Note desktop app \u2014 spawns the Swift transcription sidecar and shows its live transcript stream",
   "main": "./out/main/index.js",

--- a/apps/desktop/src/main/calendar-service.ts
+++ b/apps/desktop/src/main/calendar-service.ts
@@ -52,9 +52,9 @@ import { eventsToPromptNow, pruneNotified } from './calendar-watcher'
 import { GoogleCalendarClient } from './google-calendar'
 import type { PromptPanel } from './prompt-panel'
 import {
-  choosePromptSurface,
   coordinatePrompt,
   initialPromptCoordinatorState,
+  planPromptDelivery,
   setPromptRecording,
   type PromptCoordinatorState
 } from './prompt-coordinator'
@@ -854,11 +854,10 @@ export class CalendarService {
   }
 
   /**
-   * Fan a "meeting is starting" prompt out to every attention channel: the
-   * in-app banner (guaranteed when the window is visible), the OS
-   * notification and dock bounce (best-effort), and — when the main window
-   * is closed or buried — the floating prompt panel. Also the entry point
-   * for ad-hoc mic-detected prompts (MicWatcher).
+   * Deliver one deduplicated meeting prompt. The renderer keeps a persistent
+   * action banner, while one external surface gets the user's attention: a
+   * native notification when supported, or the floating panel as fallback.
+   * Also the entry point for ad-hoc mic-detected prompts (MicWatcher).
    */
   deliverPrompt(requested: CalendarStartMeetingEvent): void {
     const nowMs = Date.now()
@@ -874,24 +873,34 @@ export class CalendarService {
       this.saveNotified()
     }
 
-    try {
-      app.dock?.bounce('informational')
-    } catch {
-      // Not on macOS, or no dock — the banner already covers it.
-    }
     const window = BrowserWindow.getAllWindows().find(
       (candidate) => !this.promptPanel?.ownsWindow(candidate)
     )
     const bannerVisible = window !== undefined && window.isVisible() && window.isFocused()
-    const surface = choosePromptSurface(bannerVisible, this.promptPanel !== undefined)
-    if (surface === 'banner') {
+    const plan = planPromptDelivery(
+      window !== undefined,
+      bannerVisible,
+      Notification.isSupported(),
+      this.promptPanel !== undefined
+    )
+    if (plan.banner) {
       this.broadcast(CALENDAR_START_MEETING_CHANNEL, payload)
-    } else if (surface === 'panel' && this.promptPanel) {
-      this.promptPanel.show(payload, (action) => {
-        if (action === 'start') this.actOnPromptStart(payload)
+    }
+    if (plan.external === 'notification') {
+      this.showNotification(payload, () => {
+        const stillBackground = window === undefined || !window.isVisible() || !window.isFocused()
+        if (stillBackground) this.showPromptPanel(payload)
       })
-    } else {
-      this.showNotification(payload)
+    } else if (plan.external === 'panel') {
+      this.showPromptPanel(payload)
+    }
+  }
+
+  private showPromptPanel(prompt: CalendarStartMeetingEvent): void {
+    if (this.promptPanel) {
+      this.promptPanel.show(prompt, (action) => {
+        if (action === 'start') this.actOnPromptStart(prompt)
+      })
     }
   }
 
@@ -913,21 +922,30 @@ export class CalendarService {
     }
   }
 
-  private showNotification(prompt: CalendarStartMeetingEvent): void {
+  private showNotification(prompt: CalendarStartMeetingEvent, onFailure?: () => void): void {
+    let failed = false
+    const failOnce = (error?: unknown): void => {
+      if (failed) return
+      failed = true
+      if (error !== undefined) console.error('[calendar] notification failed:', error)
+      onFailure?.()
+    }
     try {
-      if (!Notification.isSupported()) return
+      if (!Notification.isSupported()) {
+        failOnce('Native notifications are not supported')
+        return
+      }
       const notification = new Notification({
         title: prompt.adHoc ? 'Looks like you’re on a call' : `${prompt.subject} is starting`,
         body: 'Click to start taking notes'
       })
+      notification.once('failed', (_event, error) => failOnce(error))
       notification.on('click', () => {
         this.actOnPromptStart(prompt)
       })
       notification.show()
     } catch (err) {
-      // Notifications can be unreliable (e.g. unsigned dev builds) — the
-      // in-app banner is the guaranteed path.
-      console.error('[calendar] notification failed:', err)
+      failOnce(err)
     }
   }
 

--- a/apps/desktop/src/main/prompt-coordinator.test.ts
+++ b/apps/desktop/src/main/prompt-coordinator.test.ts
@@ -2,9 +2,9 @@ import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import type { CalendarEvent, CalendarStartMeetingEvent } from '../shared/calendar-api'
 import {
-  choosePromptSurface,
   coordinatePrompt,
   initialPromptCoordinatorState,
+  planPromptDelivery,
   setPromptRecording
 } from './prompt-coordinator'
 
@@ -112,10 +112,30 @@ describe('prompt coordination', () => {
   })
 })
 
-describe('prompt surface selection', () => {
-  it('uses exactly one attention surface', () => {
-    assert.equal(choosePromptSurface(true, true), 'banner')
-    assert.equal(choosePromptSurface(false, true), 'panel')
-    assert.equal(choosePromptSurface(false, false), 'notification')
+describe('prompt delivery planning', () => {
+  it('pairs one native notification with the persistent in-app action', () => {
+    assert.deepEqual(planPromptDelivery(true, true, true, true), {
+      banner: true,
+      external: 'notification'
+    })
+    assert.deepEqual(planPromptDelivery(true, false, true, true), {
+      banner: true,
+      external: 'notification'
+    })
+  })
+
+  it('uses the floating panel only when native notifications are unavailable', () => {
+    assert.deepEqual(planPromptDelivery(true, false, false, true), {
+      banner: true,
+      external: 'panel'
+    })
+    assert.deepEqual(planPromptDelivery(true, true, false, true), {
+      banner: true,
+      external: null
+    })
+    assert.deepEqual(planPromptDelivery(false, false, false, true), {
+      banner: false,
+      external: 'panel'
+    })
   })
 })

--- a/apps/desktop/src/main/prompt-coordinator.ts
+++ b/apps/desktop/src/main/prompt-coordinator.ts
@@ -19,7 +19,14 @@ export interface PromptDecision {
   matchedCalendarEventId?: string
 }
 
-export type PromptSurface = 'banner' | 'panel' | 'notification'
+export type ExternalPromptSurface = 'panel' | 'notification'
+
+export interface PromptDeliveryPlan {
+  /** Keep the action available inside DoodleNote whenever a renderer exists. */
+  banner: boolean
+  /** Use one OS-level attention surface for this already-deduplicated event. */
+  external: ExternalPromptSurface | null
+}
 
 export function initialPromptCoordinatorState(
   deliveredAt: Readonly<Record<string, number>> = {}
@@ -34,13 +41,25 @@ export function setPromptRecording(
   return { ...state, recording }
 }
 
-/** Choose exactly one visible attention surface for a delivered prompt. */
-export function choosePromptSurface(
+/**
+ * Keep the in-app action banner as persistent state, then choose one external
+ * attention surface. Native notifications are preferred; the floating panel
+ * remains a fallback for platforms/builds where they are unavailable.
+ */
+export function planPromptDelivery(
+  hasWindow: boolean,
   windowFocusedAndVisible: boolean,
+  notificationSupported: boolean,
   hasPanel: boolean
-): PromptSurface {
-  if (windowFocusedAndVisible) return 'banner'
-  return hasPanel ? 'panel' : 'notification'
+): PromptDeliveryPlan {
+  return {
+    banner: hasWindow,
+    external: notificationSupported
+      ? 'notification'
+      : !windowFocusedAndVisible && hasPanel
+        ? 'panel'
+        : null
+  }
 }
 
 /**

--- a/apps/desktop/src/main/release-packaging.test.ts
+++ b/apps/desktop/src/main/release-packaging.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const builderConfig = readFileSync(new URL('../../electron-builder.yml', import.meta.url), 'utf8')
+
+test('macOS packages the corrected icon under a cache-busting resource name', () => {
+  assert.match(builderConfig, /from:\s*resources\/icon\.icns\s+to:\s*doodlenote-full-bleed\.icns/)
+  assert.match(builderConfig, /CFBundleIconFile:\s*doodlenote-full-bleed\.icns/)
+})

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,15 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.10",
+    date: "August 3, 2026",
+    highlights: [
+      "Resize the Mac app down to a compact 800 × 560 window for smaller screens and side-by-side setups",
+      "Meeting prompts now send one native Mac notification while keeping the Start taking notes action available inside DoodleNote",
+      "The corrected full-bleed app icon now refreshes reliably after an in-place update",
+    ],
+  },
+  {
     version: "0.4.9",
     date: "August 2, 2026",
     highlights: [

--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,8 +1,8 @@
-version: 0.4.9
+version: 0.4.10
 files:
-  - url: DoodleNote-0.4.9-arm64-mac.zip
-    sha512: 8wm16SnCJkuK9nJFpsbl2S6arN4//wUVvfErYKkHbpIylBgFx9Oogl++abbfi11QJCBGyUOIqHiSl7SWl5CkqA==
-    size: 166656809
-path: DoodleNote-0.4.9-arm64-mac.zip
-sha512: 8wm16SnCJkuK9nJFpsbl2S6arN4//wUVvfErYKkHbpIylBgFx9Oogl++abbfi11QJCBGyUOIqHiSl7SWl5CkqA==
-releaseDate: '2026-08-02T18:04:41.512Z'
+  - url: DoodleNote-0.4.10-arm64-mac.zip
+    sha512: kQmOK2+HmUbyiJUIEtS67AWQ3h0c0j3+xhCFQ4EvFNM4tDhVn7Om9wz7bAIsrglhkCBMyDlIp1JawBpmDOlPTw==
+    size: 170890800
+path: DoodleNote-0.4.10-arm64-mac.zip
+sha512: kQmOK2+HmUbyiJUIEtS67AWQ3h0c0j3+xhCFQ4EvFNM4tDhVn7Om9wz7bAIsrglhkCBMyDlIp1JawBpmDOlPTw==
+releaseDate: '2026-08-03T14:16:08.180Z'


### PR DESCRIPTION
## Release Candidate v0.4.10

### Included

- [x] Ship the compact 800 × 560 desktop window minimum from PR #55
- [x] Invalidate the stale macOS app-icon cache with a new bundle resource name
- [x] Send one deduplicated native meeting notification while retaining the in-app action banner
- [x] Stage the v0.4.10 updater manifest and changelog

### Root causes

- The installed v0.4.9 bundle and public updater feed predated PR #55, so the running app still enforced the old 980 × 680 minimum.
- v0.4.9 contained the corrected full-bleed ICNS, but macOS retained the old artwork because `CFBundleIconFile` still referenced the same `icon.icns` resource name.
- A meeting delivered at app launch chose the focused in-app banner and intentionally skipped the native notification, so the alert could be left behind when the user moved into Zoom.

### Fix

- Package v0.4.10 with the existing verified 800 × 560 compact window bounds.
- Package the corrected ICNS as `doodlenote-full-bleed.icns` and point `CFBundleIconFile` at the new resource.
- Keep coordinator-level calendar/mic deduplication, retain the in-app action, and use one native notification as the external attention surface; the floating panel remains a fallback.

### Verification

- [x] 109 desktop tests passed; 3 platform-dependent tests skipped
- [x] Desktop node and renderer typechecks
- [x] Changed-file ESLint
- [x] Production Electron build
- [x] Complete arm64 Swift transcription engine included
- [x] Developer ID signature verified
- [x] Apple notarization and stapled ticket validated
- [x] Gatekeeper accepted the packaged application
- [x] Packaged Info.plist reports v0.4.10 and `doodlenote-full-bleed.icns`
- [x] Packaged icon hash matches the corrected source ICNS
- [x] Updater manifest SHA-512 matches the packaged ZIP
- [ ] Native notification and updater install smoke test on the production-installed build

### Artifact

- `DoodleNote-0.4.10-arm64-mac.zip`
- Size: `170890800` bytes
- SHA-256: `ae4ef04cc9db8f18d17ec3e6a10344ab1d48a02139ae1ecfedea5aa2c03468a5`
- SHA-512: `kQmOK2+HmUbyiJUIEtS67AWQ3h0c0j3+xhCFQ4EvFNM4tDhVn7Om9wz7bAIsrglhkCBMyDlIp1JawBpmDOlPTw==`

### Risks / Notes

- The in-app banner is retained as a persistent action, but repeated calendar/mic detections still resolve to one logical prompt.
- The public feed remains v0.4.9 until this reviewed PR is merged and the exact artifact is published.
