### PR TITLE
Release DoodleNote v0.4.12

### DIFF
--- a/RELEASE-v0.4.12.md
+++ b/RELEASE-v0.4.12.md
@@ -18,16 +18,16 @@
 
 ## Verification
 
-- [ ] Frozen-lockfile dependency install
-- [ ] Workspace typecheck
-- [ ] Full workspace test suite
-- [ ] Swift transcription engine release build
-- [ ] Production Electron package
-- [ ] Packaged application reports version 0.4.12
-- [ ] Signed and notarized arm64 package with the Swift transcription engine
-- [ ] Strict code-signature, Gatekeeper, and stapled-ticket validation
-- [ ] Updater ZIP and website DMG checksums recorded
-- [ ] Updater manifest references only version-matched v0.4.12 artifacts
+- [x] Frozen-lockfile dependency install
+- [x] Workspace typecheck (8 packages)
+- [x] Full workspace test suite (197 passing, 0 failing, 0 skipped after native packaging dependencies were available)
+- [x] Swift transcription engine release build
+- [x] Production Electron and web builds
+- [x] Packaged application reports version 0.4.12
+- [x] Signed and notarized arm64 package with the Swift transcription engine
+- [x] Strict code-signature, Gatekeeper, and stapled-ticket validation
+- [x] Updater ZIP and website DMG checksums recorded
+- [x] Updater manifest references only version-matched v0.4.12 artifacts
 
 ## Release gates
 
@@ -40,9 +40,14 @@
 
 ## Package
 
-- Updater artifact: pending
-- Website installer: pending
+- Updater artifact: `DoodleNote-0.4.12-arm64-mac.zip`
+- Updater size: `170317348` bytes
+- Updater SHA-256: `6438a7d996467b73c519ce202fd7d43c33fd96aa2f79b8ef02ff4d3619ed605f`
+- Website installer: `DoodleNote-0.4.12-arm64.dmg`
+- Website installer size: `172215086` bytes
+- Website installer SHA-256: `6acdeee9767ec731597d6c546553d3b264319b57612d54ec7039bba97bb71d4d`
 - Developer ID: `SEAN INMAN (VTZW6K32K4)`
-- Gatekeeper: pending
-- Stapled notarization ticket: pending
-- Packaged engine: pending
+- Apple notarization submission: `777c1a68-d8e7-45cf-b3f0-4e44b4a25d76` (`Accepted`)
+- Gatekeeper: `accepted` (`Notarized Developer ID`)
+- Stapled notarization ticket: validated
+- Packaged engine: arm64 Mach-O executable present

