### PR TITLE
Fix iOS Ask anything locale failure

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,54 @@
+name: iOS
+
+on:
+  pull_request:
+    paths:
+      - "apps/ios/**"
+      - ".github/workflows/ios.yml"
+  push:
+    branches: [main]
+    paths:
+      - "apps/ios/**"
+      - ".github/workflows/ios.yml"
+
+jobs:
+  unit-tests:
+    runs-on: macos-26
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        working-directory: apps/ios
+        run: xcodegen generate
+
+      - name: Run iOS unit tests
+        working-directory: apps/ios
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          IOS_RUNTIME_ID=$(xcrun simctl list runtimes available -j | jq -r \
+            '[.runtimes[] | select(.isAvailable and (.name | startswith("iOS")))] | last | .identifier')
+          IPHONE_DEVICE_TYPE=$(xcrun simctl list devicetypes -j | jq -r \
+            '([.devicetypes[] | select(.name == "iPhone 17 Pro")] | first | .identifier) // ([.devicetypes[] | select(.name | startswith("iPhone"))] | first | .identifier)')
+
+          test -n "$IOS_RUNTIME_ID"
+          test -n "$IPHONE_DEVICE_TYPE"
+
+          SIMULATOR_UDID=$(xcrun simctl create "DoodleNote CI" "$IPHONE_DEVICE_TYPE" "$IOS_RUNTIME_ID")
+          trap 'xcrun simctl shutdown "$SIMULATOR_UDID" || true; xcrun simctl delete "$SIMULATOR_UDID" || true' EXIT
+
+          xcrun simctl boot "$SIMULATOR_UDID"
+          xcrun simctl bootstatus "$SIMULATOR_UDID" -b
+
+          xcodebuild test \
+            -project DoodleNote.xcodeproj \
+            -scheme DoodleNote \
+            -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" \
+            -only-testing:DoodleNoteTests \
+            CODE_SIGNING_ALLOWED=NO \
+            DEVELOPMENT_TEAM=""

