### PR TITLE
Release DoodleNote 0.4.14

### DIFF
--- a/RELEASE-v0.4.14.md
+++ b/RELEASE-v0.4.14.md
@@ -1,0 +1,36 @@
+# DoodleNote v0.4.14 release candidate
+
+## Included
+
+- [x] Remove the retired G Brain export from Settings > Integrations
+- [x] Remove the G Brain background service, IPC surface, workspace package, tests, and endpoint specification
+- [x] Preserve Claude Desktop, Claude Code, Codex, and other MCP agent integrations
+- [x] Bump the desktop version from 0.4.13 to 0.4.14
+- [x] Add the v0.4.14 changelog entry
+
+## Verification
+
+- [ ] Frozen-lockfile dependency install
+- [ ] Workspace typecheck
+- [ ] Full test suite
+- [ ] Production Electron and web builds
+- [ ] Production dependency audit
+- [ ] Packaged application reports version 0.4.14
+- [ ] Signed and notarized arm64 package with the Swift transcription engine
+- [ ] Strict code-signature, Gatekeeper, and stapled-ticket validation
+- [ ] Updater ZIP and website DMG checksums recorded
+- [ ] Updater manifest references only version-matched v0.4.14 artifacts
+
+## Release gates
+
+- [x] User authorized merge and publication
+- [ ] Release PR has green required CI
+- [ ] Release PR merged into main
+- [ ] Public update feed reports 0.4.14
+- [ ] Public updater artifact checksum matches the release artifact
+- [ ] Existing 0.4.13 client can detect the 0.4.14 update
+
+## Package
+
+- Updater artifact: `DoodleNote-0.4.14-arm64-mac.zip`
+- Website installer: `DoodleNote-0.4.14-arm64.dmg`

--- a/RELEASE-v0.4.14.md
+++ b/RELEASE-v0.4.14.md
@@ -10,16 +10,16 @@
 
 ## Verification
 
-- [ ] Frozen-lockfile dependency install
-- [ ] Workspace typecheck
-- [ ] Full test suite
-- [ ] Production Electron and web builds
-- [ ] Production dependency audit
-- [ ] Packaged application reports version 0.4.14
-- [ ] Signed and notarized arm64 package with the Swift transcription engine
-- [ ] Strict code-signature, Gatekeeper, and stapled-ticket validation
-- [ ] Updater ZIP and website DMG checksums recorded
-- [ ] Updater manifest references only version-matched v0.4.14 artifacts
+- [x] Frozen-lockfile dependency install
+- [x] Workspace typecheck
+- [x] Full test suite
+- [x] Production Electron and web builds
+- [x] Production dependency audit
+- [x] Packaged application reports version 0.4.14
+- [x] Signed and notarized arm64 package with the Swift transcription engine
+- [x] Strict code-signature, Gatekeeper, and stapled-ticket validation
+- [x] Updater ZIP and website DMG checksums recorded
+- [x] Updater manifest references only version-matched v0.4.14 artifacts
 
 ## Release gates
 
@@ -34,3 +34,7 @@
 
 - Updater artifact: `DoodleNote-0.4.14-arm64-mac.zip`
 - Website installer: `DoodleNote-0.4.14-arm64.dmg`
+- Updater ZIP SHA-256: `197682d7ca9a95d2dbe7bf6fefd119222554f74b41c592991d78203882b2d9aa`
+- Website DMG SHA-256: `3eb847d994234c50f1d8e65d101cf22e396346808bcc3754aad071168e5c9fc0`
+- App notarization submission: `93d44e96-e47c-440e-bf8c-7b4731fe2bdf`
+- DMG notarization submission: `c9c3aa76-9264-43cd-aa6a-70568d362939`

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "private": true,
   "description": "DoodleNote desktop app for privacy-first local capture, transcription, and AI meeting notes",
   "main": "./out/main/index.js",

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,14 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.14",
+    date: "August 27, 2026",
+    highlights: [
+      "Remove the retired G Brain export from Settings and the desktop application",
+      "Keep Claude Desktop, Claude Code, Codex, and other MCP agent integrations available",
+    ],
+  },
+  {
     version: "0.4.13",
     date: "August 26, 2026",
     highlights: [

--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,11 +1,11 @@
-version: 0.4.13
+version: 0.4.14
 files:
-  - url: DoodleNote-0.4.13-arm64-mac.zip
-    sha512: AxAl7GiJDTAjbKeweaOGg6yDQRM/4Og2M+s9yefOH3WvTAOJIzODfR9ceAzPnlXgapXP5jdkUcYlIBpSnMmsKg==
-    size: 170317949
-  - url: DoodleNote-0.4.13-arm64.dmg
-    sha512: RrXSQihGNXxm7YvJ5H0YTqyKdQWcr3QfTZvHOvD+K0kmXTX2C3MfwWZoj2ba18j5vzKFh8QWkjEE9R5SbI9uBA==
-    size: 172208738
-path: DoodleNote-0.4.13-arm64-mac.zip
-sha512: AxAl7GiJDTAjbKeweaOGg6yDQRM/4Og2M+s9yefOH3WvTAOJIzODfR9ceAzPnlXgapXP5jdkUcYlIBpSnMmsKg==
-releaseDate: '2026-08-26T22:27:38.791Z'
+  - url: DoodleNote-0.4.14-arm64-mac.zip
+    sha512: EN9m2lBcYMsxoC2XN82POzsEWP2LWodUh4Vn6mEIpmzncomkjdc7D1cUJWaQnH68lZVRMjppqSJwyLZ37DhNtg==
+    size: 179762475
+  - url: DoodleNote-0.4.14-arm64.dmg
+    sha512: Q+NZtJuOOIEp2ci49myfJlftv4JiqRwTqV1pZj0Na50lSQPYH8gIuet0VtUJCrrcOsU1BeEnsIZ//QAuOQUiLQ==
+    size: 181676002
+path: DoodleNote-0.4.14-arm64-mac.zip
+sha512: EN9m2lBcYMsxoC2XN82POzsEWP2LWodUh4Vn6mEIpmzncomkjdc7D1cUJWaQnH68lZVRMjppqSJwyLZ37DhNtg==
+releaseDate: '2026-08-27T23:10:54.159Z'


### PR DESCRIPTION
## Release Candidate v0.4.14

### Included
- Remove the retired G Brain export from Desktop Settings > Integrations
- Remove the G Brain service, IPC bridge, workspace package, tests, and endpoint specification
- Preserve Claude Desktop, Claude Code, Codex, and other MCP agent integrations
- Publish the signed and notarized macOS updater ZIP and website DMG

### Version
- Bumped from v0.4.13 to v0.4.14

### Verification
- Frozen-lockfile install with pnpm 10.33.2
- 216 tests passed
- Workspace lint and type checks passed
- Swift engine, Electron, and production web builds passed
- Production dependency audit found no known vulnerabilities
- App and final DMG signed, notarized, stapled, and Gatekeeper accepted
- Mounted DMG contains DoodleNote 0.4.14 with a valid strict signature
- ZIP and DMG SHA-512 metadata match the staged updater manifest
- Public GitHub API confirms the removed G Brain paths return 404 on main

### Risks / Notes
- Existing 0.4.13 installations keep the old UI until they install 0.4.14
- Release is macOS arm64, matching the existing production updater channel
- Rollback is restoring the 0.4.13 static manifest and prior versioned artifacts