--- a/RELEASE-v0.4.12.md
+++ b/RELEASE-v0.4.12.md
@@ -1,0 +1,48 @@
+# DoodleNote v0.4.12 release candidate
+
+## Included
+
+- [x] Add stable speaker identities and a per-meeting participant roster
+- [x] Let the DoodleNote user configure their own transcript name
+- [x] Let a speaker be renamed once across the complete meeting transcript
+- [x] Use resolved speaker names in generated meeting notes and Ask prompts
+- [x] Preserve You/Them fallbacks for legacy and unnamed meetings
+- [x] Preserve speaker labels through desktop, web, iOS, sync, export, connector, and MCP readers
+- [x] Bump the desktop version from 0.4.11 to 0.4.12
+- [x] Add the v0.4.12 changelog entry
+
+## Deferred
+
+- Calendar-attendee names are not seeded automatically yet; this remains active in ONY-83
+- Multi-speaker diarization, Slack Huddles, and conversational name inference remain out of scope
+
+## Verification
+
+- [ ] Frozen-lockfile dependency install
+- [ ] Workspace typecheck
+- [ ] Full workspace test suite
+- [ ] Swift transcription engine release build
+- [ ] Production Electron package
+- [ ] Packaged application reports version 0.4.12
+- [ ] Signed and notarized arm64 package with the Swift transcription engine
+- [ ] Strict code-signature, Gatekeeper, and stapled-ticket validation
+- [ ] Updater ZIP and website DMG checksums recorded
+- [ ] Updater manifest references only version-matched v0.4.12 artifacts
+
+## Release gates
+
+- [ ] Release PR has green required CI
+- [x] User authorized merge and publication
+- [ ] Release PR merged into main
+- [ ] Public update feed reports 0.4.12
+- [ ] Public updater artifact checksum matches the release artifact
+- [ ] Installed 0.4.11 client detects the 0.4.12 update
+
+## Package
+
+- Updater artifact: pending
+- Website installer: pending
+- Developer ID: `SEAN INMAN (VTZW6K32K4)`
+- Gatekeeper: pending
+- Stapled notarization ticket: pending
+- Packaged engine: pending

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "private": true,
   "description": "DoodleNote desktop app \u2014 private local capture, transcription, and AI meeting notes",
   "main": "./out/main/index.js",

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,15 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.12",
+    date: "August 7, 2026",
+    highlights: [
+      "Add your name in Settings so your side of transcripts is labeled consistently instead of You",
+      "Rename the other speaker once and apply that name throughout the entire meeting transcript",
+      "Generated meeting notes and Ask now use the resolved speaker names when attributing what people said",
+    ],
+  },
+  {
     version: "0.4.11",
     date: "August 3, 2026",
     highlights: [

--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,11 +1,11 @@
-version: 0.4.11
+version: 0.4.12
 files:
-  - url: DoodleNote-0.4.11-arm64-mac.zip
-    sha512: YKJRTme7ONEEDF2CnwyzOojeO+nRrs8MfwwQ4mwFHEM89nXH+LaLK4m7nNg/3kimh8R8yrsV79JHpIHa5SZ2Ig==
-    size: 170287455
-  - url: DoodleNote-0.4.11-arm64.dmg
-    sha512: 9ckyCmFj4Yyck8yIprYZY8kTOIz251Umf/hDUtIjhsCTeqd+xOBopwPF8mSBSUhxFzZ7l+jAqL6n01aAvwdttA==
-    size: 172180064
-path: DoodleNote-0.4.11-arm64-mac.zip
-sha512: YKJRTme7ONEEDF2CnwyzOojeO+nRrs8MfwwQ4mwFHEM89nXH+LaLK4m7nNg/3kimh8R8yrsV79JHpIHa5SZ2Ig==
-releaseDate: '2026-08-03T15:03:08.508Z'
+  - url: DoodleNote-0.4.12-arm64-mac.zip
+    sha512: qpe1n4WLc85Frfp7/GhEOiLrisdYQzYY4YJXs51VoqyXYHO5wN7f15lGa/XAVpPjLGAyveVuJj0adyJPXM4aBg==
+    size: 170317348
+  - url: DoodleNote-0.4.12-arm64.dmg
+    sha512: MQQkVyTo9gAFYIySvlwIf3erLwkvnrKuzEihd/q54RG93DII/PaCH8abMmKQNJgETSBDoAq7IRVENuAusE0qfw==
+    size: 172215086
+path: DoodleNote-0.4.12-arm64-mac.zip
+sha512: qpe1n4WLc85Frfp7/GhEOiLrisdYQzYY4YJXs51VoqyXYHO5wN7f15lGa/XAVpPjLGAyveVuJj0adyJPXM4aBg==
+releaseDate: '2026-08-07T18:59:49.914Z'


### PR DESCRIPTION
## Release Candidate v0.4.12

### Included

- [x] Stable speaker identities and per-meeting participant roster from PR #63
- [x] Configurable DoodleNote user name for transcript attribution
- [x] Rename the other speaker once across the full transcript
- [x] Resolved speaker names in generated notes and Ask prompts
- [x] Backward-compatible You/Them fallbacks across desktop, web, iOS, sync, export, connectors, and MCP readers
- [x] v0.4.12 version, changelog, and updater manifest

### Deferred

- Calendar-attendee seeding remains active in ONY-83 and is not claimed by this release
- Multi-speaker diarization, Slack Huddles, and conversational inference remain out of scope
- This release does not close ONY-83

### Verification

- `pnpm install --frozen-lockfile`
- 8 workspace typechecks passed
- 197 tests passed; 0 failed; 0 skipped after native packaging dependencies were available
- Swift transcription engine release build passed
- Production Electron and web builds passed
- Packaged app reports v0.4.12
- Strict nested code-signature verification passed
- Gatekeeper accepted as Notarized Developer ID
- Stapled notarization ticket validated
- Apple notarization submission `777c1a68-d8e7-45cf-b3f0-4e44b4a25d76` accepted
- Mounted DMG contains the signed app and Applications shortcut
- Local updater ZIP matches the generated SHA-512 manifest

### Package

- ZIP: `DoodleNote-0.4.12-arm64-mac.zip` — 170,317,348 bytes
- ZIP SHA-256: `6438a7d996467b73c519ce202fd7d43c33fd96aa2f79b8ef02ff4d3619ed605f`
- DMG: `DoodleNote-0.4.12-arm64.dmg` — 172,215,086 bytes
- DMG SHA-256: `6acdeee9767ec731597d6c546553d3b264319b57612d54ec7039bba97bb71d4d`

### Release boundary

The versioned artifacts are uploaded. Merge and production deployment of this PR activates v0.4.12 on the public updater feed. User explicitly authorized merge and publication in the release task.