--- a/apps/ios/DoodleNote/AI/AskEngine.swift
+++ b/apps/ios/DoodleNote/AI/AskEngine.swift
@@ -82,7 +82,7 @@ enum AskEngine {
         var used = 0
         var omitted = 0
 
-        for meeting in meetings.sorted(by: { $0.createdAt > $1.createdAt }) {
+        for meeting in prioritizedGlobalMeetings(meetings, question: question) {
             let date = meeting.createdAt.formatted(.iso8601.year().month().day())
             let notes = bestNotes(for: meeting)
             let section = "=== MEETING: \(meeting.displayTitle) — \(date) ===\n\(notes)"
@@ -107,6 +107,72 @@ enum AskEngine {
         return try await NotesEngineFactory.make().respond(
             system: globalSystemPrompt,
             user: sections.joined(separator: "\n\n")
+        )
+    }
+
+    /// A global question is often really asking for one customer or meeting.
+    /// Put title matches first and exclude unrelated recent notes so the small
+    /// on-device context window contains the meeting the user actually named.
+    /// This also prevents one unrelated note from making Apple's language
+    /// classifier reject the entire mixed prompt.
+    @MainActor
+    static func prioritizedGlobalMeetings(_ meetings: [Meeting], question: String) -> [Meeting] {
+        let recent = meetings.sorted(by: { $0.createdAt > $1.createdAt })
+        let terms = searchTerms(in: question)
+        guard !terms.isEmpty else { return recent }
+
+        struct Match {
+            let meeting: Meeting
+            let titleHits: Int
+            let noteHits: Int
+            let recentIndex: Int
+
+            var score: Int { titleHits * 100 + noteHits * 10 }
+        }
+
+        let matches = recent.enumerated().compactMap { index, meeting -> Match? in
+            let title = normalizedSearchText(meeting.displayTitle)
+            let notes = normalizedSearchText(bestNotes(for: meeting))
+            let titleHits = terms.count(where: { title.contains($0) })
+            let noteHits = terms.count(where: { notes.contains($0) })
+            guard titleHits > 0 || noteHits > 0 else { return nil }
+            return Match(
+                meeting: meeting,
+                titleHits: titleHits,
+                noteHits: noteHits,
+                recentIndex: index
+            )
+        }
+        guard !matches.isEmpty else { return recent }
+
+        // When the user names a meeting/customer, notes-only matches are
+        // distracting and can consume the entire local-model context budget.
+        let candidates = matches.contains(where: { $0.titleHits > 0 })
+            ? matches.filter { $0.titleHits > 0 }
+            : matches
+        return candidates.sorted {
+            if $0.score != $1.score { return $0.score > $1.score }
+            return $0.recentIndex < $1.recentIndex
+        }.map(\.meeting)
+    }
+
+    private static let genericQuestionTerms: Set<String> = [
+        "about", "action", "actions", "anything", "are", "did", "does", "dos", "for",
+        "from", "how", "into", "item", "items", "list", "meeting", "meetings", "mine",
+        "my", "open", "our", "recent", "tell", "the", "this", "todo", "todos", "was",
+        "were", "what", "when", "where", "which", "who", "with", "you", "your",
+    ]
+
+    private static func searchTerms(in question: String) -> [String] {
+        normalizedSearchText(question)
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { $0.count >= 3 && !genericQuestionTerms.contains($0) }
+    }
+
+    private static func normalizedSearchText(_ text: String) -> String {
+        text.folding(
+            options: [.caseInsensitive, .diacriticInsensitive],
+            locale: Locale(identifier: "en_US_POSIX")
         )
     }
 

--- a/apps/ios/DoodleNote/AI/AskEngine.swift
+++ b/apps/ios/DoodleNote/AI/AskEngine.swift
@@ -1,189 +1,209 @@
 import Foundation
 import SwiftData
 
-/// "Ask anything" — chat with one meeting or across recent meetings.
-/// Prompts ported from packages/ai/src/ask-prompt.ts and
-/// global-ask-prompt.ts; answers are grounded strictly in meeting context.
+/// "Ask anything" — grounded chat with one meeting or the full local corpus.
+/// Retrieval stays on-device; the selected NotesEngine performs synthesis.
 enum AskEngine {
-    struct Exchange {
+    struct Exchange: Sendable {
         var question: String
         var answer: String
     }
 
     static let meetingSystemPrompt = """
-    You are the meeting assistant inside Doodle Note, an AI meeting notepad. The user asks questions about ONE specific meeting; its full context (transcript, the user's rough notes, generated notes, prior Q&A) is provided with the question.
+    You are the meeting assistant inside DoodleNote. The user asks about ONE meeting. Source excerpts from that meeting's generated notes, rough notes, and transcript are provided.
 
     Rules:
-    - Answer using ONLY the provided meeting context. No outside knowledge, no guesses.
-    - If the answer is not in the meeting, say plainly that it didn't come up in this meeting. Never invent facts, names, numbers, or commitments.
-    - This transcript is a single-channel in-person recording: speakers are not separated. Attribute a statement to a person only when the transcript itself makes that clear.
-    - Be concise: answer the question directly, then stop. No preamble like "Based on the meeting…".
-    - Markdown is allowed when it helps (bullet lists, **bold**); plain sentences otherwise.
-    - When asked to draft an email (e.g. a follow-up), produce a ready-to-send email grounded in the meeting's decisions and action items: a Subject line, a brief recap, decisions made, and action items with owners. Use only facts from the meeting and add no placeholders beyond the sender's own sign-off.
+    - Answer using ONLY the provided sources. Never use outside knowledge or guess.
+    - If the answer is absent, say plainly that it did not come up in the provided meeting sources.
+    - This is a single-channel in-person recording. Attribute a statement to a person only when the source makes that clear.
+    - Preserve names, owners, dates, numbers, and commitments exactly as written.
+    - Cite factual claims with the source label and meeting title, for example: [M1] Project Kickoff — 2026-07-15.
+    - When asked for action items, output only the action items; do not add a meeting recap or unrelated topics.
+    - When asked to draft an email or follow-up, produce ready-to-send copy using only the supplied meeting facts.
+    - Be concise and answer directly. Markdown is allowed.
     """
 
     static let globalSystemPrompt = """
-    You are the meeting assistant inside DoodleNote, an AI meeting notepad. The user asks questions across their RECENT MEETINGS. Notes for each meeting are provided, newest first.
+    You are the meeting assistant inside DoodleNote. The user asks questions across their meetings. Relevant excerpts from meeting titles, generated notes, rough notes, and transcripts are provided.
 
     Rules:
-    - Answer using ONLY the provided meeting notes. No outside knowledge, no guesses.
-    - Attribute what you say: name the meeting (title and date) each point comes from. When the answer spans meetings, group by meeting, newest first.
-    - If the answer is not in the provided notes, say plainly that it doesn't appear in the recent meetings. Never invent facts, names, numbers, or commitments.
-    - When asked for todos or action items: list outstanding items grouped by meeting, newest first, keeping each item's owner. Skip meetings with none rather than writing "none".
-    - Be concise: answer the question directly, then stop. No preamble.
-    - Markdown is allowed when it helps (headings per meeting, bullet lists, **bold**).
+    - Answer using ONLY the provided sources. Never use outside knowledge or guess.
+    - If the answer is absent, say plainly that it does not appear in the provided sources.
+    - Preserve names, owners, dates, numbers, and commitments exactly as written.
+    - Transcript excerpts come from single-channel recordings. Attribute words to a person only when the excerpt itself makes the speaker clear.
+    - Every factual group or bullet must cite its source label, meeting title, and date, for example: [M2] Customer Review — 2026-07-15.
+    - For todos, decisions, or follow-ups, group results by meeting and retain the owner and deadline when present.
+    - When asked for action items, output only the action items; do not add a meeting recap or unrelated topics.
+    - Do not claim an item is still open unless the source explicitly says so; call it an action item instead.
+    - When asked to draft an email or follow-up, produce ready-to-send copy using only the supplied meeting facts.
+    - Be concise and answer directly. Markdown is allowed.
     """
 
-    private static let maxHistory = 6
+    private static let exhaustiveSystemPrompt = globalSystemPrompt + """
+
+    This request may be processed in multiple evidence batches. Return every relevant fact in THIS batch, with citations. Do not summarize away distinct action items, owners, deadlines, or decisions. If this batch contains nothing that answers the question, output exactly NO_MATCH.
+    """
+
+    private static let maxHistory = 4
 
     // MARK: Per-meeting ask
 
     @MainActor
     static func ask(meeting: Meeting, question: String, history: [Exchange]) async throws -> String {
+        let snapshot = snapshot(meeting)
+        guard snapshot.hasSourceContent else {
+            return "This meeting doesn't have notes or transcript content to search yet."
+        }
+
+        let historySearch = retrievalHistory(history)
         let budget = NotesEngineFactory.contextBudgetChars
+        let result = await Task.detached(priority: .userInitiated) {
+            AskRetrieval.retrieve(
+                meetings: [snapshot],
+                question: question,
+                history: historySearch,
+                maxBatchChars: budget
+            )
+        }.value
 
-        var transcript = meeting.sortedSegments
-            .map { "[\(NotePrompt.formatTimestamp(ms: $0.startMs))] \($0.speaker): \($0.text)" }
-            .joined(separator: "\n")
-        if transcript.isEmpty { transcript = "(no transcript captured)" }
-        if transcript.count > budget {
-            let half = budget / 2
-            transcript = transcript.prefix(half) + "\n[… middle omitted …]\n" + transcript.suffix(half)
+        guard let batch = result.batches.first else {
+            return "I couldn't find that in this meeting's notes or transcript."
         }
-
-        var sections = [
-            "Meeting: \(meeting.displayTitle)",
-            "=== TRANSCRIPT ===\n\(transcript)",
-            "=== USER'S ROUGH NOTES ===\n\(meeting.roughNotes.isEmpty ? "(the user took no rough notes)" : meeting.roughNotes)",
-        ]
-        if let generated = meeting.generatedNotes, !generated.isEmpty {
-            sections.append("=== GENERATED NOTES ===\n\(generated)")
-        }
-        if !history.isEmpty {
-            let exchanges = history.suffix(maxHistory)
-                .map { "Q: \($0.question)\nA: \($0.answer)" }
-                .joined(separator: "\n\n")
-            sections.append("=== PRIOR Q&A (this conversation) ===\n\(exchanges)")
-        }
-        sections.append("=== QUESTION ===\n\(question)\n\nAnswer using only the meeting context above.")
-
-        return try await NotesEngineFactory.make().respond(
-            system: meetingSystemPrompt,
-            user: sections.joined(separator: "\n\n")
+        let user = prompt(
+            evidence: result.render(batch),
+            question: question,
+            history: history
         )
+        let answer = try await NotesEngineFactory.make().respond(
+            system: meetingSystemPrompt,
+            user: user,
+            maxResponseTokens: 600
+        )
+        return result.attributed(answer)
     }
 
     // MARK: Cross-meeting ask
 
     @MainActor
     static func askGlobal(meetings: [Meeting], question: String, history: [Exchange]) async throws -> String {
+        var snapshots: [AskMeetingSnapshot] = []
+        snapshots.reserveCapacity(meetings.count)
+        for (index, meeting) in meetings.enumerated() where meeting.hasNoteSourceContent {
+            snapshots.append(snapshot(meeting))
+            if index.isMultiple(of: 5) { await Task.yield() }
+        }
+
+        guard !snapshots.isEmpty else {
+            return "I couldn't find any meeting notes or transcripts to search yet."
+        }
+
+        let historySearch = retrievalHistory(history)
         let budget = NotesEngineFactory.contextBudgetChars
-        var sections: [String] = []
-        var used = 0
-        var omitted = 0
-
-        for meeting in prioritizedGlobalMeetings(meetings, question: question) {
-            let date = meeting.createdAt.formatted(.iso8601.year().month().day())
-            let notes = bestNotes(for: meeting)
-            let section = "=== MEETING: \(meeting.displayTitle) — \(date) ===\n\(notes)"
-            if used + section.count > budget && !sections.isEmpty {
-                omitted += 1
-                continue
-            }
-            sections.append(section)
-            used += section.count
-        }
-        if omitted > 0 {
-            sections.append("(\(omitted) older meeting\(omitted == 1 ? "" : "s") omitted for length)")
-        }
-        if !history.isEmpty {
-            let exchanges = history.suffix(maxHistory)
-                .map { "Q: \($0.question)\nA: \($0.answer)" }
-                .joined(separator: "\n\n")
-            sections.append("=== PRIOR Q&A (this conversation) ===\n\(exchanges)")
-        }
-        sections.append("=== QUESTION ===\n\(question)\n\nAnswer using only the meeting notes above.")
-
-        return try await NotesEngineFactory.make().respond(
-            system: globalSystemPrompt,
-            user: sections.joined(separator: "\n\n")
-        )
-    }
-
-    /// A global question is often really asking for one customer or meeting.
-    /// Put title matches first and exclude unrelated recent notes so the small
-    /// on-device context window contains the meeting the user actually named.
-    /// This also prevents one unrelated note from making Apple's language
-    /// classifier reject the entire mixed prompt.
-    @MainActor
-    static func prioritizedGlobalMeetings(_ meetings: [Meeting], question: String) -> [Meeting] {
-        let recent = meetings.sorted(by: { $0.createdAt > $1.createdAt })
-        let terms = searchTerms(in: question)
-        guard !terms.isEmpty else { return recent }
-
-        struct Match {
-            let meeting: Meeting
-            let titleHits: Int
-            let noteHits: Int
-            let recentIndex: Int
-
-            var score: Int { titleHits * 100 + noteHits * 10 }
-        }
-
-        let matches = recent.enumerated().compactMap { index, meeting -> Match? in
-            let title = normalizedSearchText(meeting.displayTitle)
-            let notes = normalizedSearchText(bestNotes(for: meeting))
-            let titleHits = terms.count(where: { title.contains($0) })
-            let noteHits = terms.count(where: { notes.contains($0) })
-            guard titleHits > 0 || noteHits > 0 else { return nil }
-            return Match(
-                meeting: meeting,
-                titleHits: titleHits,
-                noteHits: noteHits,
-                recentIndex: index
+        let result = await Task.detached(priority: .userInitiated) {
+            AskRetrieval.retrieve(
+                meetings: snapshots,
+                question: question,
+                history: historySearch,
+                maxBatchChars: budget
             )
+        }.value
+
+        guard !result.batches.isEmpty else {
+            if let scope = result.dateScopeDescription {
+                return "I couldn't find any meetings from \(scope)."
+            }
+            return "I couldn't find relevant meeting notes or transcript details for that question."
         }
-        guard !matches.isEmpty else { return recent }
 
-        // When the user names a meeting/customer, notes-only matches are
-        // distracting and can consume the entire local-model context budget.
-        let candidates = matches.contains(where: { $0.titleHits > 0 })
-            ? matches.filter { $0.titleHits > 0 }
-            : matches
-        return candidates.sorted {
-            if $0.score != $1.score { return $0.score > $1.score }
-            return $0.recentIndex < $1.recentIndex
-        }.map(\.meeting)
+        let engine = NotesEngineFactory.make()
+        if !result.isExhaustive, let batch = result.batches.first {
+            let answer = try await engine.respond(
+                system: globalSystemPrompt,
+                user: prompt(
+                    evidence: result.render(batch),
+                    question: question,
+                    history: history
+                ),
+                maxResponseTokens: 600
+            )
+            return result.attributed(answer)
+        }
+
+        // Broad requests (for example, "all action items this week") are
+        // processed in bounded batches. This is slower than one completion but
+        // never silently drops meetings just because Apple's context is small.
+        var answers: [String] = []
+        for batch in result.batches {
+            let answer = try await engine.respond(
+                system: exhaustiveSystemPrompt,
+                user: prompt(
+                    evidence: result.render(batch),
+                    question: question,
+                    history: history
+                ),
+                maxResponseTokens: 700
+            ).trimmingCharacters(in: .whitespacesAndNewlines)
+            if answer.caseInsensitiveCompare("NO_MATCH") != .orderedSame {
+                answers.append(answer)
+            }
+        }
+
+        guard !answers.isEmpty else {
+            return "I couldn't find that in the matching meeting notes or transcripts."
+        }
+        return result.attributed(answers.joined(separator: "\n\n"))
     }
 
-    private static let genericQuestionTerms: Set<String> = [
-        "about", "action", "actions", "anything", "are", "did", "does", "dos", "for",
-        "from", "how", "into", "item", "items", "list", "meeting", "meetings", "mine",
-        "my", "open", "our", "recent", "tell", "the", "this", "todo", "todos", "was",
-        "were", "what", "when", "where", "which", "who", "with", "you", "your",
-    ]
+    // MARK: Context snapshots and prompts
 
-    private static func searchTerms(in question: String) -> [String] {
-        normalizedSearchText(question)
-            .components(separatedBy: CharacterSet.alphanumerics.inverted)
-            .filter { $0.count >= 3 && !genericQuestionTerms.contains($0) }
-    }
-
-    private static func normalizedSearchText(_ text: String) -> String {
-        text.folding(
-            options: [.caseInsensitive, .diacriticInsensitive],
-            locale: Locale(identifier: "en_US_POSIX")
+    @MainActor
+    private static func snapshot(_ meeting: Meeting) -> AskMeetingSnapshot {
+        AskMeetingSnapshot(
+            id: meeting.id,
+            title: meeting.displayTitle,
+            createdAt: meeting.createdAt,
+            generatedNotes: meeting.generatedNotes ?? "",
+            roughNotes: meeting.roughNotes,
+            segments: meeting.sortedSegments.map {
+                AskMeetingSnapshot.TranscriptSegment(
+                    speaker: $0.speaker,
+                    text: $0.text,
+                    startMs: $0.startMs,
+                    endMs: $0.endMs
+                )
+            }
         )
     }
 
-    /// Generated notes preferred (compact and dense), then rough notes, then
-    /// a transcript excerpt — same fallback order as desktop.
-    private static func bestNotes(for meeting: Meeting) -> String {
-        if let generated = meeting.generatedNotes, !generated.isEmpty { return generated }
-        if !meeting.roughNotes.isEmpty { return meeting.roughNotes }
-        let excerpt = meeting.sortedSegments.prefix(30)
-            .map { "\($0.speaker): \($0.text)" }
-            .joined(separator: "\n")
-        return excerpt.isEmpty ? "(no notes captured)" : "Transcript excerpt:\n" + excerpt
+    private static func retrievalHistory(_ history: [Exchange]) -> [String] {
+        history.suffix(2).map { exchange in
+            // The previous question carries conversational scope. Feeding the
+            // entire answer back into retrieval can introduce unrelated terms
+            // and pull a follow-up toward the wrong meeting.
+            "Previous question: \(exchange.question)"
+        }
+    }
+
+    private static func prompt(
+        evidence: String,
+        question: String,
+        history: [Exchange]
+    ) -> String {
+        var sections = ["=== MEETING SOURCES ===\n\(evidence)"]
+        if !history.isEmpty {
+            let prior = history.suffix(maxHistory).map { exchange in
+                "Q: \(exchange.question)\nA: \(exchange.answer)"
+            }.joined(separator: "\n\n")
+            // Retrieval uses the complete recent exchanges, while the model
+            // gets a bounded tail so history cannot evict current evidence.
+            sections.append("=== PRIOR Q&A ===\n\(String(prior.suffix(1_600)))")
+        }
+        sections.append("""
+        === QUESTION ===
+        \(question)
+
+        Answer using only the labeled meeting sources above.
+        """)
+        return sections.joined(separator: "\n\n")
     }
 }

--- a/apps/ios/DoodleNote/AI/AskRetrieval.swift
+++ b/apps/ios/DoodleNote/AI/AskRetrieval.swift
@@ -1,0 +1,731 @@
+import Foundation
+import NaturalLanguage
+
+/// Sendable copies of SwiftData meeting records. SwiftData relationships stay
+/// on the main actor; retrieval and semantic ranking run on a background task.
+struct AskMeetingSnapshot: Sendable {
+    struct TranscriptSegment: Sendable {
+        let speaker: String
+        let text: String
+        let startMs: Int
+        let endMs: Int
+    }
+
+    let id: UUID
+    let title: String
+    let createdAt: Date
+    let generatedNotes: String
+    let roughNotes: String
+    let segments: [TranscriptSegment]
+
+    var hasSourceContent: Bool {
+        !generatedNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !roughNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !segments.isEmpty
+    }
+}
+
+enum AskEvidenceSource: String, Sendable {
+    case generatedNotes = "Generated notes"
+    case roughNotes = "Rough notes"
+    case transcript = "Transcript"
+}
+
+struct AskEvidenceChunk: Sendable, Equatable {
+    let meetingID: UUID
+    let meetingTitle: String
+    let meetingDate: Date
+    let source: AskEvidenceSource
+    let text: String
+    let startMs: Int?
+    let endMs: Int?
+}
+
+struct AskRetrievalResult: Sendable {
+    let batches: [[AskEvidenceChunk]]
+    let meetingLabels: [UUID: String]
+    let selectedMeetingIDs: [UUID]
+    let isExhaustive: Bool
+    let dateScopeDescription: String?
+
+    var allChunks: [AskEvidenceChunk] { batches.flatMap { $0 } }
+
+    func attributed(_ answer: String) -> String {
+        let sources = selectedMeetingIDs.compactMap { id -> String? in
+            guard let chunk = allChunks.first(where: { $0.meetingID == id }) else { return nil }
+            let label = meetingLabels[id] ?? "M?"
+            return "- [\(label)] \(chunk.meetingTitle) — \(Self.isoDate(chunk.meetingDate))"
+        }
+        guard !sources.isEmpty else { return answer }
+        return answer + "\n\n**Sources**\n" + sources.joined(separator: "\n")
+    }
+
+    func render(_ batch: [AskEvidenceChunk]) -> String {
+        batch.map { chunk in
+            let label = meetingLabels[chunk.meetingID] ?? "M?"
+            var source = chunk.source.rawValue
+            if let startMs = chunk.startMs {
+                let start = NotePrompt.formatTimestamp(ms: startMs)
+                if let endMs = chunk.endMs, endMs > startMs {
+                    source += " \(start)-\(NotePrompt.formatTimestamp(ms: endMs))"
+                } else {
+                    source += " \(start)"
+                }
+            }
+            return """
+            === SOURCE [\(label)] ===
+            Meeting: \(chunk.meetingTitle)
+            Date: \(Self.isoDate(chunk.meetingDate))
+            Source: \(source)
+            \(chunk.text)
+            """
+        }.joined(separator: "\n\n")
+    }
+
+    private static func isoDate(_ date: Date) -> String {
+        let components = Calendar(identifier: .gregorian)
+            .dateComponents([.year, .month, .day], from: date)
+        return String(
+            format: "%04d-%02d-%02d",
+            components.year ?? 0,
+            components.month ?? 0,
+            components.day ?? 0
+        )
+    }
+}
+
+/// Query-time, local-only retrieval over titles, generated notes, rough notes,
+/// and the complete transcript. No meeting content leaves the device unless
+/// the user has explicitly selected the BYOK cloud engine.
+enum AskRetrieval {
+    private static let maxChunkChars = 900
+    private static let maxTargetedChunks = 14
+    private static let maxTargetedChunksPerMeeting = 5
+    private static let maxExhaustiveChunksPerMeeting = 2
+    private static let maxSemanticMeetings = 3
+
+    private static let stopWords: Set<String> = [
+        "a", "about", "all", "am", "an", "and", "any", "are", "as", "at",
+        "be", "been", "being", "but", "by", "can", "did", "discuss", "discussed",
+        "do", "does", "doing", "for", "from", "get", "got", "had", "has", "have",
+        "how", "i", "in", "into", "is", "it", "just", "list", "me", "meeting",
+        "meetings", "mine", "my", "of", "on", "or", "our", "recent", "said", "say",
+        "some", "tell", "than", "that", "the", "their", "them", "there", "these",
+        "they", "this", "those", "to", "us", "was", "we", "were", "what", "when",
+        "where", "which", "who", "why", "will", "with", "would", "you", "your",
+    ]
+
+    private static let actionWords: Set<String> = [
+        "action", "actions", "assign", "assigned", "commit", "committed", "commitment",
+        "due", "follow", "followup", "item", "items", "next", "open", "owe", "owner",
+        "promise", "promised", "responsible", "step", "steps", "task", "tasks", "todo",
+        "todos",
+    ]
+
+    private static let actionExpansion: Set<String> = actionWords.union([
+        "deliver", "deadline", "email", "need", "needs", "prepare", "proposal", "send",
+        "schedule", "will",
+    ])
+
+    private static let decisionWords: Set<String> = [
+        "agree", "agreed", "decision", "decisions", "decide", "decided", "conclusion",
+    ]
+
+    private struct QueryIntent {
+        let normalizedQuestion: String
+        let queryTerms: Set<String>
+        let identityTerms: Set<String>
+        let isActionQuestion: Bool
+        let isDecisionQuestion: Bool
+        let requestsAll: Bool
+        let latestMeetingOnly: Bool
+    }
+
+    private struct DateScope {
+        let range: Range<Date>
+        let description: String
+    }
+
+    private struct ScoredChunk {
+        let chunk: AskEvidenceChunk
+        let score: Double
+        let hasIntentEvidence: Bool
+    }
+
+    static func retrieve(
+        meetings: [AskMeetingSnapshot],
+        question: String,
+        history: [String] = [],
+        maxBatchChars: Int,
+        now: Date = .now,
+        calendar: Calendar = .current,
+        useSemanticSearch: Bool = true
+    ) -> AskRetrievalResult {
+        let intent = queryIntent(question)
+        let dateScope = dateScope(for: question, now: now, calendar: calendar)
+        let datedMeetings = meetings
+            .filter(\.hasSourceContent)
+            .filter { meeting in
+                guard let dateScope else { return true }
+                return dateScope.range.contains(meeting.createdAt)
+            }
+            .sorted { $0.createdAt > $1.createdAt }
+
+        guard !datedMeetings.isEmpty else {
+            return AskRetrievalResult(
+                batches: [],
+                meetingLabels: [:],
+                selectedMeetingIDs: [],
+                isExhaustive: intent.requestsAll,
+                dateScopeDescription: dateScope?.description
+            )
+        }
+
+        let retrievalText = (history.suffix(2) + [question]).joined(separator: " ")
+        let retrievalTerms = meaningfulTerms(in: retrievalText)
+        let namedMeetings = namedMeetingIDs(in: datedMeetings, identityTerms: retrievalTerms
+            .subtracting(stopWords)
+            .subtracting(actionWords)
+            .subtracting(decisionWords))
+        let matchingMeetings = namedMeetings.isEmpty
+            ? datedMeetings
+            : datedMeetings.filter { namedMeetings.contains($0.id) }
+        let initialScopedMeetings = intent.latestMeetingOnly
+            ? Array(matchingMeetings.prefix(1))
+            : matchingMeetings
+        let exhaustive = intent.requestsAll || ((intent.isActionQuestion || intent.isDecisionQuestion)
+            && namedMeetings.isEmpty && !intent.latestMeetingOnly)
+
+        // Exhaustive action/decision searches already have strong structural
+        // and lexical signals. Embedding every transcript chunk there adds
+        // tens of seconds without improving coverage.
+        let embedding = useSemanticSearch && !exhaustive
+            ? NLEmbedding.sentenceEmbedding(for: .english)
+            : nil
+        // For an unscoped corpus, cheaply rank one compact summary per meeting
+        // before embedding individual chunks. This preserves semantic search
+        // without making a broad paraphrased question embed every transcript.
+        let scopedMeetings = if let embedding,
+                                initialScopedMeetings.count > maxSemanticMeetings
+        {
+            semanticMeetingCandidates(
+                initialScopedMeetings,
+                question: intent.normalizedQuestion,
+                queryTerms: retrievalTerms,
+                embedding: embedding
+            )
+        } else {
+            initialScopedMeetings
+        }
+
+        let chunks = scopedMeetings.flatMap(makeChunks)
+        // Across several meetings, exact terms and section headings rank the
+        // finalist chunks without an expensive second pass over transcripts.
+        // Chunk-level semantics remain useful inside one clearly scoped call.
+        let chunkEmbedding = scopedMeetings.count == 1 ? embedding : nil
+        let scored = chunks.map { chunk in
+            score(
+                chunk,
+                intent: intent,
+                retrievalTerms: retrievalTerms,
+                namedMeetingIDs: namedMeetings,
+                embedding: chunkEmbedding,
+                now: now
+            )
+        }
+
+        let selected: [AskEvidenceChunk]
+        if exhaustive {
+            selected = selectExhaustive(
+                scored,
+                meetings: scopedMeetings,
+                intent: intent
+            )
+        } else {
+            selected = selectTargeted(
+                scored,
+                meetings: scopedMeetings,
+                seedEveryMeeting: !namedMeetings.isEmpty
+            )
+        }
+
+        let selectedMeetingIDs = selected.reduce(into: [UUID]()) { ids, chunk in
+            if !ids.contains(chunk.meetingID) { ids.append(chunk.meetingID) }
+        }
+        let labels = Dictionary(uniqueKeysWithValues: selectedMeetingIDs.enumerated().map {
+            ($0.element, "M\($0.offset + 1)")
+        })
+        var batches = pack(selected, labels: labels, maxBatchChars: max(1_000, maxBatchChars))
+        if !exhaustive, batches.count > 1 {
+            batches = Array(batches.prefix(1))
+        }
+
+        return AskRetrievalResult(
+            batches: batches,
+            meetingLabels: labels,
+            selectedMeetingIDs: selectedMeetingIDs,
+            isExhaustive: exhaustive,
+            dateScopeDescription: dateScope?.description
+        )
+    }
+
+    // MARK: Chunking
+
+    private static func makeChunks(_ meeting: AskMeetingSnapshot) -> [AskEvidenceChunk] {
+        var chunks: [AskEvidenceChunk] = []
+
+        if !meeting.generatedNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            chunks += splitMarkdown(meeting.generatedNotes).map {
+                AskEvidenceChunk(
+                    meetingID: meeting.id,
+                    meetingTitle: meeting.title,
+                    meetingDate: meeting.createdAt,
+                    source: .generatedNotes,
+                    text: $0,
+                    startMs: nil,
+                    endMs: nil
+                )
+            }
+        }
+
+        if !meeting.roughNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            chunks += splitMarkdown(meeting.roughNotes).map {
+                AskEvidenceChunk(
+                    meetingID: meeting.id,
+                    meetingTitle: meeting.title,
+                    meetingDate: meeting.createdAt,
+                    source: .roughNotes,
+                    text: $0,
+                    startMs: nil,
+                    endMs: nil
+                )
+            }
+        }
+
+        var transcriptLines: [(text: String, startMs: Int, endMs: Int)] = []
+        for segment in meeting.segments.sorted(by: { $0.startMs < $1.startMs }) {
+            let line = "[\(NotePrompt.formatTimestamp(ms: segment.startMs))] \(segment.speaker): \(segment.text)"
+            transcriptLines.append((line, segment.startMs, segment.endMs))
+        }
+        chunks += splitTranscript(transcriptLines).map {
+            AskEvidenceChunk(
+                meetingID: meeting.id,
+                meetingTitle: meeting.title,
+                meetingDate: meeting.createdAt,
+                source: .transcript,
+                text: $0.text,
+                startMs: $0.startMs,
+                endMs: $0.endMs
+            )
+        }
+
+        return chunks
+    }
+
+    /// Carries a Markdown heading into every split chunk so an "Action Items"
+    /// section remains discoverable even when the list is longer than one chunk.
+    private static func splitMarkdown(_ text: String) -> [String] {
+        var result: [String] = []
+        var heading: String?
+        var body: [String] = []
+
+        func rendered(_ lines: [String]) -> String {
+            ([heading].compactMap { $0 } + lines)
+                .joined(separator: "\n")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        func flush() {
+            let value = rendered(body)
+            if !value.isEmpty { result.append(value) }
+            body.removeAll(keepingCapacity: true)
+        }
+
+        for rawLine in text.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix("#") {
+                flush()
+                heading = line
+                continue
+            }
+
+            let candidate = rendered(body + [line])
+            if candidate.count <= maxChunkChars {
+                body.append(line)
+                continue
+            }
+
+            flush()
+            var remainder = line
+            while rendered([remainder]).count > maxChunkChars {
+                let headingCount = heading?.count ?? 0
+                let available = max(100, maxChunkChars - headingCount - 1)
+                let prefix = String(remainder.prefix(available))
+                body = [prefix]
+                flush()
+                remainder = String(remainder.dropFirst(prefix.count))
+            }
+            if !remainder.isEmpty { body.append(remainder) }
+        }
+        flush()
+        return result
+    }
+
+    private static func splitTranscript(
+        _ lines: [(text: String, startMs: Int, endMs: Int)]
+    ) -> [(text: String, startMs: Int, endMs: Int)] {
+        var result: [(String, Int, Int)] = []
+        var current: [String] = []
+        var startMs: Int?
+        var endMs: Int?
+
+        func flush() {
+            guard let start = startMs, let end = endMs, !current.isEmpty else { return }
+            result.append((current.joined(separator: "\n"), start, end))
+            current.removeAll(keepingCapacity: true)
+            startMs = nil
+            endMs = nil
+        }
+
+        for line in lines {
+            let candidate = (current + [line.text]).joined(separator: "\n")
+            if candidate.count > maxChunkChars, !current.isEmpty { flush() }
+
+            if line.text.count <= maxChunkChars {
+                if startMs == nil { startMs = line.startMs }
+                endMs = line.endMs
+                current.append(line.text)
+            } else {
+                var remainder = line.text
+                while !remainder.isEmpty {
+                    let prefix = String(remainder.prefix(maxChunkChars))
+                    result.append((prefix, line.startMs, line.endMs))
+                    remainder = String(remainder.dropFirst(prefix.count))
+                }
+            }
+        }
+        flush()
+        return result
+    }
+
+    // MARK: Ranking
+
+    private static func semanticMeetingCandidates(
+        _ meetings: [AskMeetingSnapshot],
+        question: String,
+        queryTerms: Set<String>,
+        embedding: NLEmbedding
+    ) -> [AskMeetingSnapshot] {
+        meetings.map { meeting in
+            let summary = semanticSummary(for: meeting)
+            let exactHits = queryTerms.intersection(words(in: summary)).count
+            let distance = embedding.distance(between: question, and: summary)
+            return (meeting: meeting, score: distance - Double(exactHits) * 0.08)
+        }
+        .sorted { lhs, rhs in
+            if lhs.score != rhs.score { return lhs.score < rhs.score }
+            return lhs.meeting.createdAt > rhs.meeting.createdAt
+        }
+        .prefix(maxSemanticMeetings)
+        .map(\.meeting)
+    }
+
+    private static func semanticSummary(for meeting: AskMeetingSnapshot) -> String {
+        var parts = [meeting.title]
+        if !meeting.generatedNotes.isEmpty {
+            parts.append(String(meeting.generatedNotes.prefix(550)))
+        }
+        if !meeting.roughNotes.isEmpty {
+            parts.append(String(meeting.roughNotes.prefix(200)))
+        }
+        if parts.joined(separator: "\n").count < maxChunkChars {
+            parts.append(meeting.segments.prefix(4).map(\.text).joined(separator: " "))
+        }
+        return String(parts.joined(separator: "\n").prefix(maxChunkChars))
+    }
+
+    private static func score(
+        _ chunk: AskEvidenceChunk,
+        intent: QueryIntent,
+        retrievalTerms: Set<String>,
+        namedMeetingIDs: Set<UUID>,
+        embedding: NLEmbedding?,
+        now: Date
+    ) -> ScoredChunk {
+        let titleTerms = words(in: chunk.meetingTitle)
+        let chunkTerms = words(in: chunk.text)
+        let contentHits = retrievalTerms.intersection(chunkTerms).count
+        let focusHits = retrievalTerms
+            .subtracting(titleTerms)
+            .intersection(chunkTerms)
+            .count
+        let identityContentHits = intent.identityTerms.intersection(chunkTerms).count
+        let titleHits = intent.identityTerms.intersection(titleTerms).count
+        // Once a title identifies the meeting, words not present in that title
+        // carry the user's actual information need (for example "Wi-Fi" or
+        // "Cody"). Give those exact source hits priority over repeated title
+        // text inside a generated summary.
+        var value = Double(contentHits * 4 + focusHits * 20 + titleHits * 36)
+
+        if namedMeetingIDs.contains(chunk.meetingID) { value += 30 }
+
+        let actionHits = actionExpansion.intersection(chunkTerms).count
+        let decisionHits = decisionWords.intersection(chunkTerms).count
+        let hasActionHeading = normalized(chunk.text).contains("action item")
+            || normalized(chunk.text).contains("next step")
+            || normalized(chunk.text).contains("follow up")
+        let hasDecisionHeading = normalized(chunk.text).contains("decision")
+
+        if intent.isActionQuestion {
+            value += Double(actionHits * 5)
+            if hasActionHeading { value += 28 }
+        }
+        if intent.isDecisionQuestion {
+            value += Double(decisionHits * 6)
+            if hasDecisionHeading { value += 24 }
+        }
+
+        switch chunk.source {
+        case .generatedNotes: value += 3
+        case .roughNotes: value += 2
+        case .transcript: value += 1
+        }
+
+        if let embedding {
+            let distance = embedding.distance(
+                between: intent.normalizedQuestion,
+                and: String(chunk.text.prefix(maxChunkChars))
+            )
+            value += max(0, 1.35 - distance) * 12
+        }
+
+        let ageDays = max(0, now.timeIntervalSince(chunk.meetingDate) / 86_400)
+        value += max(0, 1 - ageDays / 365)
+
+        let topicMatches = intent.identityTerms.isEmpty || identityContentHits > 0 || titleHits > 0
+        return ScoredChunk(
+            chunk: chunk,
+            score: value,
+            hasIntentEvidence: intent.isActionQuestion
+                ? (actionHits > 0 || hasActionHeading) && topicMatches
+                : intent.isDecisionQuestion
+                    ? (decisionHits > 0 || hasDecisionHeading) && topicMatches
+                    : contentHits > 0 || titleHits > 0
+        )
+    }
+
+    private static func selectTargeted(
+        _ scored: [ScoredChunk],
+        meetings: [AskMeetingSnapshot],
+        seedEveryMeeting: Bool
+    ) -> [AskEvidenceChunk] {
+        let sorted = scored.sorted(by: scoredBefore)
+        var selected: [AskEvidenceChunk] = []
+        var counts: [UUID: Int] = [:]
+
+        // Seed every explicitly named meeting. For a topic question without a
+        // named meeting, seed only the three strongest meetings; seeding the
+        // whole corpus would recreate the old newest-first context crowding.
+        let seedIDs: [UUID]
+        if seedEveryMeeting {
+            seedIDs = meetings.map(\.id)
+        } else {
+            seedIDs = sorted.reduce(into: [UUID]()) { ids, candidate in
+                if ids.count < 3, !ids.contains(candidate.chunk.meetingID) {
+                    ids.append(candidate.chunk.meetingID)
+                }
+            }
+        }
+        for id in seedIDs {
+            guard let best = sorted.first(where: { $0.chunk.meetingID == id }) else { continue }
+            selected.append(best.chunk)
+            counts[id, default: 0] += 1
+        }
+
+        let perMeetingLimit = seedEveryMeeting ? maxTargetedChunksPerMeeting : 3
+        for candidate in sorted {
+            guard selected.count < maxTargetedChunks else { break }
+            guard counts[candidate.chunk.meetingID, default: 0] < perMeetingLimit else {
+                continue
+            }
+            guard !selected.contains(candidate.chunk) else { continue }
+            selected.append(candidate.chunk)
+            counts[candidate.chunk.meetingID, default: 0] += 1
+        }
+        return selected
+    }
+
+    private static func selectExhaustive(
+        _ scored: [ScoredChunk],
+        meetings: [AskMeetingSnapshot],
+        intent: QueryIntent
+    ) -> [AskEvidenceChunk] {
+        var selected: [AskEvidenceChunk] = []
+        for meeting in meetings {
+            let meetingChunks = scored
+                .filter { $0.chunk.meetingID == meeting.id }
+                .sorted(by: scoredBefore)
+            let intentMatches = meetingChunks.filter(\.hasIntentEvidence)
+            let candidates = intentMatches.isEmpty ? meetingChunks : intentMatches
+            let limit = (intent.isActionQuestion || intent.isDecisionQuestion)
+                ? maxExhaustiveChunksPerMeeting
+                : 1
+            selected += candidates.prefix(limit).map(\.chunk)
+        }
+        return selected
+    }
+
+    private static func scoredBefore(_ lhs: ScoredChunk, _ rhs: ScoredChunk) -> Bool {
+        if lhs.score != rhs.score { return lhs.score > rhs.score }
+        if lhs.chunk.meetingDate != rhs.chunk.meetingDate {
+            return lhs.chunk.meetingDate > rhs.chunk.meetingDate
+        }
+        return lhs.chunk.source.rawValue < rhs.chunk.source.rawValue
+    }
+
+    private static func namedMeetingIDs(
+        in meetings: [AskMeetingSnapshot],
+        identityTerms: Set<String>
+    ) -> Set<UUID> {
+        guard !identityTerms.isEmpty else { return [] }
+        let threshold = identityTerms.count == 1 ? 1 : 2
+        let titleMatches = meetings.compactMap { meeting -> UUID? in
+            let hits = identityTerms.intersection(words(in: meeting.title)).count
+            return hits >= threshold ? meeting.id : nil
+        }
+        if !titleMatches.isEmpty { return Set(titleMatches) }
+
+        // A customer or project name may only appear inside notes or the
+        // transcript. Fall back to the complete local meeting corpus before
+        // deciding the question is broad.
+        let contentMatches = meetings.compactMap { meeting -> UUID? in
+            var meetingTerms = words(in: meeting.generatedNotes)
+            meetingTerms.formUnion(words(in: meeting.roughNotes))
+            for segment in meeting.segments {
+                meetingTerms.formUnion(words(in: segment.text))
+            }
+            let hits = identityTerms.intersection(meetingTerms).count
+            return hits >= threshold ? meeting.id : nil
+        }
+        return Set(contentMatches)
+    }
+
+    // MARK: Query parsing and packing
+
+    private static func queryIntent(_ question: String) -> QueryIntent {
+        let normalizedQuestion = normalized(question)
+        let terms = words(in: question)
+        let action = !terms.intersection(actionWords).isEmpty
+            || normalizedQuestion.contains("to do")
+            || normalizedQuestion.contains("follow up")
+        let decision = !terms.intersection(decisionWords).isEmpty
+        let requestsAll = terms.contains("all")
+            || terms.contains("every")
+            || terms.contains("each")
+            || normalizedQuestion.contains("across my meetings")
+            || normalizedQuestion.contains("this week")
+            || normalizedQuestion.contains("last week")
+        let latestMeetingOnly = normalizedQuestion.contains("last meeting")
+            || normalizedQuestion.contains("latest meeting")
+            || normalizedQuestion.contains("most recent meeting")
+        return QueryIntent(
+            normalizedQuestion: normalizedQuestion,
+            queryTerms: terms,
+            identityTerms: terms
+                .subtracting(stopWords)
+                .subtracting(actionWords)
+                .subtracting(decisionWords),
+            isActionQuestion: action,
+            isDecisionQuestion: decision,
+            requestsAll: requestsAll,
+            latestMeetingOnly: latestMeetingOnly
+        )
+    }
+
+    private static func dateScope(
+        for question: String,
+        now: Date,
+        calendar: Calendar
+    ) -> DateScope? {
+        let query = normalized(question)
+        if query.contains("today") {
+            let start = calendar.startOfDay(for: now)
+            guard let end = calendar.date(byAdding: .day, value: 1, to: start) else { return nil }
+            return DateScope(range: start..<end, description: "today")
+        }
+        if query.contains("yesterday") {
+            let end = calendar.startOfDay(for: now)
+            guard let start = calendar.date(byAdding: .day, value: -1, to: end) else { return nil }
+            return DateScope(range: start..<end, description: "yesterday")
+        }
+        if query.contains("this week") {
+            guard let interval = calendar.dateInterval(of: .weekOfYear, for: now) else { return nil }
+            return DateScope(range: interval.start..<interval.end, description: "this week")
+        }
+        if query.contains("last week") {
+            guard
+                let thisWeek = calendar.dateInterval(of: .weekOfYear, for: now),
+                let start = calendar.date(byAdding: .weekOfYear, value: -1, to: thisWeek.start)
+            else { return nil }
+            return DateScope(range: start..<thisWeek.start, description: "last week")
+        }
+        return nil
+    }
+
+    private static func pack(
+        _ chunks: [AskEvidenceChunk],
+        labels: [UUID: String],
+        maxBatchChars: Int
+    ) -> [[AskEvidenceChunk]] {
+        guard !chunks.isEmpty else { return [] }
+        var batches: [[AskEvidenceChunk]] = []
+        var current: [AskEvidenceChunk] = []
+        var used = 0
+
+        for chunk in chunks {
+            let sectionChars = renderedLength(chunk, label: labels[chunk.meetingID] ?? "M?")
+            if used + sectionChars > maxBatchChars, !current.isEmpty {
+                batches.append(current)
+                current = []
+                used = 0
+            }
+            current.append(chunk)
+            used += sectionChars
+        }
+        if !current.isEmpty { batches.append(current) }
+        return batches
+    }
+
+    private static func renderedLength(_ chunk: AskEvidenceChunk, label: String) -> Int {
+        chunk.text.count + chunk.meetingTitle.count + chunk.source.rawValue.count + label.count + 100
+    }
+
+    private static func meaningfulTerms(in text: String) -> Set<String> {
+        words(in: text).subtracting(stopWords)
+    }
+
+    private static func words(in text: String) -> Set<String> {
+        let value = normalized(text)
+        var result = Set(value
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { $0.count >= 2 })
+        // Treat common hyphen variants as equivalent: "Wi-Fi" should match
+        // "wifi", and "follow-up" should match "followup".
+        for token in value.components(separatedBy: .whitespacesAndNewlines)
+            where token.contains("-")
+        {
+            let collapsed = token
+                .components(separatedBy: CharacterSet.alphanumerics.inverted)
+                .joined()
+            if collapsed.count >= 2 { result.insert(collapsed) }
+        }
+        return result
+    }
+
+    private static func normalized(_ text: String) -> String {
+        text.folding(
+            options: [.caseInsensitive, .diacriticInsensitive],
+            locale: Locale(identifier: "en_US_POSIX")
+        )
+    }
+}

--- a/apps/ios/DoodleNote/AI/NotesEngine.swift
+++ b/apps/ios/DoodleNote/AI/NotesEngine.swift
@@ -27,6 +27,7 @@ enum NotesError: LocalizedError {
     case onDeviceUnavailable(String)
     case onDeviceUnsupportedLocale
     case onDeviceUnsupportedLanguage
+    case onDeviceContextTooLarge
     case missingAPIKey
     case apiFailure(String)
     case emptyResponse
@@ -39,6 +40,8 @@ enum NotesError: LocalizedError {
             "Apple's on-device model doesn't support this iPhone's current language and region. Match the iPhone and Apple Intelligence languages, or choose Anthropic in Settings."
         case .onDeviceUnsupportedLanguage:
             "Apple's on-device model couldn't process the language in these notes. Try asking about one meeting, or choose Anthropic in Settings."
+        case .onDeviceContextTooLarge:
+            "That question needs more meeting context than Apple's on-device model can process at once. Narrow the question or choose Anthropic in Settings."
         case .missingAPIKey:
             "Add your Anthropic API key in Settings to generate notes with a cloud model."
         case .apiFailure(let detail):
@@ -52,7 +55,13 @@ enum NotesError: LocalizedError {
 protocol NotesEngine {
     func generate(_ input: NotesInput) async throws -> String
     /// One-shot completion — shared by note generation and "ask anything".
-    func respond(system: String, user: String) async throws -> String
+    func respond(system: String, user: String, maxResponseTokens: Int?) async throws -> String
+}
+
+extension NotesEngine {
+    func respond(system: String, user: String) async throws -> String {
+        try await respond(system: system, user: user, maxResponseTokens: nil)
+    }
 }
 
 enum NotesEngineFactory {
@@ -96,7 +105,7 @@ struct FoundationModelsEngine: NotesEngine {
         )
     }
 
-    func respond(system: String, user: String) async throws -> String {
+    func respond(system: String, user: String, maxResponseTokens: Int?) async throws -> String {
         let model = SystemLanguageModel.default
         switch model.availability {
         case .available:
@@ -108,12 +117,27 @@ struct FoundationModelsEngine: NotesEngine {
             throw NotesError.onDeviceUnsupportedLocale
         }
 
+        if #available(iOS 26.4, *), let maxResponseTokens {
+            let instructionTokens = try? await model.tokenCount(for: Instructions(system))
+            let promptTokens = try? await model.tokenCount(for: Prompt(user))
+            if let instructionTokens, let promptTokens,
+               instructionTokens + promptTokens + maxResponseTokens > model.contextSize
+            {
+                throw NotesError.onDeviceContextTooLarge
+            }
+        }
+
         let session = LanguageModelSession(instructions: system)
         let response: LanguageModelSession.Response<String>
         do {
-            response = try await session.respond(to: user)
+            response = try await session.respond(
+                to: user,
+                options: GenerationOptions(maximumResponseTokens: maxResponseTokens)
+            )
         } catch LanguageModelSession.GenerationError.unsupportedLanguageOrLocale {
             throw NotesError.onDeviceUnsupportedLanguage
+        } catch LanguageModelSession.GenerationError.exceededContextWindowSize {
+            throw NotesError.onDeviceContextTooLarge
         }
         let text = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { throw NotesError.emptyResponse }
@@ -154,7 +178,7 @@ struct AnthropicEngine: NotesEngine {
         )
     }
 
-    func respond(system: String, user: String) async throws -> String {
+    func respond(system: String, user: String, maxResponseTokens: Int?) async throws -> String {
         guard let apiKey = Keychain.read(key: .anthropicAPIKey), !apiKey.isEmpty else {
             throw NotesError.missingAPIKey
         }
@@ -171,7 +195,7 @@ struct AnthropicEngine: NotesEngine {
 
         let body: [String: Any] = [
             "model": model,
-            "max_tokens": 4096,
+            "max_tokens": maxResponseTokens ?? 4096,
             "system": system,
             "messages": [["role": "user", "content": user]],
         ]

--- a/apps/ios/DoodleNote/AI/NotesEngine.swift
+++ b/apps/ios/DoodleNote/AI/NotesEngine.swift
@@ -25,6 +25,8 @@ enum NotesEngineChoice: String, CaseIterable, Identifiable {
 
 enum NotesError: LocalizedError {
     case onDeviceUnavailable(String)
+    case onDeviceUnsupportedLocale
+    case onDeviceUnsupportedLanguage
     case missingAPIKey
     case apiFailure(String)
     case emptyResponse
@@ -33,6 +35,10 @@ enum NotesError: LocalizedError {
         switch self {
         case .onDeviceUnavailable(let reason):
             "The on-device model isn't available: \(reason) You can add an Anthropic API key in Settings instead."
+        case .onDeviceUnsupportedLocale:
+            "Apple's on-device model doesn't support this iPhone's current language and region. Match the iPhone and Apple Intelligence languages, or choose Anthropic in Settings."
+        case .onDeviceUnsupportedLanguage:
+            "Apple's on-device model couldn't process the language in these notes. Try asking about one meeting, or choose Anthropic in Settings."
         case .missingAPIKey:
             "Add your Anthropic API key in Settings to generate notes with a cloud model."
         case .apiFailure(let detail):
@@ -98,9 +104,17 @@ struct FoundationModelsEngine: NotesEngine {
         case .unavailable(let reason):
             throw NotesError.onDeviceUnavailable(describe(reason))
         }
+        guard model.supportsLocale() else {
+            throw NotesError.onDeviceUnsupportedLocale
+        }
 
         let session = LanguageModelSession(instructions: system)
-        let response = try await session.respond(to: user)
+        let response: LanguageModelSession.Response<String>
+        do {
+            response = try await session.respond(to: user)
+        } catch LanguageModelSession.GenerationError.unsupportedLanguageOrLocale {
+            throw NotesError.onDeviceUnsupportedLanguage
+        }
         let text = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { throw NotesError.emptyResponse }
         return text

--- a/apps/ios/DoodleNote/Views/ChatView.swift
+++ b/apps/ios/DoodleNote/Views/ChatView.swift
@@ -166,8 +166,9 @@ struct ChatView: View {
             case .meeting(let meeting):
                 answer = try await AskEngine.ask(meeting: meeting, question: question, history: history)
             case .global:
-                var descriptor = FetchDescriptor<Meeting>(sortBy: [SortDescriptor(\.createdAt, order: .reverse)])
-                descriptor.fetchLimit = 25
+                let descriptor = FetchDescriptor<Meeting>(
+                    sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+                )
                 let meetings = (try? context.fetch(descriptor)) ?? []
                 answer = try await AskEngine.askGlobal(meetings: meetings, question: question, history: history)
             }

--- a/apps/ios/DoodleNoteTests/AskEngineTests.swift
+++ b/apps/ios/DoodleNoteTests/AskEngineTests.swift
@@ -2,65 +2,292 @@ import XCTest
 @testable import DoodleNote
 
 final class AskEngineTests: XCTestCase {
-    @MainActor
     func testNamedMeetingWinsOverNewerUnrelatedMeetings() {
         let target = meeting(
             title: "Jordan Conley IT Consultation | Celebration Community Church",
-            notes: "Sean will prepare the managed services proposal.",
-            age: 5
+            generated: "Sean will prepare the managed services proposal.",
+            daysAgo: 5
         )
         let newest = meeting(
             title: "Turnkey Estimator Prototype Demo",
-            notes: "Roofing estimator API follow-up.",
-            age: 1
+            generated: "Roofing estimator API follow-up.",
+            daysAgo: 1
         )
 
-        let result = AskEngine.prioritizedGlobalMeetings(
+        let result = retrieve(
             [newest, target],
             question: "What are my to dos from the meeting with celebration church?"
         )
 
-        XCTAssertEqual(result.map(\.id), [target.id])
+        XCTAssertEqual(result.selectedMeetingIDs, [target.id])
+        XCTAssertTrue(result.allChunks.contains { $0.text.contains("managed services proposal") })
     }
 
-    @MainActor
-    func testNotesMatchFindsRelevantMeetingWhenTitleDoesNotMatch() {
+    func testRoughNotesRemainSearchableWhenGeneratedNotesExist() {
+        let target = meeting(
+            title: "Celebration Community Church",
+            generated: "Managed services proposal and security review.",
+            rough: "Replace the wifi access points before the office move.",
+            daysAgo: 2
+        )
+
+        let result = retrieve(
+            [target],
+            question: "What did Celebration Church say about Wi-Fi?"
+        )
+
+        XCTAssertTrue(result.allChunks.contains {
+            $0.source == .roughNotes && $0.text.contains("wifi")
+        })
+    }
+
+    func testGeneratedNotesCanFindMeetingWhenTitleDoesNotMatch() {
         let target = meeting(
             title: "Weekly customer call",
-            notes: "Follow up with Celebration Community Church about the proposal.",
-            age: 3
+            generated: "Follow up with Celebration Community Church about the proposal.",
+            daysAgo: 3
         )
         let unrelated = meeting(
             title: "Internal planning",
-            notes: "Review next quarter's hiring plan.",
-            age: 1
+            generated: "Review next quarter's hiring plan.",
+            daysAgo: 1
         )
 
-        let result = AskEngine.prioritizedGlobalMeetings(
+        let result = retrieve(
             [unrelated, target],
             question: "What did we promise Celebration Church?"
         )
 
-        XCTAssertEqual(result.map(\.id), [target.id])
+        XCTAssertEqual(result.selectedMeetingIDs.first, target.id)
+        XCTAssertTrue(result.allChunks.contains {
+            $0.meetingID == target.id && $0.text.contains("Celebration Community Church")
+        })
     }
 
-    @MainActor
-    func testGenericQuestionKeepsRecentMeetingOrder() {
-        let newest = meeting(title: "Newest", notes: "Alpha", age: 1)
-        let older = meeting(title: "Older", notes: "Beta", age: 2)
-
-        let result = AskEngine.prioritizedGlobalMeetings(
-            [older, newest],
-            question: "What are my open action items?"
+    func testFullTranscriptRemainsSearchableWhenGeneratedNotesExist() {
+        let target = meeting(
+            title: "XChange Security 2026 Prep Call",
+            generated: "Reviewed the presentation and event schedule.",
+            segments: [
+                .init(
+                    speaker: "Speaker",
+                    text: "Cody will present the threat landscape slides on Friday.",
+                    startMs: 15_040,
+                    endMs: 19_000
+                ),
+            ],
+            daysAgo: 4
         )
 
-        XCTAssertEqual(result.map(\.id), [newest.id, older.id])
+        let result = retrieve(
+            [target],
+            question: "What did Cody say in the XChange Security prep call?"
+        )
+
+        XCTAssertTrue(result.allChunks.contains {
+            $0.source == .transcript && $0.text.contains("Cody")
+        })
     }
 
-    @MainActor
-    private func meeting(title: String, notes: String, age: TimeInterval) -> Meeting {
-        let meeting = Meeting(title: title, createdAt: Date(timeIntervalSinceNow: -age))
-        meeting.generatedNotes = notes
-        return meeting
+    func testExhaustiveActionQuestionKeepsEveryMatchingMeetingAcrossBatches() {
+        let meetings = (1...4).map { index in
+            meeting(
+                title: "Customer \(index)",
+                generated: """
+                ## Action Items
+                - Owner \(index) will send the proposal and schedule the follow-up review.
+                \(String(repeating: "Supporting action-item detail. ", count: 14))
+                """,
+                daysAgo: index
+            )
+        }
+
+        let result = retrieve(
+            meetings,
+            question: "What are all my open action items?",
+            maxBatchChars: 1_000
+        )
+
+        XCTAssertTrue(result.isExhaustive)
+        XCTAssertGreaterThan(result.batches.count, 1)
+        XCTAssertEqual(Set(result.selectedMeetingIDs), Set(meetings.map(\.id)))
+        XCTAssertEqual(Set(result.allChunks.map(\.meetingID)), Set(meetings.map(\.id)))
+    }
+
+    func testThisWeekUsesMeetingDatesInsteadOfMatchingWeeklyInTitle() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = try XCTUnwrap(calendar.date(from: DateComponents(
+            year: 2026, month: 8, day: 5, hour: 12
+        )))
+        let thisWeek = meeting(
+            title: "Customer review",
+            generated: "## Action Items\n- Send the revised quote.",
+            createdAt: try XCTUnwrap(calendar.date(byAdding: .day, value: -1, to: now))
+        )
+        let olderWeekly = meeting(
+            title: "Weekly coaching",
+            generated: "## Action Items\n- Update the coaching plan.",
+            createdAt: try XCTUnwrap(calendar.date(byAdding: .day, value: -14, to: now))
+        )
+
+        let result = AskRetrieval.retrieve(
+            meetings: [olderWeekly, thisWeek],
+            question: "What were all my action items this week?",
+            maxBatchChars: 6_000,
+            now: now,
+            calendar: calendar,
+            useSemanticSearch: false
+        )
+
+        XCTAssertEqual(result.selectedMeetingIDs, [thisWeek.id])
+        XCTAssertFalse(result.allChunks.contains { $0.meetingID == olderWeekly.id })
+    }
+
+    func testFollowUpQuestionKeepsPriorMeetingScope() {
+        let target = meeting(
+            title: "Celebration Community Church",
+            generated: "The proposal deadline is Friday.",
+            daysAgo: 3
+        )
+        let recent = meeting(
+            title: "Internal planning",
+            generated: "The hiring review is due Monday.",
+            daysAgo: 1
+        )
+
+        let result = AskRetrieval.retrieve(
+            meetings: [recent, target],
+            question: "What was the deadline?",
+            history: ["Previous question: What did we promise Celebration Church?"],
+            maxBatchChars: 6_000,
+            useSemanticSearch: false
+        )
+
+        XCTAssertEqual(result.selectedMeetingIDs, [target.id])
+        XCTAssertTrue(result.allChunks.contains { $0.text.contains("Friday") })
+    }
+
+    func testMeetingOlderThanFormerTwentyFiveItemLimitCanBeRetrieved() {
+        let recent = (1...30).map { index in
+            meeting(title: "Recent \(index)", generated: "General planning notes.", daysAgo: index)
+        }
+        let olderTarget = meeting(
+            title: "Bluebird Clinic Migration",
+            generated: "Move the firewall during the Saturday maintenance window.",
+            daysAgo: 60
+        )
+
+        let result = retrieve(
+            recent + [olderTarget],
+            question: "What is the plan for the Bluebird Clinic migration?"
+        )
+
+        XCTAssertEqual(result.selectedMeetingIDs, [olderTarget.id])
+    }
+
+    func testLastMeetingActionQuestionDoesNotExpandAcrossCorpus() {
+        let newest = meeting(
+            title: "Newest customer call",
+            generated: "## Action Items\n- Send the revised agreement.",
+            daysAgo: 1
+        )
+        let older = meeting(
+            title: "Older customer call",
+            generated: "## Action Items\n- Schedule the migration.",
+            daysAgo: 4
+        )
+
+        let result = retrieve(
+            [older, newest],
+            question: "What are my action items from my last meeting?"
+        )
+
+        XCTAssertFalse(result.isExhaustive)
+        XCTAssertEqual(result.selectedMeetingIDs, [newest.id])
+        XCTAssertFalse(result.allChunks.contains { $0.meetingID == older.id })
+    }
+
+    func testRenderedEvidenceStaysWithinBatchBudget() {
+        let target = meeting(
+            title: "Long planning meeting",
+            generated: "## Action Items\n" + String(repeating: "- Complete a detailed task.\n", count: 200),
+            daysAgo: 1
+        )
+
+        let result = retrieve(
+            [target],
+            question: "What are all the action items?",
+            maxBatchChars: 1_500
+        )
+
+        XCTAssertFalse(result.batches.isEmpty)
+        for batch in result.batches {
+            XCTAssertLessThanOrEqual(result.render(batch).count, 1_650)
+            XCTAssertTrue(batch.allSatisfy { $0.text.count <= 900 })
+        }
+    }
+
+    func testAnswerIncludesDeterministicMeetingSources() {
+        let target = meeting(
+            title: "Celebration Community Church",
+            generated: "Sean will send the proposal.",
+            daysAgo: 2
+        )
+
+        let result = retrieve(
+            [target],
+            question: "What did we promise Celebration Church?"
+        )
+        let attributed = result.attributed("Send the proposal.")
+
+        XCTAssertTrue(attributed.contains("**Sources**"))
+        XCTAssertTrue(attributed.contains("[M1] Celebration Community Church"))
+    }
+
+    private func retrieve(
+        _ meetings: [AskMeetingSnapshot],
+        question: String,
+        maxBatchChars: Int = 6_000
+    ) -> AskRetrievalResult {
+        AskRetrieval.retrieve(
+            meetings: meetings,
+            question: question,
+            maxBatchChars: maxBatchChars,
+            useSemanticSearch: false
+        )
+    }
+
+    private func meeting(
+        title: String,
+        generated: String,
+        rough: String = "",
+        segments: [AskMeetingSnapshot.TranscriptSegment] = [],
+        daysAgo: Int
+    ) -> AskMeetingSnapshot {
+        meeting(
+            title: title,
+            generated: generated,
+            rough: rough,
+            segments: segments,
+            createdAt: Date(timeIntervalSinceNow: -Double(daysAgo) * 86_400)
+        )
+    }
+
+    private func meeting(
+        title: String,
+        generated: String,
+        rough: String = "",
+        segments: [AskMeetingSnapshot.TranscriptSegment] = [],
+        createdAt: Date
+    ) -> AskMeetingSnapshot {
+        AskMeetingSnapshot(
+            id: UUID(),
+            title: title,
+            createdAt: createdAt,
+            generatedNotes: generated,
+            roughNotes: rough,
+            segments: segments
+        )
     }
 }

--- a/apps/ios/DoodleNoteTests/AskEngineTests.swift
+++ b/apps/ios/DoodleNoteTests/AskEngineTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import DoodleNote
+
+final class AskEngineTests: XCTestCase {
+    @MainActor
+    func testNamedMeetingWinsOverNewerUnrelatedMeetings() {
+        let target = meeting(
+            title: "Jordan Conley IT Consultation | Celebration Community Church",
+            notes: "Sean will prepare the managed services proposal.",
+            age: 5
+        )
+        let newest = meeting(
+            title: "Turnkey Estimator Prototype Demo",
+            notes: "Roofing estimator API follow-up.",
+            age: 1
+        )
+
+        let result = AskEngine.prioritizedGlobalMeetings(
+            [newest, target],
+            question: "What are my to dos from the meeting with celebration church?"
+        )
+
+        XCTAssertEqual(result.map(\.id), [target.id])
+    }
+
+    @MainActor
+    func testNotesMatchFindsRelevantMeetingWhenTitleDoesNotMatch() {
+        let target = meeting(
+            title: "Weekly customer call",
+            notes: "Follow up with Celebration Community Church about the proposal.",
+            age: 3
+        )
+        let unrelated = meeting(
+            title: "Internal planning",
+            notes: "Review next quarter's hiring plan.",
+            age: 1
+        )
+
+        let result = AskEngine.prioritizedGlobalMeetings(
+            [unrelated, target],
+            question: "What did we promise Celebration Church?"
+        )
+
+        XCTAssertEqual(result.map(\.id), [target.id])
+    }
+
+    @MainActor
+    func testGenericQuestionKeepsRecentMeetingOrder() {
+        let newest = meeting(title: "Newest", notes: "Alpha", age: 1)
+        let older = meeting(title: "Older", notes: "Beta", age: 2)
+
+        let result = AskEngine.prioritizedGlobalMeetings(
+            [older, newest],
+            question: "What are my open action items?"
+        )
+
+        XCTAssertEqual(result.map(\.id), [newest.id, older.id])
+    }
+
+    @MainActor
+    private func meeting(title: String, notes: String, age: TimeInterval) -> Meeting {
+        let meeting = Meeting(title: title, createdAt: Date(timeIntervalSinceNow: -age))
+        meeting.generatedNotes = notes
+        return meeting
+    }
+}


### PR DESCRIPTION
## Bug

The iOS Home-level Ask anything sheet could return `An unsupported language or locale was used` for a normal English question. It also behaved more like a recent-note lookup than a grounded assistant over the user's meeting history.

## Root cause

- global Ask fetched only the newest 25 meetings and filled a small newest-first context window
- selecting generated notes hid useful rough-note and transcript details from the same meeting
- the named meeting could be omitted entirely when newer unrelated notes consumed the context
- broad action-item questions could silently omit older meetings
- Apple Foundation Models context/language errors surfaced without identifying the actual constraint

The original failure was reproduced with a read-only copy of the paired iPhone SwiftData store.

## Fix

- add local query-time retrieval over every meeting title, generated note, rough note, and complete transcript
- combine exact matching with Apple Natural Language semantic ranking while keeping expensive transcript ranking scoped and off the main actor
- preserve named-meeting and follow-up scope, and support today/yesterday/this week/last week/latest-meeting questions
- chunk and rank evidence, then process exhaustive action/decision requests in bounded batches so older meetings are not silently dropped
- label evidence by meeting/date/source and append a deterministic source list to every answer
- tighten grounding, attribution, action-item, and ready-to-send follow-up prompts
- preflight the Apple model's actual token count and context size; map locale/language/context failures to actionable messages
- remove the 25-meeting fetch limit
- add an iOS unit-test workflow generated from the committed XcodeGen spec

## Verification

- `xcodegen generate` succeeded
- 13 unit tests passed on an iPhone 17 Pro simulator running iOS 26.5
- 4 UI tests passed on the same simulator
- copied-device-store retrieval selected the intended Celebration Church, XChange Security/Cody, Wi-Fi, date, and follow-up evidence from generated notes, rough notes, and transcripts
- exhaustive action-item retrieval covered all 19 meetings in the copied store across bounded batches
- broad customer-concerns retrieval completed in about 0.22 seconds after the two-stage ranking guard (the original all-chunk semantic pass took about 52 seconds)
- Foundation Models smoke runs over the retrieved copied-store evidence completed without the locale error and stayed below the model context limit

## Risk / acceptance

- retrieval remains on-device; meeting evidence reaches a cloud service only when the user has explicitly selected the Anthropic BYOK engine
- exhaustive corpus questions intentionally use multiple bounded model calls and may take longer than a targeted question
- a physical-iPhone install and Sean's acceptance test remain the final device-level verification
