### PR TITLE
Add Linear authoring and delivery skills for Cloud Agents

### DIFF
--- a/.cursor/skills/linear-issue-authoring/SKILL.md
+++ b/.cursor/skills/linear-issue-authoring/SKILL.md
@@ -1,0 +1,374 @@
+---
+name: linear-issue-authoring
+description: Research and turn product ideas, feature requests, bugs, regressions, chores, spikes, and improvements into implementation-ready Linear issues for AI-assisted development, then rename the current Codex task to the confirmed primary issue. Use when the user asks to plan, spec, break down, or create Linear work before Codex, Claude, or another developer implements it.
+metadata:
+  author: Onyx Dev Labs
+  version: "1.2.0"
+---
+
+# Linear Issue Authoring
+
+Turn a user's product intent into researched, testable Linear issues that another human or AI agent can implement without rediscovering the problem or guessing at scope.
+
+This skill plans and creates work. It does not implement code, open pull requests, merge, deploy, publish, or release.
+
+Live issue creation requires repository access and a connected Linear app. Current external APIs, platform rules, or standards may also require web access.
+
+## Core Contract
+
+Use this operating model:
+
+`one independently reviewable issue = at most one accountable human at a time = one branch/worktree = one active editing session = one pull request`
+
+A `Ready` issue may remain unassigned when the implementer is not yet known. The accountable human is established either during authoring when explicitly selected or during the delivery claim. Never infer that the person authoring the issue will also implement it.
+
+Every implementation issue must contain an **Agent Build Contract v1**. The future implementation skill should be able to read that contract and determine what to build, where to investigate, how to verify it, and where its authority stops.
+
+## Operating Rules
+
+- Research before creating issues. Treat the user's request as product intent, not a complete technical specification.
+- Read current Linear, repository, and Git-host context before writing. Search for duplicate issues and existing branches, worktrees, commits, or pull requests that already represent the work.
+- Perform duplicate detection during research and again immediately before live creation. Never create a parallel issue because an earlier search became stale.
+- Keep the implementing human as the accountable Linear assignee. If no implementer is explicitly known, leave the issue unassigned for delivery claim rather than assigning the author by default. Record an AI agent as delegation metadata or an existing label only when the team's workflow supports it.
+- Create issues that are independently reviewable and normally deliverable through one focused pull request.
+- Prefer one complete issue over unnecessary fragmentation. Split only when work has separate dependencies, ownership, review boundaries, deployment risks, or independently valuable outcomes.
+- Separate shared foundations such as schemas, API contracts, shared components, generated clients, and dependency upgrades into prerequisite issues when several features depend on them.
+- Do not silently invent product behavior, priority, dates, estimates, root causes, customer impact, or technical facts. Mark uncertain information as an assumption or open question.
+- Distinguish confirmed evidence, reasonable inference, and unresolved questions.
+- Do not prescribe a speculative implementation when the outcome and constraints are sufficient. Technical notes guide investigation; acceptance criteria define success.
+- Do not put credentials, tokens, private keys, production secrets, personal data, or sensitive customer content into Linear.
+- If the user asked to create the issues and the scope is sufficiently clear, create them without requesting routine approval. Pause only for a material ambiguity that would change the product outcome, mutation target, security boundary, or issue structure.
+- Never claim an issue was created until a read-back from Linear confirms its identifier and fields.
+- After confirmed live creation, rename the current Codex task to the primary issue identifier and short title when the task-title tool is available. Do not rename from a draft, attempted creation, or unverified response.
+
+## Resolve the Working Context
+
+Infer or confirm these inputs before creation:
+
+- Product/project name
+- Repository and default branch
+- Linear workspace, team, and project
+- Request type: feature, bug, regression, improvement, chore, research spike, security, performance, or release work
+- Intended user and desired outcome
+- Affected platforms and delivery boundary: web, API, worker, macOS, Windows, iOS, Android, extension, integration, or infrastructure
+- Priority and target milestone/cycle, if the user supplied them or an established policy determines them
+- Accountable human owner, when explicitly known; otherwise mark the issue as available for authenticated delivery claim
+- Source evidence: user report, screenshot, logs, existing issue, support request, analytics, code, or documentation
+
+Use the current repository and established Linear project when they are unambiguous. Ask only when choosing incorrectly would create work in the wrong team/project or materially change the result.
+
+If Linear tools are unavailable, do not claim live creation. Explain that the Linear connection is required and return the finished issue draft only when that helps preserve the research.
+
+## Required Workflow
+
+Follow these steps in order.
+
+### 1. Read Linear First
+
+- Resolve the target workspace, team, project, available statuses, existing labels, members, milestones, and cycles as needed.
+- Search open, duplicate, canceled, and recently completed issues using the product name, requested behavior, affected surface, error text, expected result, and likely synonyms.
+- Read likely duplicates, parent issues, blockers, and related roadmap work.
+- Reuse existing labels and workflow states. Do not create new projects, teams, labels, cycles, or milestones unless they are necessary and within the user's request.
+- If an open issue already captures the same outcome, update or enrich that authoritative issue when within scope instead of creating parallel work.
+- If a completed issue has genuinely regressed, create a new regression issue and relate it to the original rather than reopening it silently.
+
+### 2. Research the Repository Read-Only
+
+Do not edit product code while authoring issues.
+
+- Read repository instructions such as `AGENTS.md`, `CLAUDE.md`, `README`, architecture notes, and contribution guidance.
+- Inspect Git status, branch, remotes, recent history, and relevant open work without overwriting local changes.
+- Search local and remote branches, worktrees, open and recently merged pull requests, and relevant commits for the issue intent, affected surface, error text, and any related issue IDs.
+- Use `rg` and `rg --files` to locate the affected routes, views, services, commands, schemas, migrations, tests, feature flags, deployment files, and release/version sources.
+- Identify current behavior and existing patterns from evidence.
+- Identify likely code areas, boundaries, integrations, data contracts, permissions, and regression surfaces.
+- Locate the repository's real test, lint, typecheck, build, packaging, and smoke-test conventions.
+- Record paths as investigation starting points, not a mandate to edit every named file.
+
+For a bug, reproduce it when safe and practical. If reproduction is unavailable, document the evidence and environment needed by the implementation agent. Never present a suspected root cause as confirmed.
+
+### 2A. Decide Whether Work Already Exists
+
+Classify each likely match before authoring:
+
+- **Exact open duplicate:** enrich the existing issue; do not create another.
+- **Partial overlap:** create a related sub-issue only for independently deliverable missing scope.
+- **Completed work that regressed:** create a linked regression issue with new evidence.
+- **Existing branch or PR without a Linear issue:** adopt and link the active lane when ownership and scope are clear; do not create competing implementation work.
+- **Materially different outcome:** create a separate issue and explicitly relate the work.
+
+Title similarity alone is not enough. Compare the desired outcome, affected product surface, repository, platform, evidence, scope, and acceptance criteria.
+
+### 3. Research External Requirements When Needed
+
+Use current primary sources when the request depends on an external API, operating-system rule, platform policy, library version, security standard, or vendor behavior that may have changed.
+
+- Prefer official documentation, specifications, or original research.
+- Capture only facts that affect scope, constraints, acceptance criteria, or testing.
+- Link the source in the issue when it will help implementation or review.
+- Clearly label conclusions inferred from sources.
+
+Do not browse merely to pad the issue. Research should reduce implementation uncertainty.
+
+### 4. Classify and Shape the Work
+
+Choose one of these shapes:
+
+- **Single issue:** one focused outcome that can normally be implemented and reviewed in one PR.
+- **Parent plus sub-issues:** a larger outcome with multiple independently implementable lanes.
+- **Prerequisite plus dependent issues:** shared foundation must merge before product work can proceed safely.
+- **Research spike followed by implementation:** a material technical or product unknown prevents testable implementation scope.
+
+Split work when any of these are true:
+
+- The issue mixes unrelated user outcomes.
+- Different repositories, platforms, or owners can deliver independently.
+- A schema/API/foundation change is shared by multiple downstream issues.
+- Migration, rollout, or security work needs separate review and rollback.
+- The expected diff is too broad for reliable review.
+- One portion can deliver value while another remains blocked.
+
+Do not create separate issues solely for ordinary coding, unit tests, documentation updates, or PR review when those are part of one deliverable's definition of done.
+
+### 5. Write Implementation-Ready Issues
+
+Use concise outcome-oriented titles:
+
+- Feature: `Add manual mailbox refresh`
+- Bug: `Prevent blank inbox after Gmail connection`
+- Performance: `Reduce initial dashboard load time`
+- Security: `Enforce tenant ownership on public quote access`
+
+Avoid vague titles such as `Fix sync`, `UI updates`, or `Improve app`.
+
+Every implementation issue description must use this structure:
+
+```markdown
+## Outcome
+What will be observably better, for whom, and why it matters.
+
+## Current Behavior / Evidence
+Confirmed current behavior, source of the request, reproduction evidence, logs,
+screenshots, relevant existing issues, or code-grounded findings.
+
+## Desired Behavior
+The user-visible or system-visible result. Describe behavior, not just files to edit.
+
+## Scope
+- In scope: ...
+- Out of scope: ...
+
+## Acceptance Criteria
+- [ ] Testable, observable criterion
+- [ ] Relevant failure, empty, loading, permission, persistence, or edge state
+- [ ] Regression-sensitive behavior that must remain intact
+
+## Technical Context
+- Repository: ...
+- Default branch: ...
+- Affected platform(s): ...
+- Likely investigation areas: ...
+- Existing patterns/contracts to preserve: ...
+- Data, API, authentication, authorization, tenant, audit, or migration notes: ...
+
+## Dependencies and Relationships
+- Parent: ...
+- Blocks / blocked by: ...
+- Related issues or PRs: ...
+
+## Verification Plan
+- Automated tests: ...
+- Static checks/build/package checks: ...
+- Manual QA: ...
+- Delivery-boundary verification: ...
+
+## Release and Risk Notes
+- Rollout, migration, backfill, feature flag, compatibility, rollback, monitoring,
+  packaging, signing, store submission, scheduler, or updater-feed considerations.
+
+## Assumptions and Open Questions
+- Confirmed assumption or unresolved question, with implementation impact.
+
+## Agent Build Contract v1
+- Issue type: ...
+- Accountable owner: `<named Linear human>` | `Unassigned until authenticated delivery claim`
+- Repository: ...
+- Base branch: ...
+- Target platform(s): ...
+- Required outcome: ...
+- Scope boundaries: ...
+- Required automated verification: ...
+- Required manual verification: ...
+- Agent stopping boundary: tested PR | merge | staging | production | packaged release
+- Issue completion boundary: merged | deployed | migrated | published | installed and verified
+- Dependencies that must land first: ...
+- Suggested branch pattern: `<developer>/<ISSUE-ID>-<short-slug>`
+- Suggested PR title: `[<ISSUE-ID>] <issue title>`
+- Claim required before editing: Yes
+- Expected shared or collision-prone areas: ...
+- Active prerequisite branches or PRs: ...
+- Required human reviewer and QA gate: ...
+- Status lifecycle: Ready -> In Progress -> In Review -> Ready to Merge -> Awaiting Release -> Done
+- External CRM/project reference: ...
+- Merge/deploy/release authority: Not granted by this issue; requires explicit user approval.
+- Completion evidence required: PR, checks, QA evidence, deployment/release evidence as applicable.
+```
+
+Remove empty boilerplate only when a section truly cannot apply. Preserve the Agent Build Contract on every implementation issue.
+
+## Type-Specific Requirements
+
+### Feature or Improvement
+
+Include:
+
+- Target user and user story or job to be done
+- Entry point and primary workflow
+- UI states when relevant: loading, empty, success, error, disabled, offline, permission denied
+- Edge cases and compatibility expectations
+- Accessibility, responsive behavior, telemetry, feature flags, and rollout when relevant
+- Behavior that must remain unchanged
+
+### Bug or Regression
+
+Include:
+
+- Actual behavior
+- Expected behavior
+- Reproduction steps
+- Environment, platform, version, account/provider, and frequency when known
+- User/business impact and severity evidence
+- Earliest known good/bad version or suspected regression window when known
+- Logs, screenshots, stack traces, or failing tests with sensitive data removed
+- Confirmed or suspected root cause, clearly labeled
+- Required regression test or explanation of why one is impractical
+
+### Research Spike
+
+Include:
+
+- Decision the research must enable
+- Questions to answer
+- Options and constraints to evaluate
+- Time or evidence boundary
+- Required artifact or recommendation
+- Explicit statement that production implementation is out of scope
+
+### Data, Security, Integration, or Infrastructure Work
+
+Include as applicable:
+
+- Schema and data-contract changes
+- Migration, backfill, validation, and rollback strategy
+- Authentication, authorization, tenant isolation, audit, privacy, and secret-handling constraints
+- Rate limits, retries, idempotency, concurrency, webhook/cron behavior, and partial failure
+- Compatibility and versioning requirements
+- Monitoring, alerting, operational ownership, and authoritative production checks
+
+## Acceptance Criteria Standard
+
+Acceptance criteria must be observable and falsifiable.
+
+Good:
+
+- `When a second sync request arrives while one is active, the API returns the existing job and does not start a duplicate provider sync.`
+- `A user without quote access receives a non-enumerating not-found response and no quote data is returned.`
+
+Weak:
+
+- `Sync works correctly.`
+- `Handle errors.`
+- `Make the UI clean.`
+
+Cover only relevant categories, but deliberately consider:
+
+- Happy path
+- Validation and failure states
+- Loading and empty states
+- Permissions and tenant isolation
+- Persistence after reload/restart
+- Duplicate requests, concurrency, and idempotency
+- Accessibility and responsive layouts
+- Backward compatibility and regression behavior
+- Audit/telemetry/monitoring
+- Packaging, deployment, or installed-client outcome
+
+## Linear Field Rules
+
+- **Team:** required; use the team that owns the code and workflow.
+- **Project:** use the product/project that owns the outcome.
+- **Status:** use `Ready` only when research, acceptance criteria, dependencies, repository, verification, and delivery boundaries are sufficient for implementation. A team-approved claim queue may contain unassigned `Ready` issues. Otherwise use `Backlog`, `Triage`, `Blocked`, or the team's equivalent.
+- **Priority:** derive from evidenced impact and urgency. Do not inflate priority because the request is new.
+- **Assignee:** use the explicitly named implementing human. If the implementer is unknown, leave the issue unassigned for delivery claim; never default to the authenticated authoring user merely because they created the issue.
+- **Labels:** reuse existing type, platform, component, risk, or agent-delegation labels. Avoid label sprawl.
+- **Estimate:** set only when the team uses estimates and the researched scope supports one.
+- **Cycle/milestone:** set only when an established plan or explicit user direction supports it.
+- **Relationships:** set parent, duplicate, related, blocks, and blocked-by relationships explicitly.
+
+## Create and Verify in Linear
+
+1. Explain the proposed grouping when creating multiple issues.
+2. Immediately before each live creation, repeat the Linear and Git-host duplicate search. If authoritative work appeared during research, stop creation and update or link that lane instead.
+3. Create the parent or prerequisite issue first.
+4. Create children or dependents with the proper project, team, explicitly known owner or unassigned claim state, labels, and relationship identifiers.
+5. Add explicit blocking relationships and preserve the intended delivery order.
+6. Read every created or updated issue back from Linear.
+7. Confirm title, description, status, project, assignee, labels, parent, dependencies, and URL. For an unassigned claim-pool issue, confirm that no accidental author assignment occurred.
+8. Correct material omissions before reporting completion.
+9. Select the primary issue for the current task:
+   - Use the only issue when one issue was created.
+   - Use the parent when a parent with sub-issues was created.
+   - For multiple unrelated issues, use the issue identified as the recommended first implementation lane.
+10. In the Codex app, call `set_thread_title` for the calling task with no explicit thread ID. Format the title as `<ISSUE-ID> (<short issue title>)`, for example `ONY-123 (Prevent blank inbox after Gmail connection)`.
+11. Build the task title only from the confirmed Linear identifier and title. Collapse whitespace, remove markdown/newlines, preserve the issue ID, and shorten the descriptive portion at a word boundary when needed to keep the complete task title at roughly 80 characters or fewer.
+12. Treat task renaming as a non-blocking convenience after successful issue creation. If the task-title tool is unavailable or the rename fails, preserve the created issues, report the naming gap, and never claim the task was renamed.
+
+Do not move a new issue to `In Progress`; implementation has not begun. Do not mark an issue `Done` based on issue creation or planning completeness.
+
+## Completion Report
+
+Return a compact handoff containing:
+
+- Created or updated issue IDs and links
+- Parent/child or dependency map
+- Team, project, status, priority, and accountable owner
+- Research performed and important evidence
+- Assumptions or unanswered questions that remain in the issues
+- Which issue should be implemented first
+- Whether every implementation issue contains Agent Build Contract v1
+- Whether ownership is explicitly assigned or available for authenticated delivery claim
+- Duplicate and active-work searches performed, including any existing issue, branch, worktree, or PR adopted instead
+- The resulting Codex task title, or a clear note that task renaming was unavailable or failed
+
+If creation was blocked by Linear access, distinguish the completed research/draft from the uncompleted external mutation.
+
+## Prompt Shapes
+
+Feature:
+
+```text
+Use linear-issue-authoring.
+
+Project: NARRA Mail
+Request: Add a manual mailbox refresh action.
+Why: Users need a way to request an immediate sync when waiting for a message.
+
+Research the current product and repository, check Linear for related work, decide
+whether this is one issue or a parent with sub-issues, and create implementation-ready
+Linear issues with Agent Build Contract v1. Do not implement the feature.
+```
+
+Bug:
+
+```text
+Use linear-issue-authoring.
+
+Project: NARRA Mail
+Problem: Some users see a blank inbox after connecting Gmail.
+Evidence: Screenshot attached; noticed after OAuth on iOS.
+Expected: Synced messages or an explicit loading, empty, or error state.
+
+Research and reproduce when safe, inspect related code/tests and Linear issues, then
+create the smallest implementation-ready bug issue set. Distinguish confirmed facts
+from suspected causes. Do not fix the bug.
+```

