### PR TITLE
Complete Windows desktop parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,9 @@ jobs:
           if (!llama) throw new Error('CPU llama addon is missing')
           require(llama)
           console.log('Packaged sherpa and llama native modules loaded successfully')
+          // Match the app's native-addon shutdown workaround: after proving
+          // both addons loaded, do not run llama's fragile process teardown.
+          process.exit(0)
           '@ | Set-Content -Path $script -Encoding UTF8
           $env:ELECTRON_RUN_AS_NODE = "1"
           & (Join-Path $appDir "DoodleNote.exe") $script $appDir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,39 @@ jobs:
       - name: Build Windows installer
         run: pnpm --filter desktop package:win
 
+      - name: Smoke packaged Windows native modules
+        shell: pwsh
+        run: |
+          $appDir = (Resolve-Path "apps/desktop/release/win-unpacked").Path
+          $script = Join-Path $env:RUNNER_TEMP "doodlenote-native-smoke.cjs"
+          @'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const root = process.argv[2]
+          const unpacked = path.join(root, 'resources', 'app.asar.unpacked', 'node_modules')
+          const sherpa = require(path.join(unpacked, 'sherpa-onnx-node'))
+          if (typeof sherpa.OnlineRecognizer !== 'function') {
+            throw new Error('sherpa-onnx OnlineRecognizer did not load')
+          }
+          function find(rootDir, wanted) {
+            for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+              const file = path.join(rootDir, entry.name)
+              if (entry.isDirectory()) {
+                const found = find(file, wanted)
+                if (found) return found
+              } else if (entry.name === wanted) return file
+            }
+            return null
+          }
+          const llama = find(path.join(unpacked, '@node-llama-cpp', 'win-x64'), 'llama-addon.node')
+          if (!llama) throw new Error('CPU llama addon is missing')
+          require(llama)
+          console.log('Packaged sherpa and llama native modules loaded successfully')
+          '@ | Set-Content -Path $script -Encoding UTF8
+          $env:ELECTRON_RUN_AS_NODE = "1"
+          & (Join-Path $appDir "DoodleNote.exe") $script $appDir
+          if ($LASTEXITCODE -ne 0) { throw "Packaged native module smoke failed" }
+
       - name: Verify Windows artifacts and signature state
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,58 @@ jobs:
 
       - name: Notes engine tests
         run: pnpm --filter @repo/ai test
+
+  # A Linux typecheck cannot prove that Electron packaged the Windows native
+  # addons. Build the actual NSIS updater on every PR and retain it for native
+  # Windows smoke testing. CSC_LINK/CSC_KEY_PASSWORD sign it automatically
+  # once the repository's Authenticode certificate secrets are configured.
+  windows-package:
+    runs-on: windows-latest
+    env:
+      CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
+      CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install with Windows native dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Desktop typecheck
+        run: pnpm --filter desktop typecheck
+
+      - name: Desktop tests
+        run: pnpm --filter desktop test
+
+      - name: Build Windows installer
+        run: pnpm --filter desktop package:win
+
+      - name: Verify Windows artifacts and signature state
+        shell: pwsh
+        run: |
+          $manifest = "apps/desktop/release/latest.yml"
+          if (-not (Test-Path $manifest)) { throw "latest.yml was not generated" }
+          $installer = Get-ChildItem "apps/desktop/release/DoodleNote-*-setup.exe" | Select-Object -First 1
+          if (-not $installer) { throw "Windows installer was not generated" }
+          if (-not (Test-Path "$($installer.FullName).blockmap")) { throw "Updater blockmap was not generated" }
+          $signature = Get-AuthenticodeSignature $installer.FullName
+          if ($env:CSC_LINK -and $signature.Status -ne "Valid") {
+            throw "Signing credentials were supplied but the installer signature is $($signature.Status)"
+          }
+          Write-Host "Installer: $($installer.Name)"
+          Write-Host "Authenticode: $($signature.Status)"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: doodlenote-windows-${{ github.sha }}
+          path: |
+            apps/desktop/release/DoodleNote-*-setup.exe
+            apps/desktop/release/DoodleNote-*-setup.exe.blockmap
+            apps/desktop/release/latest.yml
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,11 @@ jobs:
           process.exit(0)
           '@ | Set-Content -Path $script -Encoding UTF8
           $env:ELECTRON_RUN_AS_NODE = "1"
-          & (Join-Path $appDir "DoodleNote.exe") $script $appDir
-          if ($LASTEXITCODE -ne 0) { throw "Packaged native module smoke failed" }
+          $output = & (Join-Path $appDir "DoodleNote.exe") $script $appDir 2>&1 | Out-String
+          Write-Host $output
+          if ($output -notmatch "Packaged sherpa and llama native modules loaded successfully") {
+            throw "Packaged native module smoke did not reach the success sentinel"
+          }
 
       - name: Verify Windows artifacts and signature state
         shell: pwsh

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,7 +18,7 @@
     "package": "pnpm --filter doodle-note-mcp build && electron-vite build && APPLE_KEYCHAIN_PROFILE=doodlenote-notary electron-builder --mac",
     "package:win": "pnpm --filter doodle-note-mcp build && electron-vite build && electron-builder --win --x64",
     "release": "pnpm package && node scripts/publish-release.mjs --mac",
-    "release:win": "pnpm package:win && node scripts/publish-release.mjs --win"
+    "release:win": "pnpm package:win && powershell -NoProfile -ExecutionPolicy Bypass -File scripts/verify-windows-signature.ps1 && node scripts/publish-release.mjs --win"
   },
   "dependencies": {
     "@azure/msal-node": "^5.3.1",

--- a/apps/desktop/scripts/verify-windows-signature.ps1
+++ b/apps/desktop/scripts/verify-windows-signature.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = "Stop"
+
+$releaseDir = Join-Path $PSScriptRoot "..\release"
+$installer = Get-ChildItem (Join-Path $releaseDir "DoodleNote-*-setup.exe") |
+  Sort-Object LastWriteTime -Descending |
+  Select-Object -First 1
+
+if (-not $installer) {
+  throw "No DoodleNote Windows installer found. Run pnpm package:win first."
+}
+
+$signature = Get-AuthenticodeSignature $installer.FullName
+if ($signature.Status -ne "Valid") {
+  throw "Refusing to publish unsigned Windows installer $($installer.Name): $($signature.Status)"
+}
+
+Write-Host "Authenticode valid: $($signature.SignerCertificate.Subject)"

--- a/apps/desktop/src/main/calendar-service.ts
+++ b/apps/desktop/src/main/calendar-service.ts
@@ -97,7 +97,7 @@ function landingPage(title: string, message: string): string {
     message +
     '</p>' +
     '<div style="margin-top:30px;font-size:12px;color:#b4b6a8">Local &amp; private &middot; ' +
-    'your calendar stays on your Mac</div>' +
+    'your calendar stays on your computer</div>' +
     '</div></body></html>'
   )
 }

