### PR TITLE
Place builder attribution under DoodleNote wordmark

### DIFF
--- a/apps/web/app/ui.tsx
+++ b/apps/web/app/ui.tsx
@@ -70,21 +70,21 @@ export function BrandLockup({
   priority?: boolean;
 }) {
   return (
-    <div className="flex shrink-0 flex-col items-start gap-1">
-      <Link href="/" className="flex items-center gap-2.5">
-        <Image
-          src="/mascot.png"
-          alt=""
-          width={compact ? 30 : 34}
-          height={compact ? 30 : 34}
-          className="rounded-lg"
-          priority={priority}
-          unoptimized
-        />
+    <Link href="/" className="flex shrink-0 items-start gap-2.5">
+      <Image
+        src="/mascot.png"
+        alt=""
+        width={compact ? 30 : 34}
+        height={compact ? 30 : 34}
+        className="rounded-lg"
+        priority={priority}
+        unoptimized
+      />
+      <span className="flex flex-col items-start gap-1 pt-0.5">
         <Wordmark size={compact ? "text-base" : "text-lg"} />
-      </Link>
-      <BuilderAttribution compact={compact} />
-    </div>
+        <BuilderAttribution compact={compact} />
+      </span>
+    </Link>
   );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves the "built by Onyx Dev Labs" attribution to sit directly under the DoodleNote wordmark instead of left-aligning with the mascot icon.

## Changes

- Restructure `BrandLockup` so icon and text stack are side-by-side
- Nest wordmark + attribution in a column next to the icon

## Test plan

- [x] Existing brand attribution regression test passes
- [x] Verified header layout locally
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a39581cf-e6d1-470a-9428-1158d7ec5e1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a39581cf-e6d1-470a-9428-1158d7ec5e1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

