### PR TITLE
Fix web OAuth sign-in and sync empty-cloud trash guard

### DIFF
--- a/apps/desktop/src/main/sync-service.ts
+++ b/apps/desktop/src/main/sync-service.ts
@@ -637,6 +637,11 @@ export class SyncService {
 
   /** Soft-trash synced meetings whose cloud copy disappeared. */
   private applyCloudDeletions(cloudIds: Set<string>): boolean {
+    // Push runs before pull, but never reconcile against an empty cloud id
+    // list while meetings are still queued — that trashed entire libraries
+    // when link + sync raced on a fresh workspace.
+    if (cloudIds.size === 0 && this.pendingMeetings().length > 0) return false
+
     let changed = false
     for (const local of this.meetings.readAll()) {
       const syncedHash = this.config.pushed[local.id]

--- a/apps/web/app/login/login-form.tsx
+++ b/apps/web/app/login/login-form.tsx
@@ -95,7 +95,12 @@ export function LoginForm({
         callbackURL: next,
       });
       if (result.error) {
-        setError(result.error.message ?? "Sign-in failed. Try again.");
+        const detail =
+          result.error.message ??
+          ("code" in result.error && typeof result.error.code === "string"
+            ? result.error.code
+            : null);
+        setError(detail ?? "Sign-in failed. Try again.");
         setPending(false);
         return;
       }

--- a/apps/web/lib/create-auth.ts
+++ b/apps/web/lib/create-auth.ts
@@ -1,5 +1,6 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { nextCookies } from "better-auth/next-js";
 import { organization } from "better-auth/plugins";
 
 import { fullSchema, type Db } from "@repo/db";
@@ -11,6 +12,23 @@ import { sendWorkspaceInvitationEmail } from "./invitation-email";
  * Never rely on this outside of local development.
  */
 const DEV_ONLY_SECRET = "dev-only-insecure-better-auth-secret-change-me";
+
+/** Production canonical site; social OAuth callbacks must match this origin. */
+const PRODUCTION_ORIGINS = [
+  "https://www.doodlenote.ai",
+  "https://doodlenote.ai",
+];
+
+function resolveBaseURL(): string {
+  if (process.env.BETTER_AUTH_URL) return process.env.BETTER_AUTH_URL;
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  return "http://localhost:4040";
+}
+
+function trustedOrigins(): string[] {
+  const base = resolveBaseURL();
+  return [...new Set([base, ...PRODUCTION_ORIGINS, "http://localhost:4040"])];
+}
 
 function resolveSecret(): string {
   const secret = process.env.BETTER_AUTH_SECRET;
@@ -66,7 +84,8 @@ export function createAuth(db: Db) {
   return betterAuth({
     database: drizzleAdapter(db, { provider: "pg", schema: fullSchema }),
     secret: resolveSecret(),
-    baseURL: process.env.BETTER_AUTH_URL ?? "http://localhost:4040",
+    baseURL: resolveBaseURL(),
+    trustedOrigins: trustedOrigins(),
     emailAndPassword: {
       enabled: true,
     },
@@ -76,9 +95,11 @@ export function createAuth(db: Db) {
         cancelPendingInvitationsOnReInvite: true,
         sendInvitationEmail: sendWorkspaceInvitationEmail,
       }),
+      // Required for Next.js App Router — sets session cookies on OAuth return.
+      nextCookies(),
     ],
   });
 }
 
 export type Auth = ReturnType<typeof createAuth>;
-export { googleEnabled, microsoftEnabled };
+export { googleEnabled, microsoftEnabled, resolveBaseURL };

--- a/apps/web/lib/invitation-email.ts
+++ b/apps/web/lib/invitation-email.ts
@@ -26,7 +26,8 @@ export async function sendWorkspaceInvitationEmail(data: {
     return;
   }
 
-  const origin = process.env.BETTER_AUTH_URL ?? "http://localhost:4040";
+  const origin = process.env.BETTER_AUTH_URL
+    ?? (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:4040");
   const inviteUrl = new URL(`/invite/${data.id}`, origin).toString();
   const organizationName = html(data.organization.name);
   const inviterName = html(data.inviter.user.name || data.inviter.user.email);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes production sign-in failures when connecting cloud sync, and prevents a sync race that could move local meetings to Trash.

### Sign-in (web)
- Add `nextCookies()` plugin (required for Next.js OAuth cookie handling in Better Auth 1.6+)
- Register `trustedOrigins` for `https://www.doodlenote.ai` and `https://doodlenote.ai`
- Resolve `baseURL` from `BETTER_AUTH_URL` or `VERCEL_URL`
- Show Better Auth error codes/messages on social sign-in failure

### Desktop sync safety
- Do not reconcile cloud deletions when `allIds` is empty but meetings are still queued to push

## Ops note
Confirm Vercel `BETTER_AUTH_URL` is `https://www.doodlenote.ai`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8460378f-a8ca-45fc-8e5f-3e420670c305?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8460378f-a8ca-45fc-8e5f-3e420670c305&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

