### PR TITLE
Serve Windows beta outside the production updater

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,7 +18,8 @@
     "package": "pnpm --filter doodle-note-mcp build && electron-vite build && APPLE_KEYCHAIN_PROFILE=doodlenote-notary electron-builder --mac",
     "package:win": "pnpm --filter doodle-note-mcp build && electron-vite build && electron-builder --win --x64",
     "release": "pnpm package && node scripts/publish-release.mjs --mac",
-    "release:win": "pnpm package:win && powershell -NoProfile -ExecutionPolicy Bypass -File scripts/verify-windows-signature.ps1 && node scripts/publish-release.mjs --win"
+    "release:win": "pnpm package:win && powershell -NoProfile -ExecutionPolicy Bypass -File scripts/verify-windows-signature.ps1 && node scripts/publish-release.mjs --win",
+    "publish:win-beta": "node scripts/publish-windows-beta.mjs"
   },
   "dependencies": {
     "@azure/msal-node": "^5.3.1",

--- a/apps/desktop/scripts/publish-windows-beta.mjs
+++ b/apps/desktop/scripts/publish-windows-beta.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const desktopDir = path.join(here, '..')
-const releaseDir = path.join(desktopDir, 'release')
+const releaseDir = process.env.WINDOWS_RELEASE_DIR ?? path.join(desktopDir, 'release')
 
 if (!process.env.BLOB_READ_WRITE_TOKEN) {
   const envLocal =

--- a/apps/desktop/scripts/publish-windows-beta.mjs
+++ b/apps/desktop/scripts/publish-windows-beta.mjs
@@ -1,0 +1,68 @@
+// Publish a manually tested Windows beta without changing latest.yml, which is
+// the production electron-updater feed. Production Windows releases must keep
+// using `pnpm release:win`, including its Authenticode verification gate.
+import { put } from '@vercel/blob'
+import { createReadStream, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const desktopDir = path.join(here, '..')
+const releaseDir = path.join(desktopDir, 'release')
+
+if (!process.env.BLOB_READ_WRITE_TOKEN) {
+  const envLocal = path.join(desktopDir, '..', '..', '.env.local')
+  try {
+    const text = readFileSync(envLocal, 'utf8')
+    const match = text.match(/^BLOB_READ_WRITE_TOKEN="?([^"\n]+)"?$/m)
+    if (match) process.env.BLOB_READ_WRITE_TOKEN = match[1]
+  } catch {
+    // Fall through to the actionable error below.
+  }
+}
+if (!process.env.BLOB_READ_WRITE_TOKEN) {
+  throw new Error('BLOB_READ_WRITE_TOKEN not set (vercel env pull refreshes .env.local)')
+}
+
+const { version } = JSON.parse(readFileSync(path.join(desktopDir, 'package.json'), 'utf8'))
+const manifestPath = path.join(releaseDir, 'latest.yml')
+const manifest = readFileSync(manifestPath, 'utf8')
+const manifestVersion = /^version:\s*["']?([^\s"']+)["']?\s*$/m.exec(manifest)?.[1]
+const installerName = /^path:\s*(\S+)\s*$/m.exec(manifest)?.[1]
+
+if (manifestVersion !== version) {
+  throw new Error(`Windows manifest version ${manifestVersion ?? 'missing'} does not match ${version}`)
+}
+if (!installerName || !installerName.endsWith('-setup.exe')) {
+  throw new Error('Windows manifest does not contain a valid setup.exe path')
+}
+
+// Keep beta filenames distinct so a later signed production build at the same
+// version can never be overwritten by an unsigned tester artifact.
+const betaInstallerName = installerName.replace(/-setup\.exe$/, '-beta-setup.exe')
+const artifacts = [
+  { source: installerName, destination: betaInstallerName },
+  { source: `${installerName}.blockmap`, destination: `${betaInstallerName}.blockmap` }
+]
+for (const { source, destination } of artifacts) {
+  const file = path.join(releaseDir, source)
+  const size = statSync(file).size
+  process.stdout.write(`uploading beta ${destination} (${(size / 1024 / 1024).toFixed(1)} MB)… `)
+  const blob = await put(`updates/${destination}`, createReadStream(file), {
+    access: 'public',
+    addRandomSuffix: false,
+    allowOverwrite: true
+  })
+  console.log(blob.url)
+}
+
+process.stdout.write('uploading beta manifest… ')
+const betaManifestBody = manifest.split(installerName).join(betaInstallerName)
+const betaManifest = await put('updates/latest-beta.yml', Buffer.from(betaManifestBody), {
+  access: 'public',
+  addRandomSuffix: false,
+  allowOverwrite: true,
+  cacheControlMaxAge: 60
+})
+console.log(betaManifest.url)
+console.log('production latest.yml remains unchanged')

--- a/apps/desktop/scripts/publish-windows-beta.mjs
+++ b/apps/desktop/scripts/publish-windows-beta.mjs
@@ -11,7 +11,8 @@ const desktopDir = path.join(here, '..')
 const releaseDir = path.join(desktopDir, 'release')
 
 if (!process.env.BLOB_READ_WRITE_TOKEN) {
-  const envLocal = path.join(desktopDir, '..', '..', '.env.local')
+  const envLocal =
+    process.env.BLOB_ENV_FILE ?? path.join(desktopDir, '..', '..', '.env.local')
   try {
     const text = readFileSync(envLocal, 'utf8')
     const match = text.match(/^BLOB_READ_WRITE_TOKEN="?([^"\n]+)"?$/m)
@@ -21,7 +22,9 @@ if (!process.env.BLOB_READ_WRITE_TOKEN) {
   }
 }
 if (!process.env.BLOB_READ_WRITE_TOKEN) {
-  throw new Error('BLOB_READ_WRITE_TOKEN not set (vercel env pull refreshes .env.local)')
+  throw new Error(
+    'BLOB_READ_WRITE_TOKEN not set (vercel env pull refreshes .env.local; BLOB_ENV_FILE can select another env file)'
+  )
 }
 
 const { version } = JSON.parse(readFileSync(path.join(desktopDir, 'package.json'), 'utf8'))

--- a/apps/desktop/src/main/release-packaging.test.ts
+++ b/apps/desktop/src/main/release-packaging.test.ts
@@ -7,6 +7,10 @@ const publishScript = readFileSync(
   new URL('../../scripts/publish-release.mjs', import.meta.url),
   'utf8'
 )
+const windowsBetaPublishScript = readFileSync(
+  new URL('../../scripts/publish-windows-beta.mjs', import.meta.url),
+  'utf8'
+)
 const brandScript = readFileSync(
   new URL('../../scripts/build-brand-assets.sh', import.meta.url),
   'utf8'
@@ -83,6 +87,13 @@ test('CI builds and retains a real Windows installer', () => {
   assert.match(ciWorkflow, /Get-AuthenticodeSignature/)
   assert.match(ciWorkflow, /actions\/upload-artifact@v4/)
   assert.match(desktopPackage, /release:win[\s\S]*verify-windows-signature\.ps1/)
+})
+
+test('Windows website betas cannot replace the production updater feed', () => {
+  assert.match(desktopPackage, /publish:win-beta[\s\S]*publish-windows-beta\.mjs/)
+  assert.match(windowsBetaPublishScript, /-beta-setup\.exe/)
+  assert.match(windowsBetaPublishScript, /put\('updates\/latest-beta\.yml'/)
+  assert.doesNotMatch(windowsBetaPublishScript, /put\('updates\/latest\.yml'/)
 })
 
 test('macOS-only settings are gated out of the Windows UI', () => {

--- a/apps/web/app/download/[platform]/route.ts
+++ b/apps/web/app/download/[platform]/route.ts
@@ -1,27 +1,26 @@
 import { NextResponse } from "next/server";
 
-import { downloadArtifactFromManifest } from "@/lib/download-artifact";
+import {
+  downloadArtifactFromManifest,
+  downloadManifestForPlatform,
+} from "@/lib/download-artifact";
 
 /**
  * Never-drifting download links: /download/mac and /download/win resolve the
- * CURRENT version from the same electron-updater manifests the apps use
- * (public/updates/latest-mac.yml / latest.yml) and 302 to its installer. macOS
- * gets the matching DMG; its in-app updater keeps using the ZIP. Born from an
- * incident where the landing page hardcoded versioned artifact names and quietly
- * served 0.3.5 after 0.3.6 shipped — a manifest and this redirect cannot disagree.
+ * CURRENT website version from a platform-specific manifest and 302 to its
+ * installer. macOS gets the matching DMG from the production feed. Windows
+ * uses latest-beta.yml so an unsigned beta can be tested without changing the
+ * production updater feed in latest.yml. Born from an incident where the
+ * landing page hardcoded versioned artifact names and quietly served 0.3.5
+ * after 0.3.6 shipped — a manifest and this redirect cannot disagree.
  */
-
-const MANIFESTS: Record<string, string> = {
-  mac: "latest-mac.yml",
-  win: "latest.yml",
-};
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ platform: string }> },
 ) {
   const { platform } = await params;
-  const manifest = MANIFESTS[platform];
+  const manifest = downloadManifestForPlatform(platform);
   if (!manifest) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }

--- a/apps/web/app/ui.tsx
+++ b/apps/web/app/ui.tsx
@@ -4,8 +4,9 @@ import Link from "next/link";
 import { AppleLogo, WindowsLogo } from "./logos";
 
 /**
- * Version-independent: /download/<platform> reads the live update manifest
- * and redirects to the current installer, so these can never go stale.
+ * Version-independent: /download/<platform> reads the live platform download
+ * manifest and redirects to the current installer, so these can never go stale.
+ * The Windows website manifest remains separate from its production updater.
  */
 export const DOWNLOADS = {
   mac: "/download/mac",

--- a/apps/web/lib/download-artifact.ts
+++ b/apps/web/lib/download-artifact.ts
@@ -1,5 +1,20 @@
 const SAFE_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
 
+/**
+ * Website downloads are intentionally independent from desktop update feeds.
+ * Windows remains a public beta until its Authenticode signing is configured,
+ * so the website may serve a beta installer without offering it to installed
+ * clients through latest.yml.
+ */
+const DOWNLOAD_MANIFESTS: Record<string, string> = {
+  mac: "latest-mac.yml",
+  win: "latest-beta.yml",
+};
+
+export function downloadManifestForPlatform(platform: string): string | null {
+  return DOWNLOAD_MANIFESTS[platform] ?? null;
+}
+
 /** Resolve the public artifact for a website download without changing the updater feed. */
 export function downloadArtifactFromManifest(
   platform: string,

--- a/apps/web/tests/download-artifact.test.ts
+++ b/apps/web/tests/download-artifact.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { downloadArtifactFromManifest } from "../lib/download-artifact";
+import {
+  downloadArtifactFromManifest,
+  downloadManifestForPlatform,
+} from "../lib/download-artifact";
 
 const macManifest = `version: 0.4.10
 files:
@@ -16,7 +19,7 @@ test("website Mac downloads use the version-matched DMG", () => {
   );
 });
 
-test("Windows downloads continue using the updater manifest path", () => {
+test("Windows downloads use the installer path from their selected manifest", () => {
   assert.equal(
     downloadArtifactFromManifest(
       "win",
@@ -24,6 +27,12 @@ test("Windows downloads continue using the updater manifest path", () => {
     ),
     "DoodleNote-0.4.10-setup.exe",
   );
+});
+
+test("Windows website downloads use the beta manifest, not the updater feed", () => {
+  assert.equal(downloadManifestForPlatform("win"), "latest-beta.yml");
+  assert.equal(downloadManifestForPlatform("mac"), "latest-mac.yml");
+  assert.equal(downloadManifestForPlatform("linux"), null);
 });
 
 test("malformed or unsafe versions never become redirect targets", () => {


### PR DESCRIPTION
## Summary
- route the website's Windows beta download through `latest-beta.yml`
- publish beta installers under distinct `-beta-setup.exe` names
- keep the production `latest.yml` updater feed and Authenticode release gate untouched

## Verification
- `pnpm --filter desktop test` — 121 passed
- `pnpm --filter web test` — 19 passed
- `pnpm --filter web typecheck`
- `pnpm --filter web build`
- `node --check apps/desktop/scripts/publish-windows-beta.mjs`

## Release note
After merge, upload the v0.4.11 CI artifact with `pnpm --filter desktop publish:win-beta`; then verify `/download/win` resolves to the beta installer while `/updates/latest.yml` remains v0.3.4.
