### PR TITLE
Point doodlenote.ai and OPEN-SOURCE.md at the public repo

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -18,7 +18,7 @@ const REASONS = [
   },
   {
     title: "Free, without a catch",
-    body: "Unlimited meetings, transcripts, AI notes, and search on your device — no account required. Pay only if you want your notes synced across devices.",
+    body: "Unlimited meetings, transcripts, AI notes, and search on your device — no account required. The apps are MIT open source. Pay only if you want your notes synced across devices.",
   },
 ];
 

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -5,6 +5,7 @@ import {
   buttonPrimary,
   DoodleStroke,
   DownloadButtons,
+  GITHUB_REPO,
   navLinkClass,
   navPillClass,
   SiteFooter,
@@ -54,6 +55,10 @@ const FAQ = [
     q: "Do I need a ChatGPT or Claude subscription?",
     a: "No. DoodleNote downloads a local model in-app that writes your notes for free. If you prefer a frontier model, you can plug in your own OpenAI or Anthropic API key.",
   },
+  {
+    q: "Is DoodleNote open source?",
+    a: "Yes. The whole monorepo — desktop, iPhone, and the sync server — is MIT at github.com/Onyx-Dev-Labs/doodle-note. Official hosted Sync at doodlenote.ai is still $10 / user / month. Forks must not use the DoodleNote name or mascot.",
+  },
 ];
 
 function FeatureList({ items }: { items: string[] }) {
@@ -83,6 +88,14 @@ export default function PricingPage() {
             <Link href="/changelog" className={navLinkClass}>
               What&rsquo;s new
             </Link>
+            <a
+              href={GITHUB_REPO}
+              className={navLinkClass}
+              rel="noreferrer"
+              target="_blank"
+            >
+              GitHub
+            </a>
             <Link href="/login" className={navPillClass}>
               Sign in
             </Link>

--- a/apps/web/app/ui.tsx
+++ b/apps/web/app/ui.tsx
@@ -13,6 +13,8 @@ export const DOWNLOADS = {
   win: "/download/win",
 };
 
+export const GITHUB_REPO = "https://github.com/Onyx-Dev-Labs/doodle-note";
+
 /* Shared control styles — keep every page speaking the same visual language. */
 export const inputClass =
   "w-full rounded-lg border border-sand bg-card px-3 py-2 text-sm text-ink placeholder:text-stone focus-visible:border-sage focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-sage-deep";
@@ -60,6 +62,14 @@ export function SiteHeader({ nav }: { nav?: React.ReactNode }) {
             <Link href="/pricing" className={navLinkClass}>
               Pricing
             </Link>
+            <a
+              href={GITHUB_REPO}
+              className={navLinkClass}
+              rel="noreferrer"
+              target="_blank"
+            >
+              GitHub
+            </a>
             <Link href="/login" className={navPillClass}>
               Sign in
             </Link>
@@ -82,6 +92,14 @@ export function SiteFooter() {
           <Link href="/changelog" className="hover:text-ink">
             What&rsquo;s new
           </Link>
+          <a
+            href={GITHUB_REPO}
+            className="hover:text-ink"
+            rel="noreferrer"
+            target="_blank"
+          >
+            GitHub
+          </a>
           <Link href="/login" className="hover:text-ink">
             Sign in
           </Link>

--- a/docs/OPEN-SOURCE.md
+++ b/docs/OPEN-SOURCE.md
@@ -1,41 +1,42 @@
-# Making DoodleNote open source
+# DoodleNote open source
 
-DoodleNote is already licensed as open source. The remaining work is to
-**make the GitHub repository public** without changing the product model
-you already ship: a free local app, and paid official cloud hosting for
-sync.
+The repository is **public** as of 2026-08-25:
+[`https://github.com/Onyx-Dev-Labs/doodle-note`](https://github.com/Onyx-Dev-Labs/doodle-note).
 
-This document is the launch plan and the policy to keep after launch.
-Tracking: [ONY-196](https://linear.app/onyxdevlabs/issue/ONY-196/publish-doodlenote-as-a-public-open-source-repository)
+The product model did not change: a free local app under MIT, and paid
+official cloud hosting for Sync at [doodlenote.ai](https://www.doodlenote.ai).
+
+Launch tracking: [ONY-196](https://linear.app/onyxdevlabs/issue/ONY-196/publish-doodlenote-as-a-public-open-source-repository)
 (children [ONY-197](https://linear.app/onyxdevlabs/issue/ONY-197/confirm-mit-vs-server-relicense-before-going-public),
 [ONY-199](https://linear.app/onyxdevlabs/issue/ONY-199/harden-ci-and-docs-before-the-public-github-flip),
 [ONY-198](https://linear.app/onyxdevlabs/issue/ONY-198/scan-secrets-and-make-the-doodlenote-github-repository-public)).
 
-## What is already true
+## What is true
 
 Confirmed against `Onyx-Dev-Labs/doodle-note` on 2026-08-25:
 
 | Fact | Evidence |
 | --- | --- |
+| The repository is public | GitHub `visibility: public`; anonymous `git ls-remote` works |
 | The code is MIT | Root [`LICENSE`](../LICENSE); GitHub reports `license.key = mit` |
 | The business model is already coded | [`apps/web/app/pricing/page.tsx`](../apps/web/app/pricing/page.tsx): Free forever + Sync at **$10 / user / month** |
 | Billing already exists | [`apps/web/lib/billing.ts`](../apps/web/lib/billing.ts): Stripe, 15-day trial, grandfathering; dormant when `STRIPE_SECRET_KEY` is unset |
 | Local capture does not need an account | README and pricing copy; desktop and iPhone store meetings locally |
-| Community files already exist | `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, issue and PR templates (added in PR #62, `docs: prepare DoodleNote for public contributors`) |
-| The repository is still **private** | GitHub `visibility: private`, `allow_forking: false`, 0 stars, 0 public forks |
-| GitHub Releases are empty | README links to them; `gh release` list is empty. Consumer downloads live on [doodlenote.ai](https://www.doodlenote.ai) |
+| Community files exist | `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, issue and PR templates |
+| Signed downloads are not on GitHub Releases | Consumer downloads live on [doodlenote.ai](https://www.doodlenote.ai) |
+| Fork PRs cannot upload Windows installers | `windows-package` in `.github/workflows/ci.yml` is gated to this repository |
 
 You do not need a second “free edition” codebase. The free product is the
 desktop and iPhone apps in this repo, running locally. The **$10 Sync
 plan stays**. It is the optional official backup and multi-device copy
 of notes you already sell; open-sourcing does not remove it.
 
-## Recommended model
+## Model
 
-**Open-source the whole monorepo under MIT. Keep charging $10 / user /
-month for official hosted Sync at doodlenote.ai.** The local app is
-free forever. Sync is optional: only people who want a cloud backup,
-another device, or the web library pay.
+**The whole monorepo is MIT. Official hosted Sync is $10 / user /
+month at doodlenote.ai.** The local app is free forever. Sync is
+optional: only people who want a cloud backup, another device, or the
+web library pay.
 
 ```text
 Free (MIT, no account)
@@ -50,16 +51,15 @@ Paid ($10 / user / month, official hosting)
 This is the Cal.com / Ghost / “hosted convenience” pattern, not
 open-core with a secret server. The paid product is **operations**:
 signed binaries, Neon, Blob storage, OAuth, Stripe, uptime, and
-support. The source for those features can be public.
+support. The source for those features is public.
 
 Self-hosting falls out of the current design: the web app already
 runs locally on PGlite without cloud credentials
 ([`apps/web/README.md`](../apps/web/README.md)). When Stripe keys are
 absent, entitlement checks pass. That is the honest self-host path.
-You do not have to make Docker-compose day-one, but you should not
-block people who clone and run the web app themselves.
+Official Stripe billing is doodlenote.ai only.
 
-### Why not hide the sync *source* (this is not “drop the $10 plan”)
+### Why the sync source stays public
 
 Keep the paid Sync product. Do not move `apps/web` into a private
 repo or a closed “pro” tree.
@@ -69,34 +69,11 @@ repo or a closed “pro” tree.
 - Customers still pay DoodleNote $10 / user / month for *your* hosted
   backup, storage, and support. That charge is an API entitlement
   (`402` + `needsSubscription`), not a secret codebase.
-- Hiding the server would be a large, trust-damaging refactor.
-  Contributors would see “the interesting server is closed.”
 - Privacy is the product. An inspectable sync server is a feature of
   that pitch, not a liability.
 - A well-funded clone of a $10 notes-sync API is unlikely to beat
   **DoodleNote** the brand, signed Mac/Windows builds, and the
   existing user relationship.
-
-### The one decision you must make *before* going public
-
-MIT grants are irrevocable for the code you publish. You cannot later
-take the current tree private-in-effect by switching licenses.
-
-Choose one **now**:
-
-| Option | Use when | Cost |
-| --- | --- | --- |
-| **A. Keep MIT everywhere (recommended)** | You want maximum trust, GitHub stars, and “the app is free and open.” Moat is brand + hosting. | A competitor may host a compatible sync service. Stop them from calling it DoodleNote via trademark, not copyright. |
-| B. MIT clients + AGPL (or similar) for `apps/web` | You specifically fear a hosted fork of the sync server. | Must relicense **before** the visibility flip. Weaker “simple OSS” story. |
-| C. Source-available server (BSL / personal-use, Joplin-style) | You want to forbid commercial hosting of the server. | Not Open Source Initiative open source. Expect community pushback. |
-
-Closest analog: [Joplin](https://github.com/laurent22/joplin) ships
-local notes clients as open source and sells Joplin Cloud. They later
-moved clients to AGPL and put Joplin Server under a personal-use
-license. DoodleNote does not need that complexity to launch.
-
-**Recommendation: Option A.** Keep the MIT grant you already made.
-Protect the name and mascot separately (see Trademark below).
 
 ### Decision recorded — 2026-08-25
 
@@ -107,9 +84,10 @@ Sean Inman, on [ONY-197](https://linear.app/onyxdevlabs/issue/ONY-197/confirm-mi
   optional cloud backup. The local app stays free forever.
 - Trademark reserved in [TRADEMARK.md](../TRADEMARK.md). No CLA.
 
-## What you are selling
+MIT grants are irrevocable for the code you publish. Do not try to
+take the current tree private-in-effect by switching licenses later.
 
-Say this in public, because the code already says it:
+## What you are selling
 
 1. **The notepad is free, and stays free.** Recording, transcription,
    and note generation run on the user’s machine. No account. No
@@ -124,119 +102,43 @@ Say this in public, because the code already says it:
 
 Do not put local transcription, local models, or the Electron/iOS
 capture loop behind a paywall later. That would contradict both the
-pricing page and the open-source promise. The $10 plan remains the
-paid cloud backup; it is not removed by going public.
+pricing page and the open-source promise.
 
 ## Trademark is the real lock
 
 Copyright (MIT) lets anyone use the code. Trademark lets you stop
 someone shipping a fork as “DoodleNote.”
 
-Before going public:
-
 - Keep using “DoodleNote” as one word ([`docs/BRAND.md`](BRAND.md)).
-- Add a short `TRADEMARK.md` (or a License section) that says:
-  - MIT covers the software.
-  - “DoodleNote,” the wordmark, and the doodle-dog mascot are
-    trademarks of Onyx Dev Labs.
-  - Forks must rename and replace brand assets unless they have written
-    permission.
+- [TRADEMARK.md](../TRADEMARK.md) already says: MIT covers the
+  software; “DoodleNote,” the wordmark, and the doodle-dog mascot are
+  trademarks of Onyx Dev Labs; forks must rename and replace brand
+  assets unless they have written permission.
 - Consider a US trademark filing for DoodleNote if it is not already
   filed. This is legal work, not a code change.
 
 Public-client OAuth IDs in the desktop app
 (`BUILT_IN_GOOGLE_CLIENT_ID`, `BUILT_IN_MS_CLIENT_ID`) are **not**
 secrets. They are intended to ship in the client. Forks should use
-their own OAuth apps; document that.
+their own OAuth apps.
 
-## Launch sequence
+## Remaining owner settings
 
-Do these in order. The visibility flip is last and is an organization
-owner action. It is not a pull request.
-
-### 1. Confirm license and trademark (human)
-
-- Keep MIT, or relicense `apps/web` *before* anyone can clone publicly.
-- Decide that official Sync remains $10 / user / month at
-  doodlenote.ai.
-- Write the trademark sentence into `TRADEMARK.md` or the README.
-
-### 2. Secret and log hygiene (blocker)
-
-Going public publishes **the entire git history** and, per
-[GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/setting-repository-visibility),
-**Actions history and logs**.
-
-- Run a full-history scan (gitleaks or GitHub secret scanning on the
-  private repo first). Rotate anything that ever appeared in git,
-  Actions logs, or committed `.env` files. Then scrub history only if
-  a live secret was committed; rotating is mandatory either way.
-- Current tree: no `.env` files tracked; `.gitignore` already excludes
-  them. Desktop Google/Microsoft client IDs are public-client IDs.
-- Delete or restrict old workflow runs if logs could contain notary
-  output, Stripe, Twilio, or Blob tokens.
-- Confirm GitHub Actions secrets stay as secrets
-  (`WINDOWS_CSC_LINK`, Apple notary, `BLOB_READ_WRITE_TOKEN`). Fork
-  pull requests do not receive repository secrets; keep it that way.
-
-History note: large `.next-agent` cache blobs exist in older commits
-(~17 MB). They are not in `HEAD`. Optional cleanup with
-`git filter-repo` shrinks clones; it is not required to go public.
-
-### 3. Harden CI for strangers (code)
-
-`.github/workflows/ci.yml` builds a Windows installer on **every**
-pull request and uploads it as an artifact. After the repo is public:
-
-- Fork PRs must not produce downloadable installers. Gate
-  `windows-package` (and artifact upload) on
-  `github.event.pull_request.head.repo.full_name == github.repository`.
-- In repo Settings → Actions: require approval for first-time
-  contributors.
-- iOS uses `macos-26` on path-filtered PRs; keep that path filter.
-
-### 4. Docs that public users will hit immediately
-
-- Add `apps/web/.env.example` listing the optional groups already
-  documented in [`apps/web/README.md`](../apps/web/README.md)
-  (`.gitignore` already has `!.env.example`, but the file is missing).
-- Add a short “Self-hosting Sync” section: clone, `pnpm --filter web
-  dev`, PGlite default, what production needs (`DATABASE_URL`,
-  `BETTER_AUTH_*`, Blob). Official Stripe billing is doodlenote.ai
-  only.
-- Point README “GitHub Releases” at reality: either start publishing
-  checksummed GitHub Releases, or link downloads to doodlenote.ai so
-  the empty Releases page is not the first 404.
-- Link this document from the README License section.
-
-### 5. GitHub settings on the flip day
-
-Organization owner, after steps 1–4:
+These are GitHub organization-owner clicks, not pull requests:
 
 1. Settings → Code security: enable secret scanning, push protection,
-   Dependabot alerts, and private vulnerability reporting (SECURITY.md
-   already points at the advisory form).
-2. Settings → General: disable Wiki (spam surface; `hasWikiEnabled`
-   is currently on). Enable Discussions if you want a support forum
-   separate from issues.
+   Dependabot alerts, and private vulnerability reporting
+   (`SECURITY.md` already points at the advisory form).
+2. Settings → General: disable Wiki (spam surface; it is still on).
+   Enable Discussions only if you want a support forum separate from
+   issues.
 3. Settings → Actions: “Require approval for first-time contributors.”
 4. Protect `main`: required PR, required CI, no force-push.
-5. Danger Zone → Change visibility → **Make public**.
-   Confirm you understand: anyone can view and fork; Actions logs
-   become public; push rulesets are disabled
-   ([GitHub docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/setting-repository-visibility)).
-6. Check the [community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories)
-   (`/community`). README, license, CoC, contributing, security, and
-   issue templates should already check out.
-7. Create the first GitHub Release (even if artifacts stay on
-   doodlenote.ai) so the Releases URL in the README is not empty.
-8. Announce: README badge already claims MIT; website pricing already
-   matches. Add a changelog line and a link from doodlenote.ai to the
-   public repo.
+5. Close or mark superseded the leftover plan-only PR #66. Hardening
+   landed in #67.
 
 Do not transfer the repo out of `Onyx-Dev-Labs` unless you are
-creating a dedicated `doodlenote` GitHub org. Either is fine; stay
-put for launch.
+creating a dedicated `doodlenote` GitHub org.
 
 ## What not to do
 
@@ -245,29 +147,30 @@ put for launch.
 - Do not open-source signing certificates, notary keys, Stripe live
   keys, or customer meeting data. They are not in this tree.
 - Do not add a CLA unless you expect to relicense. CONTRIBUTING.md
-  already states contributions are MIT. A CLA is extra friction.
+  already states contributions are MIT.
 - Do not hide `apps/web` in a private repo “just in case.” The billing
   gate is an API check, not repository visibility.
-- Do not promise GitHub Releases until you publish one.
+- Do not promise GitHub Releases until you publish one. Downloads stay
+  on doodlenote.ai.
 
 ## Contributor and maintainer load
 
 Public issues will include “it didn’t record Zoom,” feature ideas, and
-the occasional security report. You already have templates that force
-a privacy checkbox and route vulns to advisories. Keep Linear as the
-internal tracker; GitHub Issues as the public inbox. Do not sync
-customer meeting content into either.
+the occasional security report. Templates already force a privacy
+checkbox and route vulns to advisories. Keep Linear as the internal
+tracker; GitHub Issues as the public inbox. Do not sync customer
+meeting content into either.
 
-## Success
+## Status
 
-DoodleNote is open source when:
-
-- [ ] `https://github.com/Onyx-Dev-Labs/doodle-note` is public and
+- [x] `https://github.com/Onyx-Dev-Labs/doodle-note` is public and
       cloneable without auth
-- [ ] LICENSE remains MIT (or a documented pre-launch relicense)
-- [ ] TRADEMARK.md (or equivalent) reserves the name and mascot
-- [ ] Free local app still requires no account
-- [ ] Official Sync is still $10 / user / month at doodlenote.ai
-- [ ] Fork PRs cannot upload Windows installers
-- [ ] Secret scanning and private vulnerability reporting are on
-- [ ] Website and README both link to the public repository
+- [x] LICENSE remains MIT
+- [x] TRADEMARK.md reserves the name and mascot
+- [x] Free local app still requires no account
+- [x] Official Sync is still $10 / user / month at doodlenote.ai
+- [x] Fork PRs cannot upload Windows installers
+- [x] README and the marketing site both link to the public repository
+- [ ] Secret scanning and private vulnerability reporting (owner UI)
+- [ ] Wiki disabled; first-time-contributor Action approval; `main`
+      protection (owner UI)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The GitHub repo is already public. The README on `main` does **not** need a rewrite: MIT, free local app, $10 Sync, trademark, and doodlenote.ai downloads are already there.

This leftover pass does the two things that were still stale after the visibility flip:

- Rewrite `docs/OPEN-SOURCE.md` as current policy (it still said the repo was private and read as a pre-launch checklist).
- Add a GitHub link on the marketing site (header, footer, pricing FAQ, and a one-line homepage mention). That was the last README/website pointer in the ONY-196 checklist.

## Affected surfaces

Web marketing pages (`apps/web/app/ui.tsx`, homepage, pricing) and `docs/OPEN-SOURCE.md`. No capture, billing, or Sync behavior changes.

## Verification

- [x] `pnpm --filter web typecheck`
- [x] Manual: homepage, pricing, and changelog show a GitHub link that opens the public repo
- [x] Visual changes include screenshots or a recording

[Homepage header GitHub link](https://cursor.com/agents/bc-e9ac0748-311b-4c52-9892-341b36c3bbd3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhomepage-github-header.webp)
[Pricing FAQ saying the monorepo is MIT open source](https://cursor.com/agents/bc-e9ac0748-311b-4c52-9892-341b36c3bbd3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpricing-oss-faq.webp)
[Public GitHub repo opened from the site link](https://cursor.com/agents/bc-e9ac0748-311b-4c52-9892-341b36c3bbd3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fgithub-repo-public.webp)
[doodlenote-github-links.mp4](https://cursor.com/agents/bc-e9ac0748-311b-4c52-9892-341b36c3bbd3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdoodlenote-github-links.mp4)

## Privacy, compatibility, and release impact

None. No new data flows, credentials, or release-channel changes.

- [x] No real meeting content, credentials, tokens, signing files, or personal data are included
- [x] Documentation reflects any setup, permissions, or behavior changes
- [x] Unfinished functionality remains gated from release builds

## Follow-up

Owner-only GitHub settings (not a PR):

- Disable Wiki (API still reports it on)
- Enable secret scanning, push protection, Dependabot alerts, and private vulnerability reporting
- Require approval for first-time contributor Actions
- Protect `main`
- Close superseded plan-only PR #66

Do not treat this PR as permission to mark ONY-196 Done until those owner clicks are confirmed.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9ac0748-311b-4c52-9892-341b36c3bbd3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9ac0748-311b-4c52-9892-341b36c3bbd3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