--- a/.cursor/skills/linear-issue-authoring/agents/openai.yaml
+++ b/.cursor/skills/linear-issue-authoring/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Linear Issue Authoring"
+  short_description: "Create deduplicated, claim-ready Linear issues."
+  default_prompt: "Use $linear-issue-authoring to research this request, search Linear and Git for existing work during research and again immediately before creation, create or update the minimum implementation-ready issue set with Agent Build Contract v1, leave ownership unassigned when no implementer is named, and rename the current Codex task to the confirmed primary issue. Do not implement the code."

--- a/.cursor/skills/linear-issue-delivery/SKILL.md
+++ b/.cursor/skills/linear-issue-delivery/SKILL.md
@@ -1,0 +1,440 @@
+---
+name: linear-issue-delivery
+description: Implement an approved Linear feature, bug, regression, improvement, chore, spike, security, performance, or infrastructure issue from Agent Build Contract v1 through an isolated Git branch/worktree, verification, pull request, review, and explicit merge or release gates. Use when the user asks Codex, Claude, or another development agent to build, fix, execute, or deliver a Linear issue.
+compatibility: Requires repository access and Git. Live Linear progress updates require a connected Linear app; pull-request work requires authenticated access to the Git hosting provider. Platform-specific builds may require the relevant SDK, signing identity, device, or deployment credentials.
+metadata:
+  author: Onyx Dev Labs
+  version: "1.1.0"
+---
+
+# Linear Issue Delivery
+
+Execute one implementation-ready Linear issue as one independently reviewable development lane.
+
+The normal stopping point is a tested pull request ready for human QA and review. Merging, deploying, publishing, store submission, updater publication, migration execution, and production release require explicit user authority.
+
+## Core Contract
+
+Use this operating model:
+
+`one Linear issue = one accountable human = one branch/worktree = one active editing agent = one pull request`
+
+The issue's **Agent Build Contract v1** is the delivery interface. Use its outcome, scope, acceptance criteria, repository, base branch, platforms, verification requirements, dependencies, agent stopping boundary, issue completion boundary, and completion evidence. For older contracts with only `Delivery boundary`, interpret it conservatively and never treat a PR-only agent stopping point as permission to mark the product work `Done`.
+
+The issue defines what success means. Repository evidence determines how to implement it safely. Neither the issue nor this skill overrides repository instructions or grants release authority.
+
+## Default Authority
+
+When the user invokes this skill for an issue, the agent is authorized to:
+
+- Read the issue, comments, relationships, and relevant Linear project context
+- Resolve the authenticated Linear human and claim an unassigned implementation-ready issue for that same human
+- Update ordinary implementation statuses and add concise progress/handoff comments
+- Inspect the repository and Git hosting state
+- Create or resume one isolated branch and worktree
+- Modify code and directly related tests/docs/configuration within issue scope
+- Run appropriate local verification
+- Commit, push, and open or update one pull request
+- Request the repository's configured automated and human review
+- Address in-scope review and CI findings on the same branch
+
+The agent is not authorized merely by issue assignment to:
+
+- Merge the pull request
+- Deploy to staging or production
+- Apply production migrations or backfills
+- Publish packages, desktop updater feeds, mobile builds, browser extensions, or store releases
+- Change repository protection, access, secrets, billing, DNS, or external customer data
+- Expand the issue into unrelated product work
+
+Perform those actions only when the user explicitly authorizes that delivery stage.
+
+## Operating Rules
+
+- Treat `main` or the repository's documented default branch as reviewed code. Do not commit directly to it unless the user explicitly requests that exception.
+- Preserve unrelated human and agent work. Never overwrite, discard, reset, or absorb unrelated dirty-worktree changes.
+- Never run two editing agents in the same directory, worktree, or branch.
+- The Linear assignee is always the accountable human, never Codex, Claude, or another AI agent. Record the AI agent separately in the claim comment or an established delegation label.
+- Resolve the authenticated Linear user with `get_user("me")` at the start of every delivery. Use `assignee: "me"` only after that identity is confirmed.
+- Never silently take over an issue assigned to another human. Require an explicit, verified ownership handoff and resume the authoritative branch and PR when safe.
+- Search for an existing issue branch, worktree, pull request, and active owner before creating another lane. Resume the authoritative lane when safe instead of duplicating work.
+- Follow repository instructions such as `AGENTS.md`, `CLAUDE.md`, contribution docs, architecture rules, generated-file policies, version rules, and required checks.
+- Keep the diff focused on the issue. Do not hide unrelated refactors inside feature or bug work.
+- Treat acceptance criteria as required behavior, not suggestions. Map each criterion to automated or manual evidence.
+- Do not present a suspected bug root cause, passing test, review approval, deployment, release, or live behavior as confirmed without authoritative evidence.
+- Do not put secrets, tokens, credentials, private keys, sensitive logs, or customer data into commits, PRs, Linear comments, or chat.
+- Ask only when a material ambiguity, access boundary, destructive action, or external mutation would change the result. Otherwise make evidence-based assumptions, record them, and continue.
+
+## Required Workflow
+
+Follow these stages in order. Do not skip a gate merely because code compiles or an agent reports success.
+
+### 1. Read and Validate the Linear Issue
+
+- Resolve the authenticated Linear user with `get_user("me")`. Record the returned user ID and display name as the prospective claimant; do not infer identity from the device, task title, Git configuration, or issue author.
+- Resolve the exact issue identifier and read the full issue, comments, parent/children, blockers, related issues, project, status, priority, assignee, and labels.
+- If the issue is unassigned, it is eligible for this authenticated human to claim after the remaining preflight succeeds. If it is assigned to the authenticated human, resume their authoritative lane. If it is assigned to anyone else, stop unless an explicit handoff has been authorized and recorded.
+- Confirm no other developer or agent is actively implementing the same lane. Search claim comments, local and remote branches, local worktrees, open and closed pull requests, and recent commits using the issue ID and likely branch names.
+- Read Agent Build Contract v1 and extract:
+  - Repository and base branch
+  - Issue type and target platforms
+  - Required outcome and scope boundaries
+  - Acceptance criteria
+  - Automated and manual verification
+  - Agent stopping boundary and issue completion boundary, or the conservative equivalent for an older contract
+  - Dependencies and required completion evidence
+- Confirm prerequisite issues/PRs have landed at the required boundary.
+- Search the Git host for an existing branch or PR containing the issue ID.
+- Compare likely shared or collision-prone areas against active pull requests, especially schemas, migrations, API contracts, authentication, shared UI, generated files, lockfiles, and release/version files.
+
+Do not start implementation when any of these are materially missing:
+
+- No testable outcome or acceptance criteria
+- Wrong or unresolved repository/team/project
+- A blocking dependency has not landed
+- A security, data, or permission decision would require guessing
+- The same issue is already active in another authoritative lane
+
+For small non-material omissions, infer from repository evidence and record the assumption in a Linear comment. For material gaps, leave the issue out of `In Progress`, document the blocker, and route it back through issue authoring or the accountable owner.
+
+If Linear is temporarily unavailable but the user supplies a complete exported issue and contract, implementation may continue only when the target and scope are unambiguous. Defer status updates and never claim they occurred.
+
+### 2. Inspect Repository and Delivery Context
+
+Before editing:
+
+- Confirm the repository root, remotes, current branch, status, existing worktrees, and recent relevant commits using non-destructive Git commands.
+- Read all applicable repository instructions completely.
+- Inspect the issue's likely code paths, existing patterns, tests, schemas, migrations, release configuration, and deployment boundaries.
+- Verify current external documentation when the implementation depends on a drift-prone API, SDK, platform rule, standard, or service behavior.
+- Identify shared files or foundations being modified by other active work.
+- When active work overlaps a shared foundation, establish dependency and merge order before editing. Worktree isolation prevents filesystem collisions, not incompatible contracts or integration conflicts.
+- Determine the repository's actual package manager and test, lint, typecheck, build, packaging, and smoke commands.
+
+If the primary checkout is dirty, preserve it and use a clean isolated worktree. Do not use destructive cleanup to make the task convenient.
+
+### 3. Create or Resume the Isolated Lane
+
+- Re-read the issue, assignee, status, claim comments, branches, worktrees, and pull requests immediately before claiming. If a competing claim or lane appeared, stop.
+- If unassigned, claim the issue with `assignee: "me"`; read it back and confirm the assignee ID matches the earlier `get_user("me")` result. If already assigned to that same authenticated user, continue. Never replace a different assignee as part of an ordinary claim.
+- Add a provisional `Implementation Claim` comment identifying the accountable human, AI agent, repository, intended base branch, task/session reference when available, and start time. Read the issue and comments back before creating a new lane.
+- Fetch or otherwise inspect the current remote base branch without overwriting local changes and record the base commit.
+- Use the branch pattern from Agent Build Contract v1, normally `<developer>/<ISSUE-ID>-<short-slug>`, where `<developer>` represents the authenticated human rather than the AI agent.
+- Create an isolated worktree from the latest safe base, or resume the existing issue worktree/branch after verifying ownership, assignee, and state.
+- Install dependencies using the repository's locked/reproducible method.
+- Run a targeted baseline check before edits when practical.
+- Record existing failures separately so they are not misrepresented as regressions caused by this issue.
+- Move the Linear issue to `In Progress` only after the implementation lane exists and work has actually begun. Update the provisional claim comment with the branch, base commit, session/worktree owner, expected touchpoints, baseline result, planned verification, and agent stopping boundary.
+- Read the issue and claim comment back. Confirm authenticated assignee, `In Progress` status, branch, and absence of a competing claim before the first product edit.
+
+Use this claim shape:
+
+```markdown
+## Implementation Claim
+- Owner: <authenticated Linear human>
+- Agent: Codex | Claude | other
+- Task/session: <reference when available>
+- Repository: <owner/repo>
+- Base branch and commit: <branch> @ <sha>
+- Branch: <developer/ISSUE-ID-slug>
+- Worktree/session owner: <human and agent>
+- Expected touchpoints: <shared areas or modules>
+- Baseline: <commands and result>
+- Planned verification: <commands and human QA>
+- Agent stopping boundary: <tested PR, merge, deployment, or release>
+- Started: <timestamp and timezone>
+```
+
+If claim setup fails before product edits and no earlier lane exists, document the failure and return the issue to the appropriate claimable or blocked state. Clear a newly added self-assignment only when it is still owned by the authenticated claimant and no work would be orphaned.
+
+Do not create an empty pull request solely to change status. For longer work, open a draft PR after the first meaningful commit; for shorter work, open it after local verification.
+
+### 4. Build According to Issue Type
+
+#### Feature or Improvement
+
+- Trace the existing user/system workflow before editing.
+- Implement the smallest coherent behavior that satisfies every in-scope acceptance criterion.
+- Reuse established architecture, state management, UI components, API patterns, accessibility conventions, analytics, and error handling.
+- Cover applicable loading, empty, success, error, disabled, offline, permission, responsive, and persistence states.
+- Preserve explicitly out-of-scope and regression-sensitive behavior.
+
+#### Bug or Regression
+
+- Reproduce the problem or create a failing test before changing behavior when practical.
+- Identify the root cause from evidence before choosing the fix.
+- Make the smallest safe root-cause fix; avoid broad refactors unless necessary for correctness.
+- Add a regression test, or document why an automated regression test is impractical and provide stronger manual evidence.
+- Verify the original reproduction no longer fails and adjacent workflows still behave correctly.
+
+#### Research Spike
+
+- Do not ship production behavior unless the issue explicitly includes it.
+- Produce the required decision artifact, experiment, benchmark, prototype, or recommendation.
+- Record evidence, options, tradeoffs, and the recommended next issue shape.
+- Use a docs-only PR only when the repository stores the required artifact there; otherwise deliver through the approved Linear/documentation surface.
+
+#### Data, Security, Integration, or Infrastructure
+
+- Preserve authentication, authorization, tenant isolation, audit, privacy, and secret-handling boundaries.
+- Make schema and API changes backward compatible when required.
+- Include safe migration, validation, backfill, rollback, retry, rate-limit, idempotency, concurrency, webhook/cron, and partial-failure handling as applicable.
+- Add monitoring or operational evidence when required by the contract.
+- Never apply a production migration or mutate live data without explicit authority.
+
+### 5. Verify Before Handoff
+
+Run verification proportional to risk and the repository's conventions:
+
+- The targeted failing/regression test or feature-specific tests
+- Relevant broader unit, integration, end-to-end, or contract tests
+- Lint, formatting, typecheck, static analysis, and generated-file checks
+- Production build or platform build
+- Migration/schema validation without applying live changes
+- Security/permission/tenant tests when affected
+- Packaging, signing, launch, device, simulator, browser, or extension checks when locally available and authorized
+- Manual smoke checks for observable behavior
+
+For each acceptance criterion, record one of:
+
+- Verified automatically with the exact command/test
+- Verified manually with steps and evidence
+- Requires accountable human QA
+- Blocked, with the exact reason
+
+Do not call the issue verified because one targeted test passed. Distinguish passing checks, skipped checks, unavailable environments, and pre-existing failures.
+
+### 6. Self-Review the Complete Diff
+
+Before commit and PR:
+
+- Review `git status`, the complete diff, and the changed-file list.
+- Confirm every changed file belongs to the issue.
+- Check for accidental generated artifacts, debug logging, disabled safeguards, secret material, unrelated formatting, and broad lockfile churn.
+- Re-check error handling, edge cases, permissions, data consistency, compatibility, and rollback implications.
+- Re-run focused verification after self-review fixes.
+- Stage only intended paths and create concise commits that explain the change.
+
+### 7. Push and Open the Pull Request
+
+- Push the issue branch without force-pushing over other work.
+- Open one PR into the contract's base branch, using `[<ISSUE-ID>] <issue title>` unless repository convention requires another format.
+- Link the Linear issue using the issue ID and supported integration syntax.
+- Move the Linear issue to `In Review` only after the PR exists and initial local verification is complete.
+- Add the PR link and verification summary to Linear when automation has not already done so.
+- Read the issue back after GitHub or Linear automation runs. If the status is already correct, do not create a competing update; otherwise apply the team-equivalent `In Review` state and verify it.
+
+Use this PR description shape:
+
+```markdown
+## Linear Issue
+- <ISSUE-ID and link>
+
+## Outcome
+- User/system outcome delivered
+
+## What Changed
+- Focused implementation summary
+
+## Bug Evidence / Root Cause
+- Reproduction, confirmed root cause, and regression protection when applicable
+
+## Acceptance Criteria Evidence
+- [x] Criterion — test or manual evidence
+- [ ] Criterion — requires human QA or is blocked
+
+## Verification
+- `exact command` — pass/fail/pre-existing failure
+- Manual checks and screenshots
+
+## Local QA
+1. Exact setup and launch command
+2. Happy-path steps
+3. Failure/edge/regression steps
+
+## Risks and Release Notes
+- Migration, rollout, rollback, compatibility, monitoring, packaging, signing,
+  scheduler, updater, store, or deployment notes
+
+## Follow-ups
+- Explicitly out-of-scope discoveries; no silent scope expansion
+```
+
+Request the repository's configured automated reviewer, such as Greptile or Gitlet, and the required human reviewers. Automated review supplements rather than replaces accountable human review and product QA.
+
+### 8. Human QA and Review Gate
+
+Provide the accountable developer with exact local QA instructions. For user-visible changes, include representative data/account setup, launch commands, happy path, failure states, regression checks, and expected results.
+
+Do not move to `Ready to Merge` until there is evidence that:
+
+- Required CI is green or any exception is explicitly accepted
+- Required human and automated reviews are complete
+- Actionable comments are resolved
+- Acceptance criteria are mapped to evidence
+- Required human product QA has passed
+- Migrations, rollout, and release risks are understood
+
+When these gates pass, move the issue to `Ready to Merge` and verify the status. Humans provide product QA and approval decisions; the agent performs and verifies the corresponding routine Linear status mutation.
+
+When review or CI findings arrive:
+
+- Classify each as a real issue, needs clarification, optional improvement, or likely false positive.
+- Fix real in-scope issues on the same branch and PR.
+- Explain false positives or deferred work in the PR when useful.
+- Re-run affected verification and update the evidence.
+- Request another review pass when needed.
+- Do not open a replacement PR unless the existing lane is unusable and the user approves the change.
+
+### 9. Merge Gate
+
+Stop after the reviewed PR unless the user explicitly authorizes merge.
+
+After explicit merge approval:
+
+- Re-read current PR state rather than relying on an earlier snapshot.
+- Confirm required CI, approvals, unresolved comments, base branch, mergeability, and intended files.
+- Confirm the approved merge strategy and whether merge automatically triggers a deployment.
+- Merge through the Git host using the repository's normal non-destructive method.
+- Verify the authoritative merge commit on the remote default branch.
+- Update Linear to the team's `Awaiting Release` or equivalent state when the issue completion boundary requires a later deployment, migration, package, publication, or installed-client result. If authoritative merge is the defined issue completion boundary, move to `Done` only after verifying the remote merge and required evidence.
+
+A successful merge does not prove a deployment, migration, scheduled job, updater feed, store build, or installed client outcome.
+
+### 10. Release and Delivery-Boundary Gate
+
+Perform deployment, production migration, packaging, notarization, signing, publishing, store submission, updater-feed changes, or installed-client verification only after explicit authority for that stage.
+
+Verify every relevant boundary separately:
+
+- Source: approved commit exists on the authoritative branch
+- CI/artifact: required build completed and the expected artifact exists
+- Database: migration/backfill is applied and validated in the intended environment
+- Hosting: the intended deployment is active
+- Scheduler/webhook: registration and real delivery evidence exist
+- Package/update feed/store: the new version is publicly available through the intended channel
+- Installed/runtime outcome: the actual client or production workflow reports and demonstrates the intended version/behavior
+- Rollback/monitoring: failure detection and recovery path are available when required
+
+Move the issue to `Done` only when the Agent Build Contract's issue completion boundary and completion evidence are satisfied. The agent stopping boundary controls authority and where the agent pauses; it never makes an unmerged PR complete. Otherwise use the team's `Awaiting Release`, `Ready for QA`, `In Review`, or equivalent state and document what remains.
+
+## Linear Status Model
+
+Map to the team's actual statuses, but preserve these meanings:
+
+- **Ready:** implementation-ready, dependencies resolved, no coding started; may be unassigned in an approved claim queue
+- **In Progress:** authenticated human claim is verified, isolated lane exists, and implementation is active
+- **In Review:** PR exists with initial local verification
+- **Ready to Merge:** CI, required reviews, resolved comments, acceptance evidence, and required human QA are complete
+- **Awaiting Release:** authoritative merge is verified but the issue completion boundary is not
+- **Done:** the issue completion boundary is authoritatively verified; a PR-only stopping boundary is never sufficient
+- **Blocked:** a named dependency, decision, access boundary, or environment prevents safe progress and is recorded with next owner/action
+
+The agent owns routine status maintenance after delivery is invoked. Apply each transition, read it back, and report failures; the human should not have to move ordinary statuses manually. If native Linear/GitHub automation already made the evidence-correct transition, verify it rather than writing a duplicate update. Do not use status changes as completion evidence; derive status from evidence.
+
+Failed CI or requested review changes normally remain `In Review`, not `Blocked`. Move from `Blocked` only after the named blocker is resolved and the authenticated owner resumes or releases the claim. Use the team's actual status names and preserve these meanings when exact labels differ.
+
+## Ownership Handoff and Claim Release
+
+Do not auto-steal a stale claim. When ownership changes:
+
+1. The current human stops their editing agent and pushes all intended commits.
+2. Record the branch, latest commit, PR, verification results, remaining work, risks, and blocker state in Linear.
+3. Reassign the issue only with explicit authority from the current owner or user controlling the workflow, then read back the new assignee.
+4. The new authenticated human verifies `get_user("me")`, resumes the same authoritative branch/worktree or creates a safe local worktree for that branch, and updates the existing PR.
+5. Do not open a replacement branch or PR unless the existing lane is unusable and that decision is recorded.
+
+After verified merge and any required evidence handoff, remove a task worktree only when it has no uncommitted or unpushed changes and repository or agent-host policy permits cleanup. Never delete an unmerged branch with unique work. Unblock dependent issues after the authoritative prerequisite boundary is verified.
+
+## Scope Discovery and Follow-ups
+
+When implementation reveals additional work:
+
+- Fix it in the current PR only when it is necessary to satisfy the issue safely and remains reviewable.
+- Record optional or unrelated improvements as suggested follow-ups in the PR/Linear comment.
+- Do not create new Linear issues or expand scope unless the user authorizes issue creation or invokes the issue-authoring workflow.
+- If a newly discovered prerequisite invalidates the current issue, stop, preserve the branch, document the blocker, and return the issue to the appropriate state.
+
+## Failure and Blocker Handling
+
+- Preserve work and report the exact command, error, environment, and next required action.
+- Separate pre-existing failures from failures introduced by the branch.
+- Do not weaken tests, permissions, validation, signing, or CI merely to make checks pass.
+- Do not leave an issue silently `In Progress` when work cannot continue.
+- When a material blocker prevents progress, move the issue to `Blocked` or the team equivalent, add the exact blocker and next required owner/action, and read the mutation back.
+- Do not mark the task blocked merely because work is difficult; exhaust safe in-scope diagnostics first.
+- Never claim that a status, comment, push, PR, review, merge, deploy, publish, or release occurred without authoritative read-back.
+
+## Completion Reports
+
+### PR Handoff
+
+Report:
+
+- Linear issue and current status
+- Authenticated Linear claimant and verified assignee
+- Branch/worktree and PR link
+- Outcome and files/components changed
+- Acceptance-criteria evidence
+- Exact verification commands and results
+- Local human QA instructions
+- Review/CI state
+- Risks, migrations, release requirements, and follow-ups
+- The next approval gate
+
+### Merge or Release Handoff
+
+Report only verified boundaries:
+
+- Merge commit and authoritative branch state
+- Deployment/artifact/migration/publication evidence as applicable
+- Production or installed-runtime verification
+- Linear final status and remaining gaps
+- Recovery/rollback notes when relevant
+
+## Prompt Shapes
+
+Implement through PR:
+
+```text
+Use linear-issue-delivery.
+
+Issue: ONYX-123
+
+Resolve the authenticated Linear user with get_user("me"), verify or claim the issue
+without taking over another human's lane, read the claim back, then implement the full
+Agent Build Contract v1 in an isolated worktree through local verification and one
+pull request. Maintain evidence-based Linear statuses automatically. Do not merge,
+deploy, publish, or release without explicit approval.
+```
+
+Address review:
+
+```text
+Use linear-issue-delivery for ONYX-123 and its existing PR.
+
+Read current CI and all unresolved review feedback, address real in-scope findings
+on the same branch, re-run affected verification, update the PR and Linear evidence,
+and stop at the merge gate.
+```
+
+Approve merge only:
+
+```text
+Use linear-issue-delivery for ONYX-123. Local QA is approved.
+
+Re-check current CI, approvals, comments, mergeability, and issue evidence. If all
+required gates pass, merge the existing PR using the repository's normal strategy,
+verify the remote merge commit, and update Linear. Do not perform a separate release
+or production mutation unless it is an automatic consequence already documented.
+```
+
+Approve release:
+
+```text
+Use linear-issue-delivery for ONYX-123. The PR is merged and release is approved.
+
+Follow the repository's release instructions, verify each required delivery boundary
+authoritatively, update Linear only from evidence, and report any boundary that remains
+incomplete. Do not claim installed or production success from CI alone.
+```

--- a/.cursor/skills/linear-issue-delivery/agents/openai.yaml
+++ b/.cursor/skills/linear-issue-delivery/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Linear Issue Delivery"
+  short_description: "Claim and deliver Linear issues through reviewed PRs."
+  default_prompt: "Use $linear-issue-delivery to resolve the authenticated Linear user, verify or claim this implementation-ready issue without taking over another human's lane, execute it in an isolated worktree through verification and one pull request, and maintain evidence-based Linear statuses automatically. Do not merge or release without explicit approval."


### PR DESCRIPTION
## Summary
- Add `.cursor/skills/linear-issue-authoring` and `.cursor/skills/linear-issue-delivery` so Cloud Agents can load these Onyx Linear workflows from the repo clone.
- Cloud Agent VMs do not receive laptop `~/.cursor/skills`; project skills are the reliable path.

## Test plan
- [ ] Start a Cloud Agent on this repo
- [ ] Confirm `.cursor/skills/linear-issue-authoring/SKILL.md` exists in the checkout
- [ ] Ask it to use linear-issue-authoring in read-only mode (do not create issues)
- [ ] Confirm it reads the skill file instead of falling back to generic Linear MCP only


Made with [Cursor](https://cursor.com)