### PR TITLE
Resolve remaining CodeQL security findings

### DIFF
--- a/apps/desktop/src/main/engine-process.test.ts
+++ b/apps/desktop/src/main/engine-process.test.ts
@@ -32,7 +32,7 @@ function fakeEngine(body: string): { binary: string; log: string } {
     [
       '#!/usr/bin/env node',
       "const fs = require('node:fs')",
-      `const log = (m) => fs.appendFileSync(${JSON.stringify(log)}, m + '\\n')`,
+      "const log = (m) => fs.appendFileSync(process.argv[1] + '.log', m + '\\n')",
       'const emit = (o) => console.log(JSON.stringify(o))',
       // Never linger past the test run.
       "setTimeout(() => { log('gave-up'); process.exit(3) }, 15000)",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "auth-smoke": "node --conditions=react-server --import tsx scripts/auth-smoke.ts",
-    "test": "tsx --test tests/*.test.ts"
+    "test": "tsx --test tests/*.test.ts scripts/*.test.mjs"
   },
   "dependencies": {
     "@repo/agent-contract": "workspace:*",

--- a/apps/web/scripts/billing-e2e-utils.mjs
+++ b/apps/web/scripts/billing-e2e-utils.mjs
@@ -1,0 +1,28 @@
+import { randomBytes, randomUUID } from "node:crypto";
+
+export function billingTestIdentity() {
+  return {
+    email: `billing-e2e-${randomUUID()}@example.com`,
+    password: `Dn!${randomBytes(24).toString("base64url")}`,
+  };
+}
+
+export function stripeCheckoutUrl(value) {
+  if (typeof value !== "string") return null;
+
+  try {
+    const url = new URL(value);
+    if (
+      url.protocol !== "https:" ||
+      url.hostname !== "checkout.stripe.com" ||
+      url.port !== "" ||
+      url.username !== "" ||
+      url.password !== ""
+    ) {
+      return null;
+    }
+    return url;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/scripts/billing-e2e-utils.test.mjs
+++ b/apps/web/scripts/billing-e2e-utils.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { billingTestIdentity, stripeCheckoutUrl } from "./billing-e2e-utils.mjs";
+
+describe("billing E2E helpers", () => {
+  it("creates independent, non-predictable test credentials", () => {
+    const first = billingTestIdentity();
+    const second = billingTestIdentity();
+
+    assert.match(first.email, /^billing-e2e-[0-9a-f-]+@example\.com$/);
+    assert.notEqual(first.email, second.email);
+    assert.notEqual(first.password, second.password);
+    assert.ok(first.password.length >= 8);
+    assert.ok(!first.password.includes(first.email));
+  });
+
+  it("accepts an exact Stripe-hosted checkout URL", () => {
+    const url = stripeCheckoutUrl("https://checkout.stripe.com/c/pay/cs_test_123#fidkdWxOYHwnPyd1blpxYHZxWjA0");
+
+    assert.equal(url?.hostname, "checkout.stripe.com");
+  });
+
+  it("rejects checkout URL lookalikes and unsafe URL forms", () => {
+    const rejected = [
+      "http://checkout.stripe.com/c/pay/cs_test_123",
+      "https://checkout.stripe.com.evil.example/c/pay/cs_test_123",
+      "https://evil-checkout.stripe.com/c/pay/cs_test_123",
+      "https://evil.example/checkout.stripe.com/c/pay/cs_test_123",
+      "https://evil.example/?next=checkout.stripe.com",
+      "https://checkout.stripe.com@evil.example/c/pay/cs_test_123",
+      "https://user:password@checkout.stripe.com/c/pay/cs_test_123",
+      "https://checkout.stripe.com:444/c/pay/cs_test_123",
+      "not a URL",
+    ];
+
+    for (const value of rejected) assert.equal(stripeCheckoutUrl(value), null, value);
+  });
+});

--- a/apps/web/scripts/billing-e2e.mjs
+++ b/apps/web/scripts/billing-e2e.mjs
@@ -12,8 +12,10 @@
  * metadata) and drives our REAL webhook route with properly signed events.
  */
 import { readFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import Stripe from "stripe";
+import { billingTestIdentity, stripeCheckoutUrl } from "./billing-e2e-utils.mjs";
 
 const BASE = "http://localhost:4040";
 const here = import.meta.dirname;
@@ -25,8 +27,7 @@ const PRICE_ID = env("STRIPE_PRICE_ID");
 const WEBHOOK_SECRET = env("STRIPE_WEBHOOK_SECRET");
 if (!PRICE_ID || !WEBHOOK_SECRET) throw new Error("Stripe env missing in .env.local");
 
-const stamp = Math.random().toString(36).slice(2, 8);
-const EMAIL = `billing-e2e-${stamp}@example.com`;
+const { email: EMAIL, password: PASSWORD } = billingTestIdentity();
 let cookie = "";
 let pass = 0;
 const check = (name, ok, detail = "") => {
@@ -60,7 +61,7 @@ const call = async (path, options = {}) => {
 {
   const { res } = await call("/api/auth/sign-up/email", {
     method: "POST",
-    body: JSON.stringify({ email: EMAIL, password: `Pw!${stamp}${stamp}`, name: "Billing E2E" }),
+    body: JSON.stringify({ email: EMAIL, password: PASSWORD, name: "Billing E2E" }),
   });
   check("sign-up", res.ok, EMAIL);
 }
@@ -96,12 +97,9 @@ let customerId = null;
     method: "POST",
     body: JSON.stringify({ next: "/app" }),
   });
-  check(
-    "checkout session",
-    res.ok && typeof body?.url === "string" && body.url.includes("checkout.stripe.com"),
-    body?.url?.slice(0, 48),
-  );
-  const page = await fetch(body.url);
+  const checkoutUrl = stripeCheckoutUrl(body?.url);
+  check("checkout session", res.ok && checkoutUrl !== null, checkoutUrl?.origin);
+  const page = await fetch(checkoutUrl);
   check("hosted checkout page loads", page.ok, `HTTP ${page.status}`);
   // ensureCustomer persisted the mapping — find the customer for later steps.
   // customers.list filters by exact email with no search-index lag.
@@ -129,7 +127,7 @@ let subscription = null;
 
 const deliverWebhook = async (type, object) => {
   const payload = JSON.stringify({
-    id: `evt_e2e_${Math.random().toString(36).slice(2, 10)}`,
+    id: `evt_e2e_${randomUUID()}`,
     object: "event",
     type,
     data: { object },

--- a/apps/web/scripts/secure-secret-output.mjs
+++ b/apps/web/scripts/secure-secret-output.mjs
@@ -1,0 +1,51 @@
+import {
+  closeSync,
+  constants,
+  fsyncSync,
+  openSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { resolve } from "node:path";
+
+export function reserveSecretEnvFile(filePath) {
+  const outputPath = resolve(filePath);
+  const fd = openSync(
+    outputPath,
+    constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY,
+    0o600,
+  );
+  let open = true;
+  let complete = false;
+
+  return {
+    path: outputPath,
+    write(name, value) {
+      if (!open || complete) throw new Error("Secret output reservation is no longer writable");
+      if (!/^[A-Z][A-Z0-9_]*$/.test(name)) throw new Error("Invalid environment variable name");
+      if (typeof value !== "string" || value.includes("\n") || value.includes("\r")) {
+        throw new Error("Invalid environment variable value");
+      }
+
+      try {
+        writeFileSync(fd, `${name}=${value}\n`, "utf8");
+        fsyncSync(fd);
+        closeSync(fd);
+        open = false;
+        complete = true;
+      } catch (error) {
+        if (open) closeSync(fd);
+        open = false;
+        unlinkSync(outputPath);
+        complete = true;
+        throw error;
+      }
+    },
+    abort() {
+      if (complete) return;
+      if (open) closeSync(fd);
+      open = false;
+      unlinkSync(outputPath);
+    },
+  };
+}

--- a/apps/web/scripts/secure-secret-output.test.mjs
+++ b/apps/web/scripts/secure-secret-output.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { reserveSecretEnvFile } from "./secure-secret-output.mjs";
+
+describe("secure secret output", () => {
+  it("writes a new env file with owner-only permissions", () => {
+    const dir = mkdtempSync(join(tmpdir(), "doodlenote-secret-output-"));
+    try {
+      const path = join(dir, "stripe-secret.env");
+      const reservation = reserveSecretEnvFile(path);
+      reservation.write("STRIPE_WEBHOOK_SECRET", "whsec_fixture");
+
+      assert.equal(readFileSync(path, "utf8"), "STRIPE_WEBHOOK_SECRET=whsec_fixture\n");
+      assert.equal(statSync(path).mode & 0o777, 0o600);
+      assert.throws(() => reserveSecretEnvFile(path), { code: "EEXIST" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("removes an unused reservation", () => {
+    const dir = mkdtempSync(join(tmpdir(), "doodlenote-secret-output-"));
+    try {
+      const path = join(dir, "stripe-secret.env");
+      const reservation = reserveSecretEnvFile(path);
+      reservation.abort();
+
+      assert.throws(() => statSync(path), { code: "ENOENT" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/web/scripts/stripe-setup.mjs
+++ b/apps/web/scripts/stripe-setup.mjs
@@ -3,13 +3,15 @@
  * looks up by lookup_key/url before creating. Run once per mode:
  *
  *   STRIPE_SECRET_KEY=sk_test_… node scripts/stripe-setup.mjs   # test mode
- *   STRIPE_SECRET_KEY=sk_live_… node scripts/stripe-setup.mjs   # go-live
+ *   STRIPE_SECRET_KEY=sk_live_… \
+ *     STRIPE_WEBHOOK_SECRET_OUTPUT=/secure/new-file.env \
+ *     node scripts/stripe-setup.mjs                            # go-live
  *
- * Prints the env vars to set (Vercel prod + root .env.local):
- *   STRIPE_PRICE_ID, STRIPE_WEBHOOK_SECRET (webhook secret prints ONCE —
- *   it cannot be fetched again later).
+ * Prints non-secret configuration. When a live webhook must be created, its
+ * one-time secret is written to a new owner-only file and never printed.
  */
 import Stripe from "stripe";
+import { reserveSecretEnvFile } from "./secure-secret-output.mjs";
 
 const key = process.env.STRIPE_SECRET_KEY;
 if (!key) {
@@ -39,24 +41,53 @@ if (!price) {
 }
 
 // Webhook endpoint (skipped in test mode — use `stripe listen` locally).
-let webhookLine = "";
+let webhookSecretPath = "";
 if (mode === "LIVE") {
   const existing = (await stripe.webhookEndpoints.list({ limit: 100 })).data.find(
     (e) => e.url === WEBHOOK_URL,
   );
   if (existing) {
-    console.log(`webhook exists: ${existing.id} (secret not retrievable — reuse the saved one)`);
+    console.log(`webhook exists: ${existing.id} (secret not retrievable; reuse the saved one)`);
   } else {
-    const endpoint = await stripe.webhookEndpoints.create({
-      url: WEBHOOK_URL,
-      enabled_events: [
-        "customer.subscription.created",
-        "customer.subscription.updated",
-        "customer.subscription.deleted",
-        "checkout.session.completed",
-      ],
-    });
-    webhookLine = `STRIPE_WEBHOOK_SECRET=${endpoint.secret}`;
+    const output = process.env.STRIPE_WEBHOOK_SECRET_OUTPUT;
+    if (!output) {
+      throw new Error(
+        "Set STRIPE_WEBHOOK_SECRET_OUTPUT to a new secure file before creating the live webhook",
+      );
+    }
+    const reservation = reserveSecretEnvFile(output);
+    let endpoint;
+    try {
+      endpoint = await stripe.webhookEndpoints.create({
+        url: WEBHOOK_URL,
+        enabled_events: [
+          "customer.subscription.created",
+          "customer.subscription.updated",
+          "customer.subscription.deleted",
+          "checkout.session.completed",
+        ],
+      });
+    } catch (error) {
+      reservation.abort();
+      throw error;
+    }
+
+    try {
+      if (!endpoint.secret) throw new Error("Stripe did not return the new webhook secret");
+      reservation.write("STRIPE_WEBHOOK_SECRET", endpoint.secret);
+    } catch (error) {
+      reservation.abort();
+      try {
+        await stripe.webhookEndpoints.del(endpoint.id);
+      } catch (rollbackError) {
+        throw new AggregateError(
+          [error, rollbackError],
+          `Could not persist the webhook secret or remove webhook ${endpoint.id}`,
+        );
+      }
+      throw error;
+    }
+    webhookSecretPath = reservation.path;
     console.log(`created webhook ${endpoint.id}`);
   }
 } else {
@@ -64,6 +95,6 @@ if (mode === "LIVE") {
 }
 
 console.log(`\n--- env for ${mode} ---`);
-console.log(`STRIPE_SECRET_KEY=${key.slice(0, 12)}…  (already have it)`);
+console.log("STRIPE_SECRET_KEY=<already supplied>");
 console.log(`STRIPE_PRICE_ID=${price.id}`);
-if (webhookLine) console.log(webhookLine);
+if (webhookSecretPath) console.log(`STRIPE_WEBHOOK_SECRET written to ${webhookSecretPath}`);

--- a/apps/web/tests/twilio.test.ts
+++ b/apps/web/tests/twilio.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { validTwilioSignature, voiceAccessToken, type TwilioVoiceConfig } from "../lib/twilio";
+
+const config: TwilioVoiceConfig = {
+  accountSid: "AC00000000000000000000000000000000",
+  apiKeySid: "SK00000000000000000000000000000000",
+  apiKeySecret: "fixture-api-key-secret",
+  twimlAppSid: "AP00000000000000000000000000000000",
+  callerId: "+18175550100",
+};
+
+function decodePart(value: string): unknown {
+  return JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+}
+
+describe("Twilio authentication helpers", () => {
+  it("creates a Twilio Voice JWT signed with the API key secret", () => {
+    const originalNow = Date.now;
+    Date.now = () => 1_700_000_000_000;
+    let token = "";
+    try {
+      token = voiceAccessToken(config, "user-123");
+    } finally {
+      Date.now = originalNow;
+    }
+    const [encodedHeader, encodedPayload, signature] = token.split(".");
+
+    assert.deepEqual(decodePart(encodedHeader), {
+      cty: "twilio-fpa;v=1",
+      typ: "JWT",
+      alg: "HS256",
+    });
+    assert.deepEqual(decodePart(encodedPayload), {
+      ...(decodePart(encodedPayload) as Record<string, unknown>),
+      iss: config.apiKeySid,
+      sub: config.accountSid,
+      grants: {
+        identity: "user-123",
+        voice: { outgoing: { application_sid: config.twimlAppSid } },
+      },
+    });
+    assert.equal(signature, "ooIjTi3BTFw90KjoE1p7u97diXbMH0WD4O6n5jJInjc");
+  });
+
+  it("matches Twilio's published webhook-signature test vector", () => {
+    const params = new URLSearchParams({
+      CallSid: "CA1234567890ABCDE",
+      Caller: "+14158675310",
+      Digits: "1234",
+      From: "+14158675310",
+      To: "+18005551212",
+    });
+    const url = "https://example.com/myapp.php?foo=1&bar=2";
+
+    assert.equal(validTwilioSignature("12345", url, params, "L/OH5YylLD5NRKLltdqwSvS0BnU="), true);
+    assert.equal(validTwilioSignature("12345", url, params, "invalid"), false);
+  });
+});


### PR DESCRIPTION
## Summary
- use cryptographic randomness for billing E2E identities and webhook event IDs
- enforce exact HTTPS Stripe checkout host validation
- keep Stripe credentials out of terminal logs and persist new webhook secrets to a new owner-only file with rollback
- remove generated-code path interpolation from the desktop engine test fixture
- add Twilio JWT and webhook-signature regression coverage

## Validation
- pnpm -r test
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm engine:build
- pnpm audit --prod --audit-level=low

## CodeQL
The Twilio HS256 finding is a false positive: the API key secret signs a Twilio JWT; this is not password hashing. The new tests verify the token structure and signature.