### PR TITLE
Add builder attribution to app header and login page

### DIFF
--- a/apps/web/app/app/app-header.tsx
+++ b/apps/web/app/app/app-header.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-import { Wordmark } from "../ui";
+import { BrandLockup } from "../ui";
 import { SignOutButton } from "./sign-out-button";
 
 const navItems = [
@@ -26,22 +25,14 @@ export function AppHeader({
   return (
     <header className="sticky top-0 z-30 border-b border-sand bg-cream/95 backdrop-blur">
       <div className="mx-auto flex w-full max-w-6xl items-center gap-2 px-3 py-3 sm:gap-4 sm:px-6">
-        <Link
+        <BrandLockup
           href="/app"
-          className="flex shrink-0 items-center gap-2.5 rounded-md focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-sage-deep"
-        >
-          <Image
-            src="/mascot.png"
-            alt=""
-            width={28}
-            height={28}
-            className="rounded-lg"
-            unoptimized
-          />
-          <span className="hidden min-[480px]:inline">
-            <Wordmark size="text-base" />
-          </span>
-        </Link>
+          compact
+          iconSize={28}
+          wordmarkSize="text-base"
+          textClassName="hidden min-[480px]:flex"
+          className="rounded-md focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-sage-deep"
+        />
 
         <nav aria-label="Primary" className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto sm:gap-1">
           {navItems.map((item) => {

--- a/apps/web/app/login/login-form.tsx
+++ b/apps/web/app/login/login-form.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import Image from "next/image";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { authClient } from "@/lib/auth-client";
-import { buttonPrimary, buttonSecondary, inputClass, Wordmark } from "../ui";
+import {
+  BrandLockup,
+  buttonPrimary,
+  buttonSecondary,
+  inputClass,
+} from "../ui";
 
 type Mode = "sign-in" | "sign-up";
 
@@ -108,18 +111,13 @@ export function LoginForm({
   return (
     <div className="w-full max-w-sm">
       <div className="mb-8 flex flex-col items-center text-center">
-        <Link href="/" className="flex flex-col items-center gap-3">
-          <Image
-            src="/mascot.png"
-            alt=""
-            width={48}
-            height={48}
-            className="rounded-xl"
-            priority
-            unoptimized
-          />
-          <Wordmark size="text-xl" />
-        </Link>
+        <BrandLockup
+          href="/"
+          layout="stacked"
+          iconSize={48}
+          wordmarkSize="text-xl"
+          priority
+        />
         <p className="mt-2 text-sm text-stone">
           {mode === "sign-in"
             ? "Sign in to your workspace"

--- a/apps/web/app/ui.tsx
+++ b/apps/web/app/ui.tsx
@@ -65,25 +65,65 @@ function BuilderAttribution({ compact = false }: { compact?: boolean }) {
 export function BrandLockup({
   compact = false,
   priority = false,
+  href = "/",
+  layout = "horizontal",
+  iconSize,
+  wordmarkSize,
+  className = "",
+  textClassName = "",
 }: {
   compact?: boolean;
   priority?: boolean;
+  href?: string;
+  layout?: "horizontal" | "stacked";
+  iconSize?: number;
+  wordmarkSize?: string;
+  className?: string;
+  textClassName?: string;
 }) {
+  const size = iconSize ?? (compact ? 30 : 34);
+  const wmSize = wordmarkSize ?? (compact ? "text-base" : "text-lg");
+  const iconClass = layout === "stacked" ? "rounded-xl" : "rounded-lg";
+  const textStack = (
+    <span
+      className={`flex flex-col gap-1 ${
+        layout === "stacked" ? "items-center" : "items-start pt-0.5"
+      } ${textClassName}`}
+    >
+      <Wordmark size={wmSize} />
+      <BuilderAttribution compact={compact} />
+    </span>
+  );
+
+  if (layout === "stacked") {
+    return (
+      <Link href={href} className={`flex flex-col items-center gap-3 ${className}`}>
+        <Image
+          src="/mascot.png"
+          alt=""
+          width={size}
+          height={size}
+          className={iconClass}
+          priority={priority}
+          unoptimized
+        />
+        {textStack}
+      </Link>
+    );
+  }
+
   return (
-    <Link href="/" className="flex shrink-0 items-start gap-2.5">
+    <Link href={href} className={`flex shrink-0 items-start gap-2.5 ${className}`}>
       <Image
         src="/mascot.png"
         alt=""
-        width={compact ? 30 : 34}
-        height={compact ? 30 : 34}
-        className="rounded-lg"
+        width={size}
+        height={size}
+        className={iconClass}
         priority={priority}
         unoptimized
       />
-      <span className="flex flex-col items-start gap-1 pt-0.5">
-        <Wordmark size={compact ? "text-base" : "text-lg"} />
-        <BuilderAttribution compact={compact} />
-      </span>
+      {textStack}
     </Link>
   );
 }

--- a/apps/web/tests/brand-attribution.test.ts
+++ b/apps/web/tests/brand-attribution.test.ts
@@ -16,4 +16,20 @@ test("marketing brand lockup includes Onyx builder attribution", () => {
   assert.match(uiSource, /export function BrandLockup/);
   assert.match(uiSource, /<BrandLockup priority \/>/);
   assert.match(uiSource, /<BrandLockup compact \/>/);
+  assert.match(uiSource, /layout\?: "horizontal" \| "stacked"/);
+});
+
+test("app and login surfaces use the shared brand lockup", () => {
+  const appHeader = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../app/app/app-header.tsx"),
+    "utf8",
+  );
+  const loginForm = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../app/login/login-form.tsx"),
+    "utf8",
+  );
+
+  assert.match(appHeader, /<BrandLockup[\s\S]*href="\/app"/);
+  assert.match(loginForm, /layout="stacked"/);
+  assert.match(loginForm, /<BrandLockup/);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the "built by Onyx Dev Labs" attribution to the authenticated app header and sign-in page shown in the screenshots.

## Changes

- Extend `BrandLockup` with `layout`, `href`, `iconSize`, and responsive text visibility props
- Use `BrandLockup` in `AppHeader` (Meetings/Shared/Settings nav)
- Use stacked `BrandLockup` on the login/sign-up form
- Add regression coverage for both surfaces

## Test plan

- [x] `pnpm typecheck` passes in `apps/web`
- [x] Brand attribution tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a39581cf-e6d1-470a-9428-1158d7ec5e1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a39581cf-e6d1-470a-9428-1158d7ec5e1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

