### PR TITLE
Add Onyx Dev Labs builder attribution to landing page

### DIFF
--- a/apps/web/app/ui.tsx
+++ b/apps/web/app/ui.tsx
@@ -14,6 +14,7 @@ export const DOWNLOADS = {
 };
 
 export const GITHUB_REPO = "https://github.com/Onyx-Dev-Labs/doodle-note";
+export const ONYX_URL = "https://onyxdev.io";
 
 /* Shared control styles — keep every page speaking the same visual language. */
 export const inputClass =
@@ -40,22 +41,58 @@ export function Wordmark({ size = "text-lg" }: { size?: string }) {
   );
 }
 
-/** Marketing-page header. Pass `nav` to swap the right side per page. */
-export function SiteHeader({ nav }: { nav?: React.ReactNode }) {
+function BuilderAttribution({ compact = false }: { compact?: boolean }) {
   return (
-    <header className="mx-auto flex w-full max-w-3xl items-center justify-between px-6 py-5">
+    <p
+      className={`whitespace-nowrap font-normal leading-none tracking-normal text-stone ${
+        compact ? "text-[11px]" : "text-xs"
+      }`}
+    >
+      built by{" "}
+      <a
+        href={ONYX_URL}
+        className="rounded-[2px] text-bark underline decoration-bark/60 underline-offset-2 transition hover:text-sage-deep hover:decoration-sage-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sage-deep"
+        rel="noreferrer"
+        target="_blank"
+      >
+        Onyx Dev Labs
+      </a>
+    </p>
+  );
+}
+
+/** Logo, wordmark, and builder attribution — matches other Onyx product sites. */
+export function BrandLockup({
+  compact = false,
+  priority = false,
+}: {
+  compact?: boolean;
+  priority?: boolean;
+}) {
+  return (
+    <div className="flex shrink-0 flex-col items-start gap-1">
       <Link href="/" className="flex items-center gap-2.5">
         <Image
           src="/mascot.png"
           alt=""
-          width={34}
-          height={34}
+          width={compact ? 30 : 34}
+          height={compact ? 30 : 34}
           className="rounded-lg"
-          priority
+          priority={priority}
           unoptimized
         />
-        <Wordmark />
+        <Wordmark size={compact ? "text-base" : "text-lg"} />
       </Link>
+      <BuilderAttribution compact={compact} />
+    </div>
+  );
+}
+
+/** Marketing-page header. Pass `nav` to swap the right side per page. */
+export function SiteHeader({ nav }: { nav?: React.ReactNode }) {
+  return (
+    <header className="mx-auto flex w-full max-w-3xl items-center justify-between px-6 py-5">
+      <BrandLockup priority />
       <nav className="flex items-center gap-1 sm:gap-2">
         {nav ?? (
           <>
@@ -84,7 +121,7 @@ export function SiteFooter() {
   return (
     <footer className="border-t border-sand">
       <div className="mx-auto flex w-full max-w-3xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-stone sm:flex-row">
-        <Wordmark size="text-sm" />
+        <BrandLockup compact />
         <nav className="flex items-center gap-5">
           <Link href="/pricing" className="hover:text-ink">
             Pricing

--- a/apps/web/tests/brand-attribution.test.ts
+++ b/apps/web/tests/brand-attribution.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const uiSource = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "../app/ui.tsx"),
+  "utf8",
+);
+
+test("marketing brand lockup includes Onyx builder attribution", () => {
+  assert.match(uiSource, /built by\{" "\}/);
+  assert.match(uiSource, /Onyx Dev Labs/);
+  assert.match(uiSource, /ONYX_URL = "https:\/\/onyxdev\.io"/);
+  assert.match(uiSource, /export function BrandLockup/);
+  assert.match(uiSource, /<BrandLockup priority \/>/);
+  assert.match(uiSource, /<BrandLockup compact \/>/);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a "built by Onyx Dev Labs" attribution beneath the DoodleNote logo on marketing pages, matching the pattern used on TechStatus and other Onyx product sites.

## Changes

- Introduce a reusable `BrandLockup` component with logo, wordmark, and builder attribution
- Use `BrandLockup` in `SiteHeader` and `SiteFooter` so attribution appears across marketing pages (landing, pricing, changelog, etc.)
- Link "Onyx Dev Labs" to https://onyxdev.io
- Add a regression test to ensure the attribution remains in place

## Test plan

- [x] `pnpm typecheck` passes in `apps/web`
- [x] `pnpm test` passes in `apps/web`
- [x] Verified locally at http://localhost:4040/ — attribution appears under the header logo
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a39581cf-e6d1-470a-9428-1158d7ec5e1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a39581cf-e6d1-470a-9428-1158d7ec5e1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