--- a/apps/desktop/src/main/engine-host-win.ts
+++ b/apps/desktop/src/main/engine-host-win.ts
@@ -10,6 +10,7 @@ import {
 import type { EngineEventListener } from './engine-process'
 import { WinSessionRecorder } from './win-audio-recorder'
 import { join as joinPath } from 'node:path'
+import type { WizardPreflightEvent, WizardPreflightResult } from '../shared/wizard-api'
 
 const RESTART_DELAY_MS = 3_000
 
@@ -29,6 +30,12 @@ export class WinEngineHost {
   private restartTimer: NodeJS.Timeout | null = null
   private disposed = false
   private readonly listeners = new Set<EngineEventListener>()
+  private readonly warmupListeners = new Set<(event: WizardPreflightEvent) => void>()
+  private readonly warmupWaiters = new Set<(result: WizardPreflightResult) => void>()
+  private lastWarmupEvent: WizardPreflightEvent = { stage: 'models' }
+  private warmupResult: WizardPreflightResult | null = null
+  private inputDevice: string | undefined
+  private activeChannels: string[] = []
   /** Tees renderer PCM frames to disk when the session persists audio. */
   private recorder: WinSessionRecorder | null = null
 
@@ -85,7 +92,30 @@ export class WinEngineHost {
   private handleEngineEvent(event: Record<string, unknown>): void {
     if (event.event === 'status' && event.stage === 'serve_ready') {
       this.ready = true
+      this.finishWarmup({ ok: true, micGranted: false, screenGranted: false }, { stage: 'ready' })
       return
+    }
+    if (!this.ready && !this.sessionActive) {
+      if (event.event === 'download' && typeof event.progress === 'number') {
+        this.emitWarmup({ stage: 'download', progress: event.progress })
+      } else if (
+        event.event === 'status' &&
+        (event.stage === 'downloading_model' ||
+          event.stage === 'extracting_model' ||
+          event.stage === 'serve_loading_models')
+      ) {
+        this.emitWarmup(
+          event.stage === 'downloading_model'
+            ? { stage: 'download', progress: 0 }
+            : { stage: 'models' }
+        )
+      } else if (event.event === 'error') {
+        const message = String(event.message ?? 'Windows transcription engine failed to start')
+        this.finishWarmup(
+          { ok: false, micGranted: false, screenGranted: false, error: message },
+          { stage: 'error', message }
+        )
+      }
     }
     // Model download/boot progress is host-side noise, not session traffic.
     if (!this.sessionActive) return
@@ -147,10 +177,16 @@ export class WinEngineHost {
     ].filter((c): c is string => c !== null)
 
     this.sessionActive = true
+    this.activeChannels = channels
+    this.inputDevice = opts.inputDevice
     this.recorder = opts.audioDir ? new WinSessionRecorder(opts.audioDir) : null
     this.emit({ event: 'started', command, filePath, binaryPath: 'sherpa-onnx (in-process)' })
     this.child.postMessage({ t: 'start', channels })
-    this.broadcast(ENGINE_CAPTURE_CONTROL_CHANNEL, { action: 'start', channels })
+    this.broadcast(ENGINE_CAPTURE_CONTROL_CHANNEL, {
+      action: 'start',
+      channels,
+      ...(this.inputDevice ? { inputDevice: this.inputDevice } : {})
+    })
   }
 
   stop(): void {
@@ -179,6 +215,48 @@ export class WinEngineHost {
     this.stop()
   }
 
+  /** Windows renderer owns microphone capture, so device switches are sent there. */
+  setInputDevice(uid: string | null): void {
+    this.inputDevice = uid ?? undefined
+    if (!this.sessionActive || !this.activeChannels.includes('mic')) return
+    this.broadcast(ENGINE_CAPTURE_CONTROL_CHANNEL, {
+      action: 'switch-input',
+      ...(this.inputDevice ? { inputDevice: this.inputDevice } : {})
+    })
+  }
+
+  /** Wait for the Windows speech model and native recognizer to be ready. */
+  preflight(onEvent?: (event: WizardPreflightEvent) => void): Promise<WizardPreflightResult> {
+    if (onEvent) {
+      onEvent(this.lastWarmupEvent)
+      this.warmupListeners.add(onEvent)
+    }
+    if (this.warmupResult) {
+      if (onEvent) this.warmupListeners.delete(onEvent)
+      return Promise.resolve(this.warmupResult)
+    }
+    return new Promise((resolve) => {
+      const finish = (result: WizardPreflightResult): void => {
+        if (onEvent) this.warmupListeners.delete(onEvent)
+        resolve(result)
+      }
+      this.warmupWaiters.add(finish)
+    })
+  }
+
+  private emitWarmup(event: WizardPreflightEvent): void {
+    this.lastWarmupEvent = event
+    for (const listener of this.warmupListeners) listener(event)
+  }
+
+  private finishWarmup(result: WizardPreflightResult, event: WizardPreflightEvent): void {
+    if (this.warmupResult) return
+    this.warmupResult = result
+    this.emitWarmup(event)
+    for (const resolve of this.warmupWaiters) resolve(result)
+    this.warmupWaiters.clear()
+  }
+
   private stopCaptureInRenderer(): void {
     this.broadcast(ENGINE_CAPTURE_CONTROL_CHANNEL, { action: 'stop' })
   }
@@ -192,6 +270,8 @@ export class WinEngineHost {
     this.child?.kill()
     this.child = null
     this.listeners.clear()
+    this.warmupListeners.clear()
+    this.warmupWaiters.clear()
   }
 
   private emit(event: EngineEvent): void {

--- a/apps/desktop/src/main/engine-win.ts
+++ b/apps/desktop/src/main/engine-win.ts
@@ -29,6 +29,8 @@ interface AudioMessage {
   t: 'audio'
   channel: string
   samples: Float32Array
+  /** Batch imports use an acknowledgement for IPC backpressure. */
+  sequence?: number
 }
 
 type InMessage =
@@ -75,7 +77,12 @@ function download(url: string, dest: string, onPct: (pct: number) => void): Prom
     const follow = (target: string, redirects: number): void => {
       if (redirects > 5) return reject(new Error('Too many redirects'))
       httpsGet(target, (res) => {
-        if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        if (
+          res.statusCode &&
+          res.statusCode >= 300 &&
+          res.statusCode < 400 &&
+          res.headers.location
+        ) {
           res.resume()
           return follow(res.headers.location, redirects + 1)
         }
@@ -193,7 +200,10 @@ class ChannelPipeline {
     }
     const now = Date.now()
     const text = joinedText(result)
-    if ((force || now - this.lastPartialAt > PARTIAL_THROTTLE_MS) && text !== this.lastPartialText) {
+    if (
+      (force || now - this.lastPartialAt > PARTIAL_THROTTLE_MS) &&
+      text !== this.lastPartialText
+    ) {
       this.lastPartialAt = now
       this.lastPartialText = text
       emit({ event: 'partial', channel: this.channel, text })
@@ -283,6 +293,9 @@ port.on('message', (message: Electron.MessageEvent) => {
       const pipeline = pipelines.get(data.channel)
       if (pipeline && data.samples instanceof Float32Array && data.samples.length > 0) {
         pipeline.ingest(data.samples)
+      }
+      if (typeof data.sequence === 'number') {
+        port.postMessage({ t: 'ack', sequence: data.sequence })
       }
       break
     }

--- a/apps/desktop/src/main/import-service.ts
+++ b/apps/desktop/src/main/import-service.ts
@@ -13,7 +13,11 @@ import {
   type RetranscribeResult
 } from '../shared/import-api'
 import { AudioService, IMPORTABLE_EXTENSIONS } from './audio-service'
-import { transcribeFileToSegments, type BatchProgress } from './import-logic'
+import {
+  transcribeFileToSegments,
+  type BatchProgress,
+  type BatchTranscription
+} from './import-logic'
 
 /** Sanity ceiling — a 2GB "audio file" is a mistake, not a meeting. */
 const MAX_IMPORT_BYTES = 2 * 1024 * 1024 * 1024
@@ -33,7 +37,11 @@ export class ImportService {
     private readonly enginePath: string,
     private readonly meetings: MeetingFileStore,
     private readonly audio: AudioService,
-    private readonly broadcast: (channel: string, payload: unknown) => void
+    private readonly broadcast: (channel: string, payload: unknown) => void,
+    private readonly platformTranscriber?: (
+      filePath: string,
+      onProgress?: (progress: BatchProgress) => void
+    ) => Promise<BatchTranscription>
   ) {}
 
   registerIpc(): void {
@@ -62,7 +70,7 @@ export class ImportService {
 
   async importAudio(): Promise<ImportResult> {
     if (this.busy) return { error: 'Another import is still running — one at a time.' }
-    if (!existsSync(this.enginePath)) {
+    if (!this.platformTranscriber && !existsSync(this.enginePath)) {
       return { error: 'The transcription engine is not available on this platform yet.' }
     }
     const picked = await dialog.showOpenDialog(BrowserWindow.getAllWindows()[0]!, {
@@ -88,11 +96,7 @@ export class ImportService {
     const meetingId = randomUUID()
     try {
       this.progress({ kind: 'import', meetingId, stage: 'starting' })
-      const result = await transcribeFileToSegments(
-        this.enginePath,
-        filePath,
-        this.toBatchProgress('import', meetingId)
-      )
+      const result = await this.transcribe(filePath, this.toBatchProgress('import', meetingId))
       const kept = result.segments.filter((s) => !s.echo)
       if (kept.length === 0) {
         return { error: 'No speech was found in that file.' }
@@ -121,7 +125,7 @@ export class ImportService {
 
   async retranscribe(meetingId: string): Promise<RetranscribeResult> {
     if (this.busy) return { error: 'Another import is still running — one at a time.' }
-    if (!existsSync(this.enginePath)) {
+    if (!this.platformTranscriber && !existsSync(this.enginePath)) {
       return { error: 'The transcription engine is not available on this platform yet.' }
     }
     const record = this.meetings.get(meetingId)
@@ -137,8 +141,7 @@ export class ImportService {
       let echoSuppressed = 0
       for (const part of parts) {
         this.progress({ kind: 'retranscribe', meetingId, stage: 'starting' })
-        const result = await transcribeFileToSegments(
-          this.enginePath,
+        const result = await this.transcribe(
           part.path,
           this.toBatchProgress('retranscribe', meetingId)
         )
@@ -169,5 +172,14 @@ export class ImportService {
     } finally {
       this.busy = false
     }
+  }
+
+  private transcribe(
+    filePath: string,
+    onProgress: (progress: BatchProgress) => void
+  ): Promise<BatchTranscription> {
+    return this.platformTranscriber
+      ? this.platformTranscriber(filePath, onProgress)
+      : transcribeFileToSegments(this.enginePath, filePath, onProgress)
   }
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -21,6 +21,7 @@ import { CalendarService } from './calendar-service'
 import { registerContextMenu } from './context-menu'
 import { EngineProcess } from './engine-process'
 import { WinEngineHost } from './engine-host-win'
+import { WinBatchTranscriber } from './win-batch-transcriber'
 import { FoldersService } from './folders-service'
 import { initAutoUpdater, isQuittingForUpdate } from './updater'
 import { MediaService } from './media-service'
@@ -126,6 +127,7 @@ protocol.registerSchemesAsPrivileged([
 
 let notesService: NotesService | null = null
 let calendarService: CalendarService | null = null
+let winBatchTranscriber: WinBatchTranscriber | null = null
 
 function broadcast(channel: string, payload: unknown): void {
   for (const window of BrowserWindow.getAllWindows()) {
@@ -377,6 +379,8 @@ app.whenReady().then(() => {
   ipcMain.on(ENGINE_SET_INPUT_CHANNEL, (_event, uid: unknown) => {
     if (engine instanceof EngineProcess) {
       engine.setInputDevice(typeof uid === 'string' && uid.length > 0 ? uid : null)
+    } else if (engine instanceof WinEngineHost) {
+      engine.setInputDevice(typeof uid === 'string' && uid.length > 0 ? uid : null)
     }
   })
 
@@ -388,18 +392,30 @@ app.whenReady().then(() => {
   notesService = new NotesService(app.getPath('userData'), broadcast, meetingsService)
   notesService.registerIpc()
 
+  if (engine instanceof WinEngineHost) {
+    winBatchTranscriber = new WinBatchTranscriber((onEvent) => engine.preflight(onEvent))
+    winBatchTranscriber.registerIpc()
+  }
+
   // Audio import + re-transcription: batch engine runs in its own process,
   // so a live recording session is never disturbed.
   const importService = new ImportService(
     resolveEngineBinary(),
     meetingsService,
     audioService,
-    broadcast
+    broadcast,
+    winBatchTranscriber
+      ? (filePath, onProgress) => winBatchTranscriber!.transcribe(filePath, onProgress)
+      : undefined
   )
   importService.registerIpc()
 
   // First-run setup wizard: visible preflight + permission status.
-  const wizardService = new WizardService(resolveEngineBinary(), broadcast)
+  const wizardService = new WizardService(
+    resolveEngineBinary(),
+    broadcast,
+    engine instanceof WinEngineHost ? (onEvent) => engine.preflight(onEvent) : undefined
+  )
   wizardService.registerIpc()
 
   // Meeting export (Markdown / PDF).
@@ -539,6 +555,7 @@ app.on('will-quit', () => {
   engine.dispose()
   void notesService?.dispose()
   calendarService?.dispose()
+  winBatchTranscriber?.dispose()
 })
 
 app.on('window-all-closed', () => {

--- a/apps/desktop/src/main/release-packaging.test.ts
+++ b/apps/desktop/src/main/release-packaging.test.ts
@@ -78,6 +78,8 @@ test('Windows builds an x64 NSIS updater with the Windows icon and native engine
 test('CI builds and retains a real Windows installer', () => {
   assert.match(ciWorkflow, /windows-package:[\s\S]*runs-on:\s*windows-latest/)
   assert.match(ciWorkflow, /pnpm --filter desktop package:win/)
+  assert.match(ciWorkflow, /Smoke packaged Windows native modules/)
+  assert.match(ciWorkflow, /sherpa and llama native modules loaded successfully/)
   assert.match(ciWorkflow, /Get-AuthenticodeSignature/)
   assert.match(ciWorkflow, /actions\/upload-artifact@v4/)
   assert.match(desktopPackage, /release:win[\s\S]*verify-windows-signature\.ps1/)

--- a/apps/desktop/src/main/release-packaging.test.ts
+++ b/apps/desktop/src/main/release-packaging.test.ts
@@ -11,6 +11,12 @@ const brandScript = readFileSync(
   new URL('../../scripts/build-brand-assets.sh', import.meta.url),
   'utf8'
 )
+const ciWorkflow = readFileSync(
+  new URL('../../../../.github/workflows/ci.yml', import.meta.url),
+  'utf8'
+)
+const modelsView = readFileSync(new URL('../renderer/src/ModelsView.tsx', import.meta.url), 'utf8')
+const desktopPackage = readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
 
 function pngMetadata(url: URL): { width: number; height: number; colorType: number } {
   const png = readFileSync(url)
@@ -18,7 +24,7 @@ function pngMetadata(url: URL): { width: number; height: number; colorType: numb
   return {
     width: png.readUInt32BE(16),
     height: png.readUInt32BE(20),
-    colorType: png[25],
+    colorType: png[25]
   }
 }
 
@@ -37,10 +43,7 @@ test('desktop and in-app mascot artwork use the opaque sage master', () => {
     new URL('../../resources/icon.png', import.meta.url),
     new URL('../renderer/src/assets/mascot-square.png', import.meta.url),
     new URL('../../../web/public/mascot.png', import.meta.url),
-    new URL(
-      '../../../ios/DoodleNote/Assets.xcassets/Mascot.imageset/mascot.png',
-      import.meta.url
-    ),
+    new URL('../../../ios/DoodleNote/Assets.xcassets/Mascot.imageset/mascot.png', import.meta.url)
   ]
 
   assert.deepEqual(readFileSync(master), readFileSync(iPhoneIcon))
@@ -61,4 +64,32 @@ test('macOS builds a DMG for website installs while retaining the ZIP updater', 
   assert.match(builderConfig, /path:\s*\/Applications/)
   assert.match(publishScript, /name\.endsWith\('\.dmg'\)/)
   assert.match(publishScript, /flags\.includes\('--dmg-only'\)/)
+})
+
+test('Windows builds an x64 NSIS updater with the Windows icon and native engines', () => {
+  assert.match(builderConfig, /win:\s+[\s\S]*target:\s*nsis[\s\S]*arch:\s+- x64/)
+  assert.match(builderConfig, /win:\s+[\s\S]*icon:\s*resources\/icon\.ico/)
+  assert.match(builderConfig, /asarUnpack:[\s\S]*sherpa-onnx-win-x64/)
+  assert.match(builderConfig, /artifactName:\s*\$\{productName\}-\$\{version\}-setup\.\$\{ext\}/)
+  assert.match(publishScript, /name === 'latest\.yml'/)
+  assert.match(publishScript, /name\.endsWith\('\.exe\.blockmap'\)/)
+})
+
+test('CI builds and retains a real Windows installer', () => {
+  assert.match(ciWorkflow, /windows-package:[\s\S]*runs-on:\s*windows-latest/)
+  assert.match(ciWorkflow, /pnpm --filter desktop package:win/)
+  assert.match(ciWorkflow, /Get-AuthenticodeSignature/)
+  assert.match(ciWorkflow, /actions\/upload-artifact@v4/)
+  assert.match(desktopPackage, /release:win[\s\S]*verify-windows-signature\.ps1/)
+})
+
+test('macOS-only settings are gated out of the Windows UI', () => {
+  assert.match(
+    modelsView,
+    /detect\?\.platform === 'darwin'[\s\S]*Show upcoming meetings in menu bar/
+  )
+  assert.match(
+    modelsView,
+    /detect\?\.platform === 'darwin'[\s\S]*Capture without screen permission/
+  )
 })

--- a/apps/desktop/src/main/sync-service.ts
+++ b/apps/desktop/src/main/sync-service.ts
@@ -224,7 +224,7 @@ export class SyncService {
             const port = typeof address === 'object' && address ? address.port : 0
             const query = new URLSearchParams({
               port: String(port),
-              name: hostname().replace(/\.local$/, '') || 'Mac'
+              name: hostname().replace(/\.local$/, '') || 'Computer'
             })
             void shell.openExternal(`${this.baseUrl}/link-device?${query}`)
           })

--- a/apps/desktop/src/main/win-audio-utils.test.ts
+++ b/apps/desktop/src/main/win-audio-utils.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mapWindowsInputDevices } from '../shared/win-audio-utils'
+
+test('Windows microphone list marks the physical device behind the system default', () => {
+  const devices = mapWindowsInputDevices([
+    { kind: 'audioinput', deviceId: 'default', groupId: 'group-a', label: 'Default - Desk Mic' },
+    { kind: 'audioinput', deviceId: 'communications', groupId: 'group-b', label: 'Comms' },
+    { kind: 'audioinput', deviceId: 'desk', groupId: 'group-a', label: 'Desk Mic' },
+    { kind: 'audioinput', deviceId: 'webcam', groupId: 'group-b', label: 'Webcam Mic' },
+    { kind: 'audiooutput', deviceId: 'speakers', groupId: 'group-c', label: 'Speakers' }
+  ])
+
+  assert.deepEqual(devices, [
+    { uid: 'desk', name: 'Desk Mic', isDefault: true },
+    { uid: 'webcam', name: 'Webcam Mic', isDefault: false }
+  ])
+})
+
+test('Windows microphone list stays usable before permission reveals labels', () => {
+  const devices = mapWindowsInputDevices([
+    { kind: 'audioinput', deviceId: 'default', groupId: '', label: '' },
+    { kind: 'audioinput', deviceId: 'mic-1', groupId: '', label: '' },
+    { kind: 'audioinput', deviceId: 'mic-1', groupId: '', label: '' }
+  ])
+
+  assert.deepEqual(devices, [{ uid: 'mic-1', name: 'Microphone 1', isDefault: false }])
+})
+
+test('Windows microphone list falls back to the system default device', () => {
+  assert.deepEqual(
+    mapWindowsInputDevices([{ kind: 'audioinput', deviceId: 'default', groupId: '', label: '' }]),
+    [{ uid: 'default', name: 'System default microphone', isDefault: true }]
+  )
+})

--- a/apps/desktop/src/main/win-batch-transcriber.ts
+++ b/apps/desktop/src/main/win-batch-transcriber.ts
@@ -1,0 +1,267 @@
+import { randomUUID } from 'node:crypto'
+import { readFile, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { app, BrowserWindow, ipcMain, utilityProcess, type UtilityProcess } from 'electron'
+import {
+  ENGINE_BATCH_CONTROL_CHANNEL,
+  ENGINE_BATCH_DATA_CHANNEL,
+  ENGINE_BATCH_READ_CHANNEL,
+  type EngineBatchMessage,
+  type EngineChannel,
+  type EngineTokenTiming,
+  type TranscriptSegment
+} from '../shared/engine-events'
+import type { WizardPreflightEvent, WizardPreflightResult } from '../shared/wizard-api'
+import type { BatchProgress, BatchTranscription } from './import-logic'
+import { SegmentAssembler } from './segmenter'
+
+const TIMEOUT_MS = 30 * 60_000
+/** Chromium decodes the complete file in memory; this still covers hours of compressed audio. */
+const MAX_DECODE_BYTES = 512 * 1024 * 1024
+
+interface ActiveJob {
+  id: string
+  filePath: string
+  rendererId: number | null
+  child: UtilityProcess
+  assembler: SegmentAssembler
+  segments: TranscriptSegment[]
+  audioSeconds: number
+  started: boolean
+  settled: boolean
+  timeout: NodeJS.Timeout
+  nextSequence: number
+  pendingAck: {
+    sequence: number
+    resolve: () => void
+    reject: (error: Error) => void
+  } | null
+  onProgress?: (progress: BatchProgress) => void
+  resolve: (result: BatchTranscription) => void
+  reject: (error: Error) => void
+}
+
+/**
+ * Windows imported-audio transcription without an extra media binary.
+ * Chromium decodes WAV/MP3/M4A in the renderer, resamples it to 16 kHz, and
+ * streams PCM here. A dedicated sherpa utility process transcribes the file,
+ * so importing never interrupts the persistent live-meeting engine.
+ */
+export class WinBatchTranscriber {
+  private active: ActiveJob | null = null
+
+  constructor(
+    private readonly ensureEngineReady: (
+      onEvent?: (event: WizardPreflightEvent) => void
+    ) => Promise<WizardPreflightResult>
+  ) {}
+
+  registerIpc(): void {
+    ipcMain.handle(ENGINE_BATCH_READ_CHANNEL, (event, jobId: unknown) => {
+      const job = this.active
+      if (!job || job.id !== String(jobId) || job.rendererId !== event.sender.id) {
+        throw new Error('That audio import is no longer active.')
+      }
+      return readFile(job.filePath)
+    })
+    ipcMain.handle(ENGINE_BATCH_DATA_CHANNEL, (event, payload: unknown) => {
+      const job = this.active
+      const message = payload as EngineBatchMessage
+      if (!job || message?.jobId !== job.id || job.rendererId !== event.sender.id) {
+        throw new Error('That audio import is no longer active.')
+      }
+      return this.handleRendererMessage(job, message)
+    })
+  }
+
+  transcribe(
+    filePath: string,
+    onProgress?: (progress: BatchProgress) => void
+  ): Promise<BatchTranscription> {
+    if (this.active) return Promise.reject(new Error('Another Windows transcription is running.'))
+    return new Promise((resolve, reject) => {
+      void this.start(filePath, onProgress, resolve, reject)
+    })
+  }
+
+  private async start(
+    filePath: string,
+    onProgress: ((progress: BatchProgress) => void) | undefined,
+    resolve: (result: BatchTranscription) => void,
+    reject: (error: Error) => void
+  ): Promise<void> {
+    onProgress?.({ stage: 'starting' })
+    try {
+      if ((await stat(filePath)).size > MAX_DECODE_BYTES) {
+        reject(new Error('Windows can import recordings up to 512 MB.'))
+        return
+      }
+    } catch (error) {
+      reject(new Error(`Could not read that audio file: ${String(error)}`))
+      return
+    }
+    const readiness = await this.ensureEngineReady((event) => {
+      if (event.stage === 'download') {
+        onProgress?.({ stage: 'downloading_model', progress: event.progress })
+      }
+    })
+    if (!readiness.ok) {
+      reject(new Error(readiness.error ?? 'The Windows transcription engine is not ready.'))
+      return
+    }
+
+    let child: UtilityProcess
+    try {
+      child = utilityProcess.fork(join(__dirname, 'engine-win.js'), [], {
+        serviceName: 'doodlenote-import-engine'
+      })
+    } catch (error) {
+      reject(new Error(`Could not start the Windows import engine: ${String(error)}`))
+      return
+    }
+
+    const job: ActiveJob = {
+      id: randomUUID(),
+      filePath,
+      rendererId: null,
+      child,
+      assembler: new SegmentAssembler(),
+      segments: [],
+      audioSeconds: 0,
+      started: false,
+      settled: false,
+      timeout: setTimeout(() => {}, TIMEOUT_MS),
+      nextSequence: 0,
+      pendingAck: null,
+      onProgress,
+      resolve,
+      reject
+    }
+    clearTimeout(job.timeout)
+    job.timeout = setTimeout(
+      () => this.finish(job, new Error('Transcription timed out.')),
+      TIMEOUT_MS
+    )
+    job.timeout.unref()
+    this.active = job
+
+    child.on('message', (message: unknown) => {
+      if (this.active !== job) return
+      const data = message as { t?: string; sequence?: number; event?: Record<string, unknown> }
+      const pending = job.pendingAck
+      if (data.t === 'ack' && pending && data.sequence === pending.sequence) {
+        job.pendingAck = null
+        pending.resolve()
+        return
+      }
+      if (data.t === 'event' && data.event) this.handleEngineEvent(job, data.event)
+    })
+    child.on('exit', () => {
+      if (this.active === job && !job.settled) {
+        this.finish(job, new Error('The Windows import engine stopped unexpectedly.'))
+      }
+    })
+    child.postMessage({ t: 'init', modelsDir: join(app.getPath('userData'), 'asr-models') })
+  }
+
+  private handleEngineEvent(job: ActiveJob, event: Record<string, unknown>): void {
+    if (event.event === 'status' && event.stage === 'serve_ready') {
+      const window = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]
+      if (!window || window.isDestroyed()) {
+        this.finish(job, new Error('Open DoodleNote to import an audio file.'))
+        return
+      }
+      job.rendererId = window.webContents.id
+      window.webContents.send(ENGINE_BATCH_CONTROL_CHANNEL, { action: 'decode', jobId: job.id })
+      return
+    }
+    if (event.event === 'status' && event.stage === 'transcribing') {
+      job.onProgress?.({ stage: 'transcribing' })
+      return
+    }
+    if (
+      event.event === 'timings' &&
+      typeof event.channel === 'string' &&
+      Array.isArray(event.tokens)
+    ) {
+      job.segments.push(
+        ...job.assembler.addTimings(
+          event.channel as EngineChannel,
+          event.tokens as EngineTokenTiming[]
+        )
+      )
+      return
+    }
+    if (event.event === 'final' && typeof event.channel === 'string') {
+      job.segments.push(...job.assembler.flush(event.channel as EngineChannel))
+      return
+    }
+    if (event.event === 'error') {
+      this.finish(job, new Error(String(event.message ?? 'Windows transcription failed.')))
+      return
+    }
+    if (event.event === 'done') this.finish(job)
+  }
+
+  private async handleRendererMessage(job: ActiveJob, message: EngineBatchMessage): Promise<void> {
+    switch (message.type) {
+      case 'begin': {
+        const channels = message.channels.filter(
+          (channel): channel is EngineChannel => channel === 'mic' || channel === 'system'
+        )
+        if (channels.length === 0) {
+          this.finish(job, new Error('No decodable audio channels were found.'))
+          return
+        }
+        job.audioSeconds = Math.max(0, message.audioSeconds)
+        job.started = true
+        job.child.postMessage({ t: 'start', channels })
+        break
+      }
+      case 'audio':
+        if (job.started && message.samples instanceof Float32Array && message.samples.length > 0) {
+          if (job.pendingAck) throw new Error('The Windows import decoder sent audio too quickly.')
+          const sequence = job.nextSequence++
+          await new Promise<void>((resolve, reject) => {
+            job.pendingAck = { sequence, resolve, reject }
+            job.child.postMessage({
+              t: 'audio',
+              channel: message.channel,
+              samples: message.samples,
+              sequence
+            })
+          })
+        }
+        break
+      case 'end':
+        if (job.started) job.child.postMessage({ t: 'stop' })
+        break
+      case 'error':
+        this.finish(job, new Error(message.message))
+        break
+    }
+  }
+
+  private finish(job: ActiveJob, error?: Error): void {
+    if (job.settled) return
+    job.settled = true
+    clearTimeout(job.timeout)
+    job.pendingAck?.reject(error ?? new Error('The Windows import engine stopped.'))
+    job.pendingAck = null
+    job.child.kill()
+    if (this.active === job) this.active = null
+    if (error) {
+      job.reject(error)
+      return
+    }
+    job.segments.push(...job.assembler.flush())
+    job.segments.sort((a, b) => a.startMs - b.startMs)
+    job.resolve({ segments: job.segments, audioSeconds: job.audioSeconds })
+  }
+
+  dispose(): void {
+    const job = this.active
+    if (!job) return
+    this.finish(job, new Error('DoodleNote closed before the import completed.'))
+  }
+}

--- a/apps/desktop/src/main/wizard-service.ts
+++ b/apps/desktop/src/main/wizard-service.ts
@@ -20,7 +20,10 @@ import {
 export class WizardService {
   constructor(
     private readonly enginePath: string,
-    private readonly broadcast: (channel: string, payload: unknown) => void
+    private readonly broadcast: (channel: string, payload: unknown) => void,
+    private readonly platformPreflight?: (
+      onEvent: (event: WizardPreflightEvent) => void
+    ) => Promise<WizardPreflightResult>
   ) {}
 
   registerIpc(): void {
@@ -43,11 +46,12 @@ export class WizardService {
   }
 
   private runPreflight(): Promise<WizardPreflightResult> {
+    if (this.platformPreflight) return this.platformPreflight((event) => this.emit(event))
     return new Promise((resolve) => {
       if (!existsSync(this.enginePath)) {
-        // Windows: no Swift engine; model download happens on first record.
-        this.emit({ stage: 'ready' })
-        resolve({ ok: true, micGranted: false, screenGranted: false })
+        const error = 'The transcription engine is not available on this platform.'
+        this.emit({ stage: 'error', message: error })
+        resolve({ ok: false, micGranted: false, screenGranted: false, error })
         return
       }
       let child: ReturnType<typeof spawn>
@@ -86,7 +90,13 @@ export class WizardService {
           buffer = buffer.slice(newline + 1)
           newline = buffer.indexOf('\n')
           if (line.length === 0) continue
-          let ev: { event?: string; stage?: string; granted?: boolean; progress?: number; message?: string }
+          let ev: {
+            event?: string
+            stage?: string
+            granted?: boolean
+            progress?: number
+            message?: string
+          }
           try {
             ev = JSON.parse(line)
           } catch {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,9 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 import {
   ENGINE_AUDIO_CHANNEL,
+  ENGINE_BATCH_CONTROL_CHANNEL,
+  ENGINE_BATCH_DATA_CHANNEL,
+  ENGINE_BATCH_READ_CHANNEL,
   ENGINE_CAPTURE_CONTROL_CHANNEL,
   ENGINE_CAPTURE_ERROR_CHANNEL,
   ENGINE_EVENT_CHANNEL,
@@ -10,6 +13,8 @@ import {
   ENGINE_START_CHANNEL,
   ENGINE_STOP_CHANNEL,
   type EngineCaptureControl,
+  type EngineBatchControl,
+  type EngineBatchMessage,
   type EngineApi,
   type EngineCommand,
   type EngineEvent,
@@ -195,7 +200,10 @@ const engineApi: EngineApi = {
   },
 
   tapSelfTest(): Promise<{ ok: boolean; reason?: string }> {
-    return ipcRenderer.invoke(ENGINE_TAP_SELFTEST_CHANNEL) as Promise<{ ok: boolean; reason?: string }>
+    return ipcRenderer.invoke(ENGINE_TAP_SELFTEST_CHANNEL) as Promise<{
+      ok: boolean
+      reason?: string
+    }>
   },
 
   onEvent(cb: (event: EngineEvent) => void): () => void {
@@ -224,6 +232,25 @@ const engineApi: EngineApi = {
 
   reportCaptureError(message: string): void {
     ipcRenderer.send(ENGINE_CAPTURE_ERROR_CHANNEL, message)
+  },
+
+  onBatchControl(cb: (control: EngineBatchControl) => void): () => void {
+    const listener = (_event: IpcRendererEvent, control: EngineBatchControl): void => {
+      cb(control)
+    }
+    ipcRenderer.on(ENGINE_BATCH_CONTROL_CHANNEL, listener)
+    return () => {
+      ipcRenderer.removeListener(ENGINE_BATCH_CONTROL_CHANNEL, listener)
+    }
+  },
+
+  async readBatchAudio(jobId: string): Promise<ArrayBuffer> {
+    const bytes = (await ipcRenderer.invoke(ENGINE_BATCH_READ_CHANNEL, jobId)) as Uint8Array
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
+  },
+
+  sendBatchMessage(message: EngineBatchMessage): Promise<void> {
+    return ipcRenderer.invoke(ENGINE_BATCH_DATA_CHANNEL, message) as Promise<void>
   }
 }
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -14,7 +14,8 @@ import OnboardingTour from './OnboardingTour'
 import mascotUrl from './assets/mascot-square.png'
 import { isOnboardingDone, isSetupWizardDone, markSetupWizardDone } from './lib/onboarding'
 import FirstRunWizard from './FirstRunWizard'
-import { startWinCapture, stopWinCapture } from './lib/win-capture'
+import { startWinCapture, stopWinCapture, switchWinInputDevice } from './lib/win-capture'
+import { decodeWinBatchAudio } from './lib/win-batch-decode'
 import {
   CalendarIcon,
   FolderIcon,
@@ -116,10 +117,18 @@ function App(): React.JSX.Element {
   useEffect(() => {
     return window.engine.onCaptureControl((control) => {
       if (control.action === 'start') {
-        void startWinCapture(control.channels ?? ['mic', 'system'])
+        void startWinCapture(control.channels ?? ['mic', 'system'], control.inputDevice)
+      } else if (control.action === 'switch-input') {
+        void switchWinInputDevice(control.inputDevice)
       } else {
         stopWinCapture()
       }
+    })
+  }, [])
+
+  useEffect(() => {
+    return window.engine.onBatchControl((control) => {
+      if (control.action === 'decode') void decodeWinBatchAudio(control.jobId)
     })
   }, [])
 

--- a/apps/desktop/src/renderer/src/FirstRunWizard.tsx
+++ b/apps/desktop/src/renderer/src/FirstRunWizard.tsx
@@ -93,7 +93,6 @@ export default function FirstRunWizard({
       )
     })
     return unsubscribe
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on entering the step
   }, [step])
 
   /* ---- notes model step ---- */
@@ -168,9 +167,11 @@ export default function FirstRunWizard({
               Welcome to <span className="wz-ink">Doodle</span>
               <span className="wz-sage">Note</span>
             </h1>
-            <p className="wizard-sub">Meeting notes that write themselves — all on your Mac.</p>
+            <p className="wizard-sub">
+              Meeting notes that write themselves — right on your computer.
+            </p>
             <ul className="wizard-props">
-              <li>No bot joins your calls — DoodleNote listens right on your Mac</li>
+              <li>No bot joins your calls — DoodleNote listens right on your computer</li>
               <li>Transcription and AI notes run on-device. Nothing leaves your machine</li>
               <li>Works offline, no account needed</li>
             </ul>
@@ -189,14 +190,14 @@ export default function FirstRunWizard({
             <p className="wizard-sub">
               {isWindows ? (
                 <>
-                  The speech model downloads automatically in the background. Windows asks for
-                  microphone and screen-audio access when your first recording starts.
+                  DoodleNote is downloading and validating the Windows speech model now. Microphone
+                  and system-audio access are requested when your first recording starts.
                 </>
               ) : (
                 <>
                   macOS will ask for the <strong>microphone</strong> (your voice) and{' '}
-                  <strong>system audio</strong> (the other side of the call) — no screen
-                  recording, ever. Meanwhile the on-device transcription engine gets ready.
+                  <strong>system audio</strong> (the other side of the call) — no screen recording,
+                  ever. Meanwhile the on-device transcription engine gets ready.
                 </>
               )}
             </p>
@@ -218,7 +219,7 @@ export default function FirstRunWizard({
                 </div>
               )}
               <div className="wizard-row">
-                <span>{isWindows ? 'Speech model prepares automatically' : engine.detail}</span>
+                <span>{engine.detail}</span>
                 <span className={engine.status === 'error' ? 'wz-bad' : 'wz-ok'}>
                   {engine.status === 'ready' ? '✓' : engine.status === 'error' ? '✕' : '…'}
                 </span>
@@ -230,8 +231,8 @@ export default function FirstRunWizard({
             {!isWindows && (engine.mic === false || engine.screen === false) && (
               <p className="wizard-hint">
                 Denied something? Grant it later in System Settings → Privacy &amp; Security →
-                Microphone / Screen &amp; System Audio Recording — recording won&rsquo;t work
-                until then.
+                Microphone / Screen &amp; System Audio Recording — recording won&rsquo;t work until
+                then.
               </p>
             )}
             <button
@@ -250,7 +251,7 @@ export default function FirstRunWizard({
             <h1 className="wizard-title">Notes model</h1>
             <p className="wizard-sub">
               After a meeting, DoodleNote merges your rough notes with the transcript into polished
-              notes — by default with a model that runs entirely on this Mac.
+              notes — by default with a model that runs entirely on this computer.
             </p>
             {alreadyActive || notesState === 'done' ? (
               <div className="wizard-rows">
@@ -285,8 +286,8 @@ export default function FirstRunWizard({
             ) : (
               <p className="wizard-hint">
                 {models === null
-                  ? 'Checking this Mac…'
-                  : 'This Mac is short on RAM for the on-device model — use your own API key instead.'}
+                  ? 'Checking this computer…'
+                  : 'This computer is short on RAM for the on-device model — use your own API key instead.'}
               </p>
             )}
             <button type="button" className="wizard-link" onClick={() => setStep('done')}>
@@ -306,7 +307,9 @@ export default function FirstRunWizard({
                 Choose <strong>New → New meeting</strong> and DoodleNote records &amp; transcribes
                 live
               </li>
-              <li>Type rough notes during the call — <strong>Generate notes</strong> polishes them</li>
+              <li>
+                Type rough notes during the call — <strong>Generate notes</strong> polishes them
+              </li>
               <li>DoodleNote also offers to record when it notices you&rsquo;re on a call</li>
             </ul>
             <button type="button" className="wizard-cta" onClick={onFinish}>

--- a/apps/desktop/src/renderer/src/MeetingView.tsx
+++ b/apps/desktop/src/renderer/src/MeetingView.tsx
@@ -10,7 +10,12 @@ import type {
   EngineInputDevice,
   TranscriptSegment
 } from '../../shared/engine-events'
-import { AUDIO_PERSIST_STORAGE_KEY, SYSTEM_BACKEND_STORAGE_KEY, type AudioPart } from '../../shared/audio-api'
+import { listWinInputDevices } from './lib/win-capture'
+import {
+  AUDIO_PERSIST_STORAGE_KEY,
+  SYSTEM_BACKEND_STORAGE_KEY,
+  type AudioPart
+} from '../../shared/audio-api'
 import type { FolderRecord } from '../../shared/folders-api'
 import type { MeetingChatEntry, MeetingRecord } from '../../shared/meetings-api'
 import type {
@@ -104,7 +109,11 @@ function sessionReducer(state: SessionState, ev: EngineEvent): SessionState {
       return { ...state, phase: 'recording', statusText: '' }
     case 'partial':
       if (!active || !ev.channel) return state
-      return { ...state, transcribing: true, partials: { ...state.partials, [ev.channel]: ev.text } }
+      return {
+        ...state,
+        transcribing: true,
+        partials: { ...state.partials, [ev.channel]: ev.text }
+      }
     case 'segments': {
       // Never attribute segments to a meeting whose view didn't run a session.
       if (state.phase === 'idle') return state
@@ -728,28 +737,25 @@ export default function MeetingView({
 
   /* ---- actions ---- */
 
-  // Mic picker: [] where unsupported (Windows), which hides the control.
   // Refreshed when the picker gains focus so plugging in a mic just works.
+  // macOS asks the native engine; Windows asks Chromium, which owns capture.
   const refreshInputDevices = useCallback(async (): Promise<void> => {
     try {
-      setInputDevices(await window.engine.listInputDevices())
+      const platform = await window.detect.getState()
+      setInputDevices(
+        platform.platform === 'win32'
+          ? await listWinInputDevices()
+          : await window.engine.listInputDevices()
+      )
     } catch {
       setInputDevices([])
     }
   }, [])
 
   useEffect(() => {
-    let cancelled = false
-    window.engine
-      .listInputDevices()
-      .then((devices) => {
-        if (!cancelled) setInputDevices(devices)
-      })
-      .catch(() => {})
-    return () => {
-      cancelled = true
-    }
-  }, [])
+    const timer = window.setTimeout(() => void refreshInputDevices(), 0)
+    return () => window.clearTimeout(timer)
+  }, [refreshInputDevices])
 
   const changeInputDevice = (uid: string): void => {
     setInputDeviceUid(uid)
@@ -861,7 +867,8 @@ export default function MeetingView({
     let current: string | null = null
     for (const s of allSegments) {
       // Same fallback as seekToSegment for sync-stripped segments.
-      const t = typeof s.absoluteStartMs === 'number' ? s.absoluteStartMs : part.startEpochMs + s.startMs
+      const t =
+        typeof s.absoluteStartMs === 'number' ? s.absoluteStartMs : part.startEpochMs + s.startMs
       if (t > epochMs) break
       current = s.id
     }
@@ -1251,8 +1258,8 @@ export default function MeetingView({
         <div className="toast" role="status">
           <span>
             Recording ended, but no speech was transcribed on either channel. Try again speaking
-            near the mic (or with meeting audio playing) — if it keeps happening, the Developer
-            view shows the raw engine events.
+            near the mic (or with meeting audio playing) — if it keeps happening, the Developer view
+            shows the raw engine events.
           </span>
           <button type="button" onClick={() => setEmptyNotice(false)}>
             ✕
@@ -1331,11 +1338,17 @@ export default function MeetingView({
                 type="button"
                 className="chip chip-regen"
                 disabled={!canEnhance}
-                title={!modelReady ? 'Activate a notes model in Settings first' : 'Regenerate notes'}
+                title={
+                  !modelReady ? 'Activate a notes model in Settings first' : 'Regenerate notes'
+                }
                 aria-label="Regenerate notes"
                 onClick={() => void runEnhance()}
               >
-                {enhanceStatus === 'running' ? <span className="spinner" aria-hidden="true" /> : '↻'}
+                {enhanceStatus === 'running' ? (
+                  <span className="spinner" aria-hidden="true" />
+                ) : (
+                  '↻'
+                )}
               </button>
             )}
             {enhancedMarkdown !== null && !capturing && (
@@ -1470,7 +1483,9 @@ export default function MeetingView({
                       audioParts.length > 0 && !capturing ? () => seekToSegment(s) : undefined
                     }
                     title={
-                      audioParts.length > 0 && !capturing ? 'Play the recording from here' : undefined
+                      audioParts.length > 0 && !capturing
+                        ? 'Play the recording from here'
+                        : undefined
                     }
                   >
                     <span className="tp-speaker">{s.speaker}</span>
@@ -1698,16 +1713,19 @@ export default function MeetingView({
               onFocus={() => void refreshInputDevices()}
             >
               <option value="">
-                Default{(() => {
+                Default
+                {(() => {
                   const def = inputDevices.find((d) => d.isDefault)
                   return def ? ` — ${def.name}` : ''
                 })()}
               </option>
-              {inputDevices.map((device) => (
-                <option key={device.uid} value={device.uid}>
-                  {device.name}
-                </option>
-              ))}
+              {inputDevices
+                .filter((device) => device.uid !== 'default')
+                .map((device) => (
+                  <option key={device.uid} value={device.uid}>
+                    {device.name}
+                  </option>
+                ))}
             </select>
           </label>
         )}

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { AUDIO_PERSIST_STORAGE_KEY, SYSTEM_BACKEND_STORAGE_KEY, type AudioUsage } from '../../shared/audio-api'
+import {
+  AUDIO_PERSIST_STORAGE_KEY,
+  SYSTEM_BACKEND_STORAGE_KEY,
+  type AudioUsage
+} from '../../shared/audio-api'
 import type { CalendarPrefsUpdate, CalendarState } from '../../shared/calendar-api'
 import type { DetectState } from '../../shared/detect-api'
 import type { SyncStatus } from '../../shared/sync-api'
@@ -254,7 +258,7 @@ export default function ModelsView({
   const clearAllAudio = async (): Promise<void> => {
     if (
       !window.confirm(
-        'Delete every saved meeting recording on this Mac? Transcripts and notes are kept.'
+        'Delete every saved meeting recording on this computer? Transcripts and notes are kept.'
       )
     ) {
       return
@@ -862,22 +866,24 @@ export default function ModelsView({
 
                   <div className="cal-subcard">
                     <div className="cal-subcard-head">Display</div>
-                    <div className="cal-row">
-                      <span className="cal-row-icon">
-                        <MenuBarIcon />
-                      </span>
-                      <span className="cal-row-main">
-                        <span className="cal-row-label">Show upcoming meetings in menu bar</span>
-                        <span className="cal-row-sub">
-                          Display your next meeting and time until it starts in the macOS menu bar
+                    {detect?.platform === 'darwin' && (
+                      <div className="cal-row">
+                        <span className="cal-row-icon">
+                          <MenuBarIcon />
                         </span>
-                      </span>
-                      <Toggle
-                        checked={calState.prefs.showMenuBar}
-                        label="Show upcoming meetings in menu bar"
-                        onChange={() => setCalPrefs({ showMenuBar: !calState.prefs.showMenuBar })}
-                      />
-                    </div>
+                        <span className="cal-row-main">
+                          <span className="cal-row-label">Show upcoming meetings in menu bar</span>
+                          <span className="cal-row-sub">
+                            Display your next meeting and time until it starts in the macOS menu bar
+                          </span>
+                        </span>
+                        <Toggle
+                          checked={calState.prefs.showMenuBar}
+                          label="Show upcoming meetings in menu bar"
+                          onChange={() => setCalPrefs({ showMenuBar: !calState.prefs.showMenuBar })}
+                        />
+                      </div>
+                    )}
                     <div className="cal-row">
                       <span className="cal-row-icon">
                         <PeopleIcon />
@@ -1111,7 +1117,7 @@ export default function ModelsView({
               <section className="keys-section">
                 <h3>Meeting recordings</h3>
                 <p className="models-sub">
-                  Recordings stay on this Mac — they are never uploaded, even with sync on.
+                  Recordings stay on this computer — they are never uploaded, even with sync on.
                 </p>
                 <div className="cal-subcard">
                   <div className="cal-row">
@@ -1128,21 +1134,23 @@ export default function ModelsView({
                       onChange={togglePersistAudio}
                     />
                   </div>
-                  <div className="cal-row">
-                    <span className="cal-row-main">
-                      <span className="cal-row-label">Capture without screen permission</span>
-                      <span className="cal-row-sub">
-                        System audio is captured with a Core Audio tap (macOS 14.2+) — no Screen
-                        Recording access needed. Turn off to use the legacy ScreenCaptureKit
-                        capture instead.
+                  {detect?.platform === 'darwin' && (
+                    <div className="cal-row">
+                      <span className="cal-row-main">
+                        <span className="cal-row-label">Capture without screen permission</span>
+                        <span className="cal-row-sub">
+                          System audio is captured with a Core Audio tap (macOS 14.2+) — no Screen
+                          Recording access needed. Turn off to use the legacy ScreenCaptureKit
+                          capture instead.
+                        </span>
                       </span>
-                    </span>
-                    <Toggle
-                      checked={tapEnabled}
-                      label="Capture system audio without screen permission"
-                      onChange={toggleTapBackend}
-                    />
-                  </div>
+                      <Toggle
+                        checked={tapEnabled}
+                        label="Capture system audio without screen permission"
+                        onChange={toggleTapBackend}
+                      />
+                    </div>
+                  )}
                   <div className="cal-row">
                     <span className="cal-row-main">
                       <span className="cal-row-label">Delete all recordings</span>

--- a/apps/desktop/src/renderer/src/OnboardingTour.tsx
+++ b/apps/desktop/src/renderer/src/OnboardingTour.tsx
@@ -194,7 +194,7 @@ function OnboardingTour({
                 <span>
                   {isWindows
                     ? 'The speech model finishes downloading on first launch — the first recording may take a moment'
-                    : 'Everything you saved during recording — audio included — stays on this Mac'}
+                    : 'Everything you saved during recording — audio included — stays on this computer'}
                 </span>
               </li>
             </ul>

--- a/apps/desktop/src/renderer/src/lib/win-batch-decode.ts
+++ b/apps/desktop/src/renderer/src/lib/win-batch-decode.ts
@@ -1,0 +1,60 @@
+import type { EngineChannel } from '../../../shared/engine-events'
+
+const TARGET_SAMPLE_RATE = 16_000
+const CHUNK_SAMPLES = TARGET_SAMPLE_RATE * 2
+
+/** Decode an imported file with Chromium and stream 16 kHz PCM back to main. */
+export async function decodeWinBatchAudio(jobId: string): Promise<void> {
+  let context: AudioContext | null = null
+  try {
+    const encoded = await window.engine.readBatchAudio(jobId)
+    context = new AudioContext()
+    const decoded = await context.decodeAudioData(encoded.slice(0))
+    const channelCount = Math.min(2, Math.max(1, decoded.numberOfChannels))
+    const channels: EngineChannel[] = channelCount > 1 ? ['mic', 'system'] : ['mic']
+
+    const sourceBuffer = context.createBuffer(channelCount, decoded.length, decoded.sampleRate)
+    for (let channel = 0; channel < channelCount; channel += 1) {
+      sourceBuffer.copyToChannel(decoded.getChannelData(channel), channel)
+    }
+    const outputLength = Math.max(1, Math.ceil(decoded.duration * TARGET_SAMPLE_RATE))
+    const offline = new OfflineAudioContext(channelCount, outputLength, TARGET_SAMPLE_RATE)
+    const source = offline.createBufferSource()
+    source.buffer = sourceBuffer
+    source.connect(offline.destination)
+    source.start()
+    const rendered = await offline.startRendering()
+
+    await window.engine.sendBatchMessage({
+      type: 'begin',
+      jobId,
+      channels,
+      audioSeconds: decoded.duration
+    })
+    for (let offset = 0; offset < rendered.length; offset += CHUNK_SAMPLES) {
+      const end = Math.min(rendered.length, offset + CHUNK_SAMPLES)
+      for (let channel = 0; channel < channels.length; channel += 1) {
+        await window.engine.sendBatchMessage({
+          type: 'audio',
+          jobId,
+          channel: channels[channel]!,
+          samples: rendered.getChannelData(channel).slice(offset, end)
+        })
+      }
+      if (offset > 0 && offset % (CHUNK_SAMPLES * 8) === 0) {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      }
+    }
+    await window.engine.sendBatchMessage({ type: 'end', jobId })
+  } catch (error) {
+    await window.engine
+      .sendBatchMessage({
+        type: 'error',
+        jobId,
+        message: error instanceof Error ? error.message : 'Could not decode that audio file.'
+      })
+      .catch(() => {})
+  } finally {
+    if (context) void context.close().catch(() => {})
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/win-capture.ts
+++ b/apps/desktop/src/renderer/src/lib/win-capture.ts
@@ -1,3 +1,6 @@
+import type { EngineInputDevice } from '../../../shared/engine-events'
+import { mapWindowsInputDevices } from '../../../shared/win-audio-utils'
+
 /**
  * Windows audio capture, in the renderer where Chromium does the heavy
  * lifting: microphone via getUserMedia (with Chromium's AEC scrubbing the
@@ -11,18 +14,22 @@
  */
 
 interface ChannelCapture {
+  channel: string
   stream: MediaStream
   context: AudioContext
 }
 
 let captures: ChannelCapture[] = []
+let activeInputDevice: string | undefined
 
-export async function startWinCapture(channels: string[]): Promise<void> {
+export async function startWinCapture(channels: string[], inputDevice?: string): Promise<void> {
   stopWinCapture()
+  activeInputDevice = inputDevice
   try {
     if (channels.includes('mic')) {
       const mic = await navigator.mediaDevices.getUserMedia({
         audio: {
+          ...(inputDevice && inputDevice !== 'default' ? { deviceId: { exact: inputDevice } } : {}),
           channelCount: 1,
           echoCancellation: true, // scrubs speaker bleed out of "You"
           noiseSuppression: true,
@@ -70,13 +77,45 @@ function pump(stream: MediaStream, channel: string): ChannelCapture {
   source.connect(processor)
   processor.connect(mute)
   mute.connect(context.destination) // ScriptProcessor only runs when routed
-  return { stream, context }
+  return { channel, stream, context }
+}
+
+export async function listWinInputDevices(): Promise<EngineInputDevice[]> {
+  if (!navigator.mediaDevices?.enumerateDevices) return []
+  const devices = await navigator.mediaDevices.enumerateDevices()
+  return mapWindowsInputDevices(devices)
+}
+
+/** Replace only the microphone stream; system loopback keeps flowing. */
+export async function switchWinInputDevice(inputDevice?: string): Promise<void> {
+  const current = captures.find((capture) => capture.channel === 'mic')
+  if (!current || inputDevice === activeInputDevice) return
+  try {
+    const replacement = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        ...(inputDevice && inputDevice !== 'default' ? { deviceId: { exact: inputDevice } } : {}),
+        channelCount: 1,
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true
+      }
+    })
+    const next = pump(replacement, 'mic')
+    stopCapture(current)
+    captures = captures.map((capture) => (capture === current ? next : capture))
+    activeInputDevice = inputDevice
+  } catch (error) {
+    console.error('[win-capture] could not switch microphones:', error)
+  }
+}
+
+function stopCapture(capture: ChannelCapture): void {
+  for (const track of capture.stream.getTracks()) track.stop()
+  void capture.context.close().catch(() => {})
 }
 
 export function stopWinCapture(): void {
-  for (const capture of captures) {
-    for (const track of capture.stream.getTracks()) track.stop()
-    void capture.context.close().catch(() => {})
-  }
+  for (const capture of captures) stopCapture(capture)
   captures = []
+  activeInputDevice = undefined
 }

--- a/apps/desktop/src/shared/engine-events.ts
+++ b/apps/desktop/src/shared/engine-events.ts
@@ -12,11 +12,34 @@ export const ENGINE_CAPTURE_CONTROL_CHANNEL = 'engine:capture-control'
 export const ENGINE_AUDIO_CHANNEL = 'engine:audio'
 /** renderer → main (Windows): capture could not start (permissions etc.). */
 export const ENGINE_CAPTURE_ERROR_CHANNEL = 'engine:capture-error'
+/** main → renderer (Windows): decode an imported file with Chromium's media stack. */
+export const ENGINE_BATCH_CONTROL_CHANNEL = 'engine:batch-control'
+/** renderer → main (Windows): decoded PCM lifecycle for an imported file. */
+export const ENGINE_BATCH_DATA_CHANNEL = 'engine:batch-data'
+/** renderer → main (invoke, Windows): read the file assigned to a batch job. */
+export const ENGINE_BATCH_READ_CHANNEL = 'engine:batch-read'
 
 export interface EngineCaptureControl {
-  action: 'start' | 'stop'
+  action: 'start' | 'stop' | 'switch-input'
   channels?: string[]
+  inputDevice?: string
 }
+
+export interface EngineBatchControl {
+  action: 'decode'
+  jobId: string
+}
+
+export type EngineBatchMessage =
+  | {
+      type: 'begin'
+      jobId: string
+      channels: EngineChannel[]
+      audioSeconds: number
+    }
+  | { type: 'audio'; jobId: string; channel: EngineChannel; samples: Float32Array }
+  | { type: 'end'; jobId: string }
+  | { type: 'error'; jobId: string; message: string }
 
 export const ENGINE_EVENT_CHANNEL = 'engine:event'
 export const ENGINE_START_CHANNEL = 'engine:start'
@@ -242,4 +265,8 @@ export interface EngineApi {
   onCaptureControl(cb: (control: EngineCaptureControl) => void): () => void
   sendAudio(channel: string, samples: Float32Array): void
   reportCaptureError(message: string): void
+  /** Windows imported-audio decoder bridge (no events are sent on macOS). */
+  onBatchControl(cb: (control: EngineBatchControl) => void): () => void
+  readBatchAudio(jobId: string): Promise<ArrayBuffer>
+  sendBatchMessage(message: EngineBatchMessage): Promise<void>
 }

--- a/apps/desktop/src/shared/win-audio-utils.ts
+++ b/apps/desktop/src/shared/win-audio-utils.ts
@@ -1,0 +1,39 @@
+import type { EngineInputDevice } from './engine-events'
+
+export interface MediaDeviceLike {
+  deviceId: string
+  groupId: string
+  kind: string
+  label: string
+}
+
+/** Normalize Chromium's Windows device list for the shared microphone picker. */
+export function mapWindowsInputDevices(devices: MediaDeviceLike[]): EngineInputDevice[] {
+  const inputs = devices.filter((device) => device.kind === 'audioinput')
+  const defaultDevice = inputs.find((device) => device.deviceId === 'default')
+  const physical = inputs.filter(
+    (device) => device.deviceId !== 'default' && device.deviceId !== 'communications'
+  )
+  const seen = new Set<string>()
+  const mapped = physical
+    .filter((device) => {
+      if (!device.deviceId || seen.has(device.deviceId)) return false
+      seen.add(device.deviceId)
+      return true
+    })
+    .map((device, index) => ({
+      uid: device.deviceId,
+      name: device.label.trim() || `Microphone ${index + 1}`,
+      isDefault: Boolean(defaultDevice?.groupId && defaultDevice.groupId === device.groupId)
+    }))
+
+  if (mapped.length > 0) return mapped
+  if (!defaultDevice) return []
+  return [
+    {
+      uid: 'default',
+      name: defaultDevice.label.trim() || 'System default microphone',
+      isDefault: true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Windows audio import and saved-recording re-transcription through Chromium decoding plus an isolated sherpa worker
- add Windows microphone enumeration and live device switching
- make first-run setup wait for the real Windows speech model and remove macOS-only controls/copy from Windows
- add Windows NSIS CI packaging, artifact retention, packaging regression tests, and an Authenticode publish gate

## Verification
- `pnpm --filter desktop typecheck`
- `pnpm --filter desktop test` — 120 passed, 0 failed
- `pnpm --filter desktop build`
- `pnpm --filter desktop package:win`
- inspected generated v0.4.11 x64 NSIS installer, updater manifest, blockmap, sherpa native DLLs, and CPU/Vulkan llama binaries

## Risks / native validation
- the Windows feature paths compile and package locally, but Zoom/Teams/WASAPI, Chromium file decoding, permissions, notifications, first-run model download, and the v0.3.4 updater jump still need smoke testing on a real Windows 10/11 system
- the repository currently has no `WINDOWS_CSC_LINK` or `WINDOWS_CSC_KEY_PASSWORD` secret; CI will retain an unsigned tester build, while `release:win` now refuses to publish unless Authenticode is valid
- Windows ring-before-answer detection remains intentionally unavailable because ConsentStore exposes microphone use but not speaker/output activity

## Release boundary
Do not publish `latest.yml` until the Windows smoke matrix passes and signing credentials are configured.