### PR TITLE
Consolidate GitHub Actions runtime upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,10 @@ updates:
       day: monday
       time: "09:15"
       timezone: America/Chicago
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: swift
     directory: /engine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
       # Public CI-only values. Production uses deployment-managed secrets.
       DOODLENOTE_SELF_HOSTED: "true"
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -85,9 +85,9 @@ jobs:
       CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
       CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -160,7 +160,7 @@ jobs:
           Write-Host "Installer: $($installer.Name)"
           Write-Host "Authenticode: $($signature.Status)"
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: doodlenote-windows-${{ github.sha }}
           path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,8 +20,8 @@ jobs:
     name: Analyze JavaScript and TypeScript
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: github/codeql-action/init@42947a340483f03ba47bb1a039b2c519aab3df85 # v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: javascript-typescript
-      - uses: github/codeql-action/analyze@42947a340483f03ba47bb1a039b2c519aab3df85 # v3
+      - uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install XcodeGen
         run: brew install xcodegen

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -18,9 +18,9 @@ jobs:
     if: github.repository == 'Onyx-Dev-Labs/doodle-note'
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -53,7 +53,7 @@ jobs:
         env:
           BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: doodlenote-mac-${{ github.sha }}
           path: |

--- a/apps/desktop/src/main/release-packaging.test.ts
+++ b/apps/desktop/src/main/release-packaging.test.ts
@@ -92,7 +92,7 @@ test('CI builds and retains a real Windows installer', () => {
   assert.match(ciWorkflow, /Smoke packaged Windows native modules/)
   assert.match(ciWorkflow, /sherpa and llama native modules loaded successfully/)
   assert.match(ciWorkflow, /Get-AuthenticodeSignature/)
-  assert.match(ciWorkflow, /actions\/upload-artifact@[0-9a-f]{40}\s+# v4/)
+  assert.match(ciWorkflow, /actions\/upload-artifact@[0-9a-f]{40}\s+# v7\.0\.1/)
   assert.match(desktopPackage, /release:win[\s\S]*verify-windows-signature\.ps1/)
 })
 


### PR DESCRIPTION
## Summary
- upgrade checkout, setup-node, upload-artifact, and both CodeQL steps together using immutable commit pins
- update the Windows packaging guard for upload-artifact v7
- group future GitHub Actions updates into one Dependabot pull request to prevent mismatched action families

## Verification
- YAML parsing passed for Dependabot and all changed workflows
- desktop test suite passed: 127 passed, 3 skipped, 0 failed
- repository lint passed
- repository typecheck passed

## Risk
Low to moderate. These are major GitHub Actions runtime upgrades, so the pull request must pass Linux checks, CodeQL, Vercel, iOS, and Windows packaging before merge.