### PR TITLE
[ONY-199] Harden CI and docs for a public repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,11 @@ jobs:
   # addons. Build the actual NSIS updater on every PR and retain it for native
   # Windows smoke testing. CSC_LINK/CSC_KEY_PASSWORD sign it automatically
   # once the repository's Authenticode certificate secrets are configured.
+  # Same-repo PRs and pushes to main only. Fork PRs still get the Ubuntu
+  # typecheck/test job; they must not produce a downloadable installer
+  # artifact from untrusted code.
   windows-package:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: windows-latest
     env:
       CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ engine/.swiftpm/
 .env
 .env.*
 !.env.example
+!apps/web/.env.example
 
 # local data
 *.db

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ DoodleNote captures your microphone and the other side of a call on your compute
 | iPhone          | In development | Native SwiftUI app targeting iOS 26; full recording verification requires a physical device.                          |
 | Web workspace   | In development | Next.js app for account linking, sync, sharing, workspaces, and hosted agent access.                                  |
 
-The repository moves quickly. See [GitHub Releases](https://github.com/Onyx-Dev-Labs/doodle-note/releases) and the versioned release checklists for exact shipped status.
+Signed desktop downloads are published at [doodlenote.ai](https://www.doodlenote.ai). Versioned release checklists in this repository (`RELEASE-v*.md`) record what shipped.
 
 ## Repository map
 
@@ -107,7 +107,12 @@ Recording and consent laws vary by location and organization. You are responsibl
 Issues and pull requests are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md), follow the [Code of Conduct](CODE_OF_CONDUCT.md), and report vulnerabilities through the private process in [SECURITY.md](SECURITY.md).
 
 Brand assets and usage notes live in [docs/BRAND.md](docs/BRAND.md).
+The DoodleNote name and mascot are reserved; see [TRADEMARK.md](TRADEMARK.md).
 
 ## License
 
-DoodleNote is available under the [MIT License](LICENSE).
+DoodleNote is available under the [MIT License](LICENSE). The local
+apps are free forever. Official cloud Sync at
+[doodlenote.ai](https://www.doodlenote.ai) is an optional paid backup
+and multi-device service ($10 / user / month). See
+[docs/OPEN-SOURCE.md](docs/OPEN-SOURCE.md).

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,17 @@
+# DoodleNote trademarks
+
+The [MIT License](LICENSE) covers the DoodleNote software. It does not
+grant rights to the DoodleNote brand.
+
+**DoodleNote**, the DoodleNote wordmark, and the doodle-dog mascot are
+trademarks of Onyx Dev Labs. Official brand assets and usage notes live
+in [docs/BRAND.md](docs/BRAND.md).
+
+You may fork and modify the software under MIT. A public fork, hosted
+service, or redistributed build must not use the DoodleNote name, logo,
+or mascot in a way that implies it is the official product unless Onyx
+Dev Labs has given written permission. Rename the project and replace
+the brand assets.
+
+Official downloads and hosted Sync are published at
+[doodlenote.ai](https://www.doodlenote.ai).

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,35 @@
+# Optional. Copy to .env.local (gitignored). The web app runs locally
+# without these: PGlite + a development-only auth fallback.
+# Official doodlenote.ai Sync billing uses the Stripe group in production.
+
+# Hosted database (unset = PGlite under packages/db/.pglite/)
+# DATABASE_URL=
+
+# Auth origin and production secret
+# BETTER_AUTH_URL=http://localhost:4040
+# BETTER_AUTH_SECRET=
+
+# Microsoft sign-in
+# MICROSOFT_CLIENT_ID=
+# MICROSOFT_CLIENT_SECRET=
+
+# Google sign-in
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+
+# Workspace invitations
+# RESEND_API_KEY=
+# INVITATION_FROM_EMAIL=
+
+# Official hosted Sync billing ($10 / user / month at doodlenote.ai)
+# STRIPE_SECRET_KEY=
+# STRIPE_PRICE_ID=
+# STRIPE_WEBHOOK_SECRET=
+
+# Voice features
+# TWILIO_ACCOUNT_SID=
+# TWILIO_API_KEY_SID=
+# TWILIO_API_KEY_SECRET=
+# TWILIO_TWIML_APP_SID=
+# TWILIO_CALLER_ID=
+# TWILIO_AUTH_TOKEN=

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -33,7 +33,23 @@ No external service is required for the basic local development path:
 | Billing                           | `STRIPE_SECRET_KEY`, `STRIPE_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`                                                                      |
 | Voice features                    | `TWILIO_ACCOUNT_SID`, `TWILIO_API_KEY_SID`, `TWILIO_API_KEY_SECRET`, `TWILIO_TWIML_APP_SID`, `TWILIO_CALLER_ID`, `TWILIO_AUTH_TOKEN` |
 
-Store local values in a gitignored `.env.local`. Do not commit production credentials or copy real account/meeting data into tests.
+A commented template is in [`.env.example`](.env.example). Store local
+values in a gitignored `.env.local`. Do not commit production
+credentials or copy real account/meeting data into tests.
+
+## Self-hosting Sync
+
+The same app can sync devices against a server you run. Local
+development already does this with PGlite when `DATABASE_URL` is
+unset. For a durable self-hosted instance you typically set
+`DATABASE_URL` and `BETTER_AUTH_SECRET` (and Blob/OAuth if you need
+those features).
+
+Official **$10 / user / month** Sync billing is the doodlenote.ai
+hosted product (Stripe). When Stripe keys are absent, entitlement
+checks pass so a self-hosted copy does not require DoodleNote's paid
+plan. This repository does not ship a production Docker Compose stack
+yet.
 
 ## Commands
 

--- a/docs/OPEN-SOURCE.md
+++ b/docs/OPEN-SOURCE.md
@@ -1,0 +1,273 @@
+# Making DoodleNote open source
+
+DoodleNote is already licensed as open source. The remaining work is to
+**make the GitHub repository public** without changing the product model
+you already ship: a free local app, and paid official cloud hosting for
+sync.
+
+This document is the launch plan and the policy to keep after launch.
+Tracking: [ONY-196](https://linear.app/onyxdevlabs/issue/ONY-196/publish-doodlenote-as-a-public-open-source-repository)
+(children [ONY-197](https://linear.app/onyxdevlabs/issue/ONY-197/confirm-mit-vs-server-relicense-before-going-public),
+[ONY-199](https://linear.app/onyxdevlabs/issue/ONY-199/harden-ci-and-docs-before-the-public-github-flip),
+[ONY-198](https://linear.app/onyxdevlabs/issue/ONY-198/scan-secrets-and-make-the-doodlenote-github-repository-public)).
+
+## What is already true
+
+Confirmed against `Onyx-Dev-Labs/doodle-note` on 2026-08-25:
+
+| Fact | Evidence |
+| --- | --- |
+| The code is MIT | Root [`LICENSE`](../LICENSE); GitHub reports `license.key = mit` |
+| The business model is already coded | [`apps/web/app/pricing/page.tsx`](../apps/web/app/pricing/page.tsx): Free forever + Sync at **$10 / user / month** |
+| Billing already exists | [`apps/web/lib/billing.ts`](../apps/web/lib/billing.ts): Stripe, 15-day trial, grandfathering; dormant when `STRIPE_SECRET_KEY` is unset |
+| Local capture does not need an account | README and pricing copy; desktop and iPhone store meetings locally |
+| Community files already exist | `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, issue and PR templates (added in PR #62, `docs: prepare DoodleNote for public contributors`) |
+| The repository is still **private** | GitHub `visibility: private`, `allow_forking: false`, 0 stars, 0 public forks |
+| GitHub Releases are empty | README links to them; `gh release` list is empty. Consumer downloads live on [doodlenote.ai](https://www.doodlenote.ai) |
+
+You do not need a second “free edition” codebase. The free product is the
+desktop and iPhone apps in this repo, running locally. The **$10 Sync
+plan stays**. It is the optional official backup and multi-device copy
+of notes you already sell; open-sourcing does not remove it.
+
+## Recommended model
+
+**Open-source the whole monorepo under MIT. Keep charging $10 / user /
+month for official hosted Sync at doodlenote.ai.** The local app is
+free forever. Sync is optional: only people who want a cloud backup,
+another device, or the web library pay.
+
+```text
+Free (MIT, no account)
+  macOS / Windows / iPhone capture, on-device transcription,
+  local or BYO AI notes, folders, search, local MCP
+
+Paid ($10 / user / month, official hosting)
+  Device linking, two-way sync, web library, share links,
+  team workspaces, hosted agent access
+```
+
+This is the Cal.com / Ghost / “hosted convenience” pattern, not
+open-core with a secret server. The paid product is **operations**:
+signed binaries, Neon, Blob storage, OAuth, Stripe, uptime, and
+support. The source for those features can be public.
+
+Self-hosting falls out of the current design: the web app already
+runs locally on PGlite without cloud credentials
+([`apps/web/README.md`](../apps/web/README.md)). When Stripe keys are
+absent, entitlement checks pass. That is the honest self-host path.
+You do not have to make Docker-compose day-one, but you should not
+block people who clone and run the web app themselves.
+
+### Why not hide the sync *source* (this is not “drop the $10 plan”)
+
+Keep the paid Sync product. Do not move `apps/web` into a private
+repo or a closed “pro” tree.
+
+- The monorepo already contains desktop, iOS, engine, **and** the
+  Next.js sync server, billing, and workspaces under one MIT license.
+- Customers still pay DoodleNote $10 / user / month for *your* hosted
+  backup, storage, and support. That charge is an API entitlement
+  (`402` + `needsSubscription`), not a secret codebase.
+- Hiding the server would be a large, trust-damaging refactor.
+  Contributors would see “the interesting server is closed.”
+- Privacy is the product. An inspectable sync server is a feature of
+  that pitch, not a liability.
+- A well-funded clone of a $10 notes-sync API is unlikely to beat
+  **DoodleNote** the brand, signed Mac/Windows builds, and the
+  existing user relationship.
+
+### The one decision you must make *before* going public
+
+MIT grants are irrevocable for the code you publish. You cannot later
+take the current tree private-in-effect by switching licenses.
+
+Choose one **now**:
+
+| Option | Use when | Cost |
+| --- | --- | --- |
+| **A. Keep MIT everywhere (recommended)** | You want maximum trust, GitHub stars, and “the app is free and open.” Moat is brand + hosting. | A competitor may host a compatible sync service. Stop them from calling it DoodleNote via trademark, not copyright. |
+| B. MIT clients + AGPL (or similar) for `apps/web` | You specifically fear a hosted fork of the sync server. | Must relicense **before** the visibility flip. Weaker “simple OSS” story. |
+| C. Source-available server (BSL / personal-use, Joplin-style) | You want to forbid commercial hosting of the server. | Not Open Source Initiative open source. Expect community pushback. |
+
+Closest analog: [Joplin](https://github.com/laurent22/joplin) ships
+local notes clients as open source and sells Joplin Cloud. They later
+moved clients to AGPL and put Joplin Server under a personal-use
+license. DoodleNote does not need that complexity to launch.
+
+**Recommendation: Option A.** Keep the MIT grant you already made.
+Protect the name and mascot separately (see Trademark below).
+
+### Decision recorded — 2026-08-25
+
+Sean Inman, on [ONY-197](https://linear.app/onyxdevlabs/issue/ONY-197/confirm-mit-vs-server-relicense-before-going-public):
+
+- **Option A.** MIT for the entire monorepo, including the sync server.
+- Official Sync stays **$10 / user / month** at doodlenote.ai as
+  optional cloud backup. The local app stays free forever.
+- Trademark reserved in [TRADEMARK.md](../TRADEMARK.md). No CLA.
+
+## What you are selling
+
+Say this in public, because the code already says it:
+
+1. **The notepad is free, and stays free.** Recording, transcription,
+   and note generation run on the user’s machine. No account. No
+   meeting caps.
+2. **$10 Sync is optional backup and multi-device copy.** People pay
+   only if they want DoodleNote to keep a hosted copy of their notes
+   (sync, web library, share links, workspaces). Local notes never
+   require this.
+3. **Canceling Sync does not delete local notes.** Entitlement is
+   enforced on device-link and sync routes (`402` +
+   `needsSubscription`), not on the local store.
+
+Do not put local transcription, local models, or the Electron/iOS
+capture loop behind a paywall later. That would contradict both the
+pricing page and the open-source promise. The $10 plan remains the
+paid cloud backup; it is not removed by going public.
+
+## Trademark is the real lock
+
+Copyright (MIT) lets anyone use the code. Trademark lets you stop
+someone shipping a fork as “DoodleNote.”
+
+Before going public:
+
+- Keep using “DoodleNote” as one word ([`docs/BRAND.md`](BRAND.md)).
+- Add a short `TRADEMARK.md` (or a License section) that says:
+  - MIT covers the software.
+  - “DoodleNote,” the wordmark, and the doodle-dog mascot are
+    trademarks of Onyx Dev Labs.
+  - Forks must rename and replace brand assets unless they have written
+    permission.
+- Consider a US trademark filing for DoodleNote if it is not already
+  filed. This is legal work, not a code change.
+
+Public-client OAuth IDs in the desktop app
+(`BUILT_IN_GOOGLE_CLIENT_ID`, `BUILT_IN_MS_CLIENT_ID`) are **not**
+secrets. They are intended to ship in the client. Forks should use
+their own OAuth apps; document that.
+
+## Launch sequence
+
+Do these in order. The visibility flip is last and is an organization
+owner action. It is not a pull request.
+
+### 1. Confirm license and trademark (human)
+
+- Keep MIT, or relicense `apps/web` *before* anyone can clone publicly.
+- Decide that official Sync remains $10 / user / month at
+  doodlenote.ai.
+- Write the trademark sentence into `TRADEMARK.md` or the README.
+
+### 2. Secret and log hygiene (blocker)
+
+Going public publishes **the entire git history** and, per
+[GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/setting-repository-visibility),
+**Actions history and logs**.
+
+- Run a full-history scan (gitleaks or GitHub secret scanning on the
+  private repo first). Rotate anything that ever appeared in git,
+  Actions logs, or committed `.env` files. Then scrub history only if
+  a live secret was committed; rotating is mandatory either way.
+- Current tree: no `.env` files tracked; `.gitignore` already excludes
+  them. Desktop Google/Microsoft client IDs are public-client IDs.
+- Delete or restrict old workflow runs if logs could contain notary
+  output, Stripe, Twilio, or Blob tokens.
+- Confirm GitHub Actions secrets stay as secrets
+  (`WINDOWS_CSC_LINK`, Apple notary, `BLOB_READ_WRITE_TOKEN`). Fork
+  pull requests do not receive repository secrets; keep it that way.
+
+History note: large `.next-agent` cache blobs exist in older commits
+(~17 MB). They are not in `HEAD`. Optional cleanup with
+`git filter-repo` shrinks clones; it is not required to go public.
+
+### 3. Harden CI for strangers (code)
+
+`.github/workflows/ci.yml` builds a Windows installer on **every**
+pull request and uploads it as an artifact. After the repo is public:
+
+- Fork PRs must not produce downloadable installers. Gate
+  `windows-package` (and artifact upload) on
+  `github.event.pull_request.head.repo.full_name == github.repository`.
+- In repo Settings → Actions: require approval for first-time
+  contributors.
+- iOS uses `macos-26` on path-filtered PRs; keep that path filter.
+
+### 4. Docs that public users will hit immediately
+
+- Add `apps/web/.env.example` listing the optional groups already
+  documented in [`apps/web/README.md`](../apps/web/README.md)
+  (`.gitignore` already has `!.env.example`, but the file is missing).
+- Add a short “Self-hosting Sync” section: clone, `pnpm --filter web
+  dev`, PGlite default, what production needs (`DATABASE_URL`,
+  `BETTER_AUTH_*`, Blob). Official Stripe billing is doodlenote.ai
+  only.
+- Point README “GitHub Releases” at reality: either start publishing
+  checksummed GitHub Releases, or link downloads to doodlenote.ai so
+  the empty Releases page is not the first 404.
+- Link this document from the README License section.
+
+### 5. GitHub settings on the flip day
+
+Organization owner, after steps 1–4:
+
+1. Settings → Code security: enable secret scanning, push protection,
+   Dependabot alerts, and private vulnerability reporting (SECURITY.md
+   already points at the advisory form).
+2. Settings → General: disable Wiki (spam surface; `hasWikiEnabled`
+   is currently on). Enable Discussions if you want a support forum
+   separate from issues.
+3. Settings → Actions: “Require approval for first-time contributors.”
+4. Protect `main`: required PR, required CI, no force-push.
+5. Danger Zone → Change visibility → **Make public**.
+   Confirm you understand: anyone can view and fork; Actions logs
+   become public; push rulesets are disabled
+   ([GitHub docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/setting-repository-visibility)).
+6. Check the [community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories)
+   (`/community`). README, license, CoC, contributing, security, and
+   issue templates should already check out.
+7. Create the first GitHub Release (even if artifacts stay on
+   doodlenote.ai) so the Releases URL in the README is not empty.
+8. Announce: README badge already claims MIT; website pricing already
+   matches. Add a changelog line and a link from doodlenote.ai to the
+   public repo.
+
+Do not transfer the repo out of `Onyx-Dev-Labs` unless you are
+creating a dedicated `doodlenote` GitHub org. Either is fine; stay
+put for launch.
+
+## What not to do
+
+- Do not rewrite history after the repo is public except for a
+  documented secret incident.
+- Do not open-source signing certificates, notary keys, Stripe live
+  keys, or customer meeting data. They are not in this tree.
+- Do not add a CLA unless you expect to relicense. CONTRIBUTING.md
+  already states contributions are MIT. A CLA is extra friction.
+- Do not hide `apps/web` in a private repo “just in case.” The billing
+  gate is an API check, not repository visibility.
+- Do not promise GitHub Releases until you publish one.
+
+## Contributor and maintainer load
+
+Public issues will include “it didn’t record Zoom,” feature ideas, and
+the occasional security report. You already have templates that force
+a privacy checkbox and route vulns to advisories. Keep Linear as the
+internal tracker; GitHub Issues as the public inbox. Do not sync
+customer meeting content into either.
+
+## Success
+
+DoodleNote is open source when:
+
+- [ ] `https://github.com/Onyx-Dev-Labs/doodle-note` is public and
+      cloneable without auth
+- [ ] LICENSE remains MIT (or a documented pre-launch relicense)
+- [ ] TRADEMARK.md (or equivalent) reserves the name and mascot
+- [ ] Free local app still requires no account
+- [ ] Official Sync is still $10 / user / month at doodlenote.ai
+- [ ] Fork PRs cannot upload Windows installers
+- [ ] Secret scanning and private vulnerability reporting are on
+- [ ] Website and README both link to the public repository


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linear Issue
- [ONY-199](https://linear.app/onyxdevlabs/issue/ONY-199/harden-ci-and-docs-before-the-public-github-flip)
- Completes hardening for [ONY-196](https://linear.app/onyxdevlabs/issue/ONY-196/publish-doodlenote-as-a-public-open-source-repository)
- License decision already recorded on [ONY-197](https://linear.app/onyxdevlabs/issue/ONY-197/confirm-mit-vs-server-relicense-before-going-public)

## Outcome
- Fork pull requests no longer build or upload a Windows installer
- Trademark reservation, env example, self-host notes, and honest download links are in the repo

## What Changed
- Gate `windows-package` (including `upload-artifact`) on same-repo PRs and pushes to `main`
- Add `TRADEMARK.md`
- Add `apps/web/.env.example` and un-ignore it
- Point README downloads at doodlenote.ai instead of empty GitHub Releases
- Document self-hosting Sync vs official $10 hosted billing
- Land `docs/OPEN-SOURCE.md` with the MIT + $10 Sync decision

## Acceptance Criteria Evidence
- [x] Fork PRs do not run `windows-package` or upload installers — job `if:` is `github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository`; artifact upload is inside that job
- [x] Same-repo PRs and `main` pushes still run the job
- [x] Trademark reservation is in `TRADEMARK.md`
- [x] `apps/web/.env.example` exists and matches the README variable groups
- [x] README download pointer is doodlenote.ai, not an empty Releases page
- [x] `pnpm --filter desktop typecheck` — pass
- [x] `pnpm --filter web typecheck` — pass

## Verification
- `pnpm --filter desktop typecheck` — pass
- `pnpm --filter web typecheck` — pass
- Workflow YAML reviewed: packaging and upload-artifact share the same gated job

## Risks and Release Notes
- First-time Windows contributors from forks will not get an installer artifact until a maintainer pushes the branch in-repo or re-runs after merge
- Does not change GitHub visibility (ONY-198)

## Follow-ups
- ONY-198 secret scan + make public after this merges
- PR #66 is the earlier plan-only doc PR and is superseded by this branch for `docs/OPEN-SOURCE.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9ac0748-311b-4c52-9892-341b36c3bbd3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9ac0748-311b-4c52-9892-341b36c3bbd3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

