### PR TITLE
Release DoodleNote v0.4.13 (cloud sync + OAuth fixes)

### DIFF
--- a/RELEASE-v0.4.13.md
+++ b/RELEASE-v0.4.13.md
@@ -1,0 +1,36 @@
+# DoodleNote v0.4.13 release candidate
+
+## Included
+
+- [x] Fix cloud sync pull cursor persistence so restarts do not re-pull from epoch (#75 / ONY-204)
+- [x] Align desktop content hashing with push payloads to stop pull/re-apply churn (#75 / ONY-204)
+- [x] Guard sync reconciliation when the cloud library is still empty on first connect (#76)
+- [x] Fix web OAuth sign-in for doodlenote.ai / www.doodlenote.ai (#76)
+- [x] Bump the desktop version from 0.4.12 to 0.4.13
+- [x] Add the v0.4.13 changelog entry
+
+## Verification
+
+- [ ] Frozen-lockfile dependency install
+- [ ] Workspace typecheck
+- [ ] Desktop test suite
+- [ ] Production Electron and web builds
+- [ ] Packaged application reports version 0.4.13
+- [ ] Signed and notarized arm64 package with the Swift transcription engine
+- [ ] Strict code-signature, Gatekeeper, and stapled-ticket validation
+- [ ] Updater ZIP and website DMG checksums recorded
+- [ ] Updater manifest references only version-matched v0.4.13 artifacts
+
+## Release gates
+
+- [ ] Release PR has green required CI
+- [ ] User authorized merge and publication
+- [ ] Release PR merged into main
+- [ ] Public update feed reports 0.4.13
+- [ ] Public updater artifact checksum matches the release artifact
+- [ ] Installed 0.4.12 client detects the 0.4.13 update
+
+## Package
+
+- Updater artifact: `DoodleNote-0.4.13-arm64-mac.zip`
+- Website installer: `DoodleNote-0.4.13-arm64.dmg`

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "private": true,
   "description": "DoodleNote desktop app \u2014 private local capture, transcription, and AI meeting notes",
   "main": "./out/main/index.js",

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,15 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.13",
+    date: "August 26, 2026",
+    highlights: [
+      "Cloud sync no longer re-pulls your entire library on every app restart",
+      "Sync reconciliation waits for the first cloud snapshot before trashing local meetings that look missing",
+      "Connecting DoodleNote to the cloud on doodlenote.ai sign-in is more reliable again",
+    ],
+  },
+  {
     version: "0.4.12",
     date: "August 7, 2026",
     highlights: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ship desktop **0.4.13** so Check for Updates can deliver the fixes already merged on `main`:

- **#75 / ONY-204** — persist cloud sync pull cursor; align content hashing with push payloads
- **#76** — guard first-sync reconciliation when the cloud library is still empty; fix doodlenote.ai OAuth sign-in on web

Users on **0.4.12** do not have these changes.

## Affected surfaces

- Desktop release tooling (`apps/desktop/package.json`, `RELEASE-v0.4.13.md`)
- Web changelog (`apps/web/app/changelog/page.tsx`)

## Verification

- [x] Desktop test suite (`pnpm test` in `apps/desktop`) — 126 passing
- [ ] Signed/notarized Mac package (`pnpm release` on maintainer Mac)
- [ ] Stage updater manifest (`apps/web/public/updates/latest-mac.yml`) after packaging
- [ ] Installed 0.4.12 client detects 0.4.13 via Check for Updates

## Privacy, compatibility, and release impact

- No new data flows or permissions
- Sync guard prevents local meetings from being soft-trashed during first cloud connect when cloud `allIds` is still empty

- [x] No real meeting content, credentials, tokens, signing files, or personal data are included
- [x] Documentation reflects release notes in `RELEASE-v0.4.13.md` and changelog entry

## Follow-up

After merge, run on a signed Mac maintainer machine:

```bash
cd apps/desktop
pnpm release
```

Then commit the staged `latest-mac.yml` and merge/publish per `RELEASE-v0.4.13.md` gates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8460378f-a8ca-45fc-8e5f-3e420670c305?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8460378f-a8ca-45fc-8e5f-3e420670c305&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

