### PR TITLE
[ONY-214] Restore and verify paid DoodleNote Sync billing

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -28,8 +28,12 @@
 
 # Official hosted Sync billing ($10 / user / month at doodlenote.ai)
 # STRIPE_SECRET_KEY=
+# STRIPE_ACCOUNT_ID=
 # STRIPE_PRICE_ID=
 # STRIPE_WEBHOOK_SECRET=
+
+# Billing integration test target. Defaults to http://localhost:4040.
+# BILLING_E2E_BASE_URL=
 
 # Voice features
 # TWILIO_ACCOUNT_SID=

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -30,7 +30,7 @@ No external service is required for the basic local development path:
 | Microsoft sign-in                 | `MICROSOFT_CLIENT_ID`, `MICROSOFT_CLIENT_SECRET`                                                                                     |
 | Google sign-in                    | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`                                                                                           |
 | Workspace invitations             | `RESEND_API_KEY`, `INVITATION_FROM_EMAIL`                                                                                            |
-| Billing                           | `STRIPE_SECRET_KEY`, `STRIPE_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`                                                                      |
+| Billing                           | `STRIPE_SECRET_KEY`, `STRIPE_ACCOUNT_ID`, `STRIPE_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`                                                  |
 | Voice features                    | `TWILIO_ACCOUNT_SID`, `TWILIO_API_KEY_SID`, `TWILIO_API_KEY_SECRET`, `TWILIO_TWIML_APP_SID`, `TWILIO_CALLER_ID`, `TWILIO_AUTH_TOKEN` |
 
 A commented template is in [`.env.example`](.env.example). Store local
@@ -52,6 +52,38 @@ entitlement gate. Official production fails closed when the Stripe
 configuration is missing or incomplete. This repository does not ship
 a production Docker Compose stack yet; see
 [`SELF-HOSTING.md`](../../SELF-HOSTING.md).
+
+## Stripe test setup
+
+Provisioning requires the expected account ID so a valid key for the wrong
+Stripe account fails before it creates anything:
+
+```sh
+STRIPE_SECRET_KEY=<test-key> \
+STRIPE_ACCOUNT_ID=<expected-account-id> \
+node apps/web/scripts/stripe-setup.mjs
+```
+
+For a deployed test preview, also set `STRIPE_WEBHOOK_URL` to that preview's
+HTTPS `/api/billing/webhook` URL and set `STRIPE_WEBHOOK_SECRET_OUTPUT` to a
+new secure local file. The script writes the one-time signing secret with
+owner-only permissions and never prints it. Copy the resulting values into
+Preview-scoped hosting variables together with an isolated `DATABASE_URL`,
+`BETTER_AUTH_URL`, and `BETTER_AUTH_SECRET`. Do not reuse the production
+database or production Stripe values for preview QA.
+
+With the preview configured, run the integration check from a trusted local
+shell that holds the test Stripe values:
+
+```sh
+BILLING_E2E_BASE_URL=https://your-preview.example \
+pnpm --filter web exec node scripts/billing-e2e.mjs
+```
+
+The check creates an isolated test user and Stripe test subscription, verifies
+signed webhook entitlement and device linking, then cancels the subscription
+and verifies access is removed. Keep `.env.local` and generated secret files
+out of Git.
 
 ## Commands
 

--- a/apps/web/app/api/billing/checkout/route.ts
+++ b/apps/web/app/api/billing/checkout/route.ts
@@ -2,7 +2,16 @@ import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 
 import { auth } from "@/lib/auth";
-import { billingEnabled, ensureCustomer, getStripe, TRIAL_DAYS } from "@/lib/billing";
+import {
+  billingEnabled,
+  blockingSubscriptionForCustomer,
+  ensureCustomer,
+  entitlementFor,
+  getVerifiedStripe,
+  recordSubscription,
+  TRIAL_DAYS,
+} from "@/lib/billing";
+import { checkoutBlocked, checkoutIdempotencyKey } from "@/lib/billing-state";
 
 /**
  * Start a cloud-sync subscription: hosted Stripe Checkout, $10/mo, 15-day
@@ -23,6 +32,20 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "STRIPE_PRICE_ID is not set" }, { status: 503 });
   }
 
+  const entitlement = await entitlementFor(session.user.id);
+  if (checkoutBlocked(entitlement)) {
+    return NextResponse.json(
+      {
+        error:
+          entitlement.reason === "grandfathered"
+            ? "Sync is already active for this account"
+            : "A subscription is already active or needs attention in billing",
+        manageBilling: entitlement.reason !== "grandfathered",
+      },
+      { status: 409 },
+    );
+  }
+
   let next = "/app";
   try {
     const body = (await request.json()) as { next?: unknown };
@@ -35,21 +58,69 @@ export async function POST(request: Request) {
   }
 
   const origin = process.env.BETTER_AUTH_URL ?? new URL(request.url).origin;
-  const customerId = await ensureCustomer(session.user.id, session.user.email);
 
-  const checkout = await getStripe().checkout.sessions.create({
-    mode: "subscription",
-    customer: customerId,
-    line_items: [{ price: priceId, quantity: 1 }],
-    subscription_data: {
-      trial_period_days: TRIAL_DAYS,
-      metadata: { doodlenoteUserId: session.user.id },
-    },
-    // BETADOODLENOTE (and future codes) get typed here.
-    allow_promotion_codes: true,
-    success_url: `${origin}${next}${next.includes("?") ? "&" : "?"}billing=success`,
-    cancel_url: `${origin}/pricing?billing=canceled`,
-  });
+  try {
+    const customerId = await ensureCustomer(session.user.id, session.user.email);
+    const stripe = await getVerifiedStripe();
+    const blockingSubscription = await blockingSubscriptionForCustomer(customerId);
+    if (blockingSubscription) {
+      await recordSubscription(blockingSubscription);
+      return NextResponse.json(
+        {
+          error: "A subscription is already active or needs attention in billing",
+          manageBilling: true,
+        },
+        { status: 409 },
+      );
+    }
 
-  return NextResponse.json({ url: checkout.url });
+    const openSessions = await stripe.checkout.sessions.list({
+      customer: customerId,
+      status: "open",
+      limit: 10,
+    });
+    const reusable = openSessions.data.find(
+      (candidate) =>
+        candidate.mode === "subscription" &&
+        candidate.client_reference_id === session.user.id &&
+        candidate.metadata?.doodlenotePriceId === priceId &&
+        typeof candidate.url === "string",
+    );
+    if (reusable?.url) return NextResponse.json({ url: reusable.url });
+
+    const checkout = await stripe.checkout.sessions.create(
+      {
+        mode: "subscription",
+        customer: customerId,
+        client_reference_id: session.user.id,
+        metadata: {
+          doodlenoteUserId: session.user.id,
+          doodlenotePriceId: priceId,
+        },
+        line_items: [{ price: priceId, quantity: 1 }],
+        subscription_data: {
+          trial_period_days: TRIAL_DAYS,
+          metadata: { doodlenoteUserId: session.user.id },
+        },
+        // BETADOODLENOTE (and future codes) get typed here.
+        allow_promotion_codes: true,
+        success_url: `${origin}${next}${next.includes("?") ? "&" : "?"}billing=success`,
+        cancel_url: `${origin}/pricing?billing=canceled`,
+      },
+      {
+        idempotencyKey: checkoutIdempotencyKey(
+          session.user.id,
+          `${origin}${next}`,
+        ),
+      },
+    );
+
+    return NextResponse.json({ url: checkout.url });
+  } catch {
+    console.error("[billing] Could not create a Stripe Checkout session");
+    return NextResponse.json(
+      { error: "Checkout is temporarily unavailable" },
+      { status: 502 },
+    );
+  }
 }

--- a/apps/web/app/api/billing/portal/route.ts
+++ b/apps/web/app/api/billing/portal/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { eq, getDb, subscriptions } from "@repo/db";
 
 import { auth } from "@/lib/auth";
-import { billingEnabled, getStripe } from "@/lib/billing";
+import { billingEnabled, getVerifiedStripe } from "@/lib/billing";
 
 /** Stripe Billing Portal: update card, cancel, view invoices. */
 export async function POST(request: Request) {
@@ -26,9 +26,18 @@ export async function POST(request: Request) {
   }
 
   const origin = process.env.BETTER_AUTH_URL ?? new URL(request.url).origin;
-  const portal = await getStripe().billingPortal.sessions.create({
-    customer: customerId,
-    return_url: `${origin}/app`,
-  });
-  return NextResponse.json({ url: portal.url });
+  try {
+    const stripe = await getVerifiedStripe();
+    const portal = await stripe.billingPortal.sessions.create({
+      customer: customerId,
+      return_url: `${origin}/app`,
+    });
+    return NextResponse.json({ url: portal.url });
+  } catch {
+    console.error("[billing] Could not create a Stripe Customer Portal session");
+    return NextResponse.json(
+      { error: "Billing management is temporarily unavailable" },
+      { status: 502 },
+    );
+  }
 }

--- a/apps/web/app/api/billing/webhook/route.ts
+++ b/apps/web/app/api/billing/webhook/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from "next/server";
 import type Stripe from "stripe";
 
-import { billingEnabled, getStripe, recordSubscription } from "@/lib/billing";
+import {
+  billingEnabled,
+  getStripe,
+  getVerifiedStripe,
+  reconcileSubscription,
+} from "@/lib/billing";
 
 /**
  * Stripe → us. Subscription lifecycle events keep the subscriptions table
@@ -30,15 +35,16 @@ export async function POST(request: Request) {
     case "customer.subscription.created":
     case "customer.subscription.updated":
     case "customer.subscription.deleted":
-      await recordSubscription(event.data.object);
+      await reconcileSubscription(event.data.object);
       break;
     case "checkout.session.completed": {
       // The subscription events above carry the real state; this is just a
       // safety net for the brief window before they arrive.
       const session = event.data.object;
       if (typeof session.subscription === "string") {
-        const sub = await getStripe().subscriptions.retrieve(session.subscription);
-        await recordSubscription(sub);
+        const stripe = await getVerifiedStripe();
+        const sub = await stripe.subscriptions.retrieve(session.subscription);
+        await reconcileSubscription(sub);
       }
       break;
     }

--- a/apps/web/app/api/device/link/route.ts
+++ b/apps/web/app/api/device/link/route.ts
@@ -20,7 +20,7 @@ export async function POST(request: Request) {
   }
 
   // Cloud sync is the paid feature — linking a device requires entitlement
-  // (trialing, active, or past_due). The approval page turns this 402
+  // (grandfathered, trialing, active, or past_due). The approval page turns this 402
   // into a "start your free trial" checkout hand-off.
   const entitlement = await entitlementFor(session.user.id);
   if (!entitlement.entitled) {

--- a/apps/web/app/api/device/link/route.ts
+++ b/apps/web/app/api/device/link/route.ts
@@ -20,7 +20,7 @@ export async function POST(request: Request) {
   }
 
   // Cloud sync is the paid feature — linking a device requires entitlement
-  // (grandfathered, trialing, or active). The approval page turns this 402
+  // (trialing, active, or past_due). The approval page turns this 402
   // into a "start your free trial" checkout hand-off.
   const entitlement = await entitlementFor(session.user.id);
   if (!entitlement.entitled) {

--- a/apps/web/app/pricing/billing-view.ts
+++ b/apps/web/app/pricing/billing-view.ts
@@ -1,0 +1,38 @@
+export type BillingView =
+  | { kind: "loading" }
+  | { kind: "signed-out" }
+  | { kind: "disabled" }
+  | { kind: "error" }
+  | { kind: "start-trial" }
+  | { kind: "legacy-access" }
+  | { kind: "subscribed"; reason: string };
+
+interface BillingStatus {
+  entitled?: unknown;
+  reason?: unknown;
+  billingEnabled?: unknown;
+}
+
+export function billingViewFromStatus(
+  responseOk: boolean,
+  value: unknown,
+): BillingView {
+  if (!responseOk || !value || typeof value !== "object") {
+    return { kind: "error" };
+  }
+
+  const body = value as BillingStatus;
+  if (body.billingEnabled === false) return { kind: "disabled" };
+  if (body.billingEnabled !== true || typeof body.reason !== "string") {
+    return { kind: "error" };
+  }
+  if (body.reason === "signed-out") return { kind: "signed-out" };
+  if (body.reason === "grandfathered" && body.entitled === true) {
+    return { kind: "legacy-access" };
+  }
+  if (body.entitled === true) {
+    return { kind: "subscribed", reason: body.reason };
+  }
+  if (body.entitled === false) return { kind: "start-trial" };
+  return { kind: "error" };
+}

--- a/apps/web/app/pricing/billing-view.ts
+++ b/apps/web/app/pricing/billing-view.ts
@@ -2,10 +2,14 @@ export type BillingView =
   | { kind: "loading" }
   | { kind: "signed-out" }
   | { kind: "disabled" }
+  | { kind: "configuration-error" }
   | { kind: "error" }
   | { kind: "start-trial" }
   | { kind: "legacy-access" }
-  | { kind: "subscribed"; reason: string };
+  | {
+      kind: "subscribed";
+      reason: "trialing" | "active" | "past_due" | "billing_attention";
+    };
 
 interface BillingStatus {
   entitled?: unknown;
@@ -22,6 +26,9 @@ export function billingViewFromStatus(
   }
 
   const body = value as BillingStatus;
+  if (body.reason === "configuration_error") {
+    return { kind: "configuration-error" };
+  }
   if (body.billingEnabled === false) return { kind: "disabled" };
   if (body.billingEnabled !== true || typeof body.reason !== "string") {
     return { kind: "error" };
@@ -30,7 +37,12 @@ export function billingViewFromStatus(
   if (body.reason === "grandfathered" && body.entitled === true) {
     return { kind: "legacy-access" };
   }
-  if (body.entitled === true) {
+  if (
+    body.entitled === true &&
+    (body.reason === "trialing" ||
+      body.reason === "active" ||
+      body.reason === "past_due")
+  ) {
     return { kind: "subscribed", reason: body.reason };
   }
   if (body.entitled === false) return { kind: "start-trial" };

--- a/apps/web/app/pricing/checkout-button.tsx
+++ b/apps/web/app/pricing/checkout-button.tsx
@@ -3,13 +3,10 @@
 import { useEffect, useState } from "react";
 
 import { buttonPrimary } from "../ui";
-
-type BillingView =
-  | { kind: "loading" }
-  | { kind: "signed-out" }
-  | { kind: "disabled" } // Stripe env incomplete — checkout unavailable
-  | { kind: "start-trial" }
-  | { kind: "subscribed"; reason: string };
+import {
+  billingViewFromStatus,
+  type BillingView,
+} from "./billing-view";
 
 /**
  * The Sync plan's call to action, state-aware: signed-out visitors go to
@@ -26,14 +23,11 @@ export function CheckoutButton() {
     fetch("/api/billing/status")
       .then(async (res) => {
         if (cancelled) return;
-        const body = await res.json();
-        if (!body.billingEnabled) setView({ kind: "disabled" });
-        else if (body.reason === "signed-out") setView({ kind: "signed-out" });
-        else if (body.entitled) setView({ kind: "subscribed", reason: body.reason });
-        else setView({ kind: "start-trial" });
+        const body = await res.json().catch(() => null);
+        setView(billingViewFromStatus(res.ok, body));
       })
       .catch(() => {
-        if (!cancelled) setView({ kind: "signed-out" });
+        if (!cancelled) setView({ kind: "error" });
       });
     return () => {
       cancelled = true;
@@ -54,11 +48,27 @@ export function CheckoutButton() {
         window.location.href = body.url;
         return;
       }
+      if (body.manageBilling === true) {
+        setView({ kind: "subscribed", reason: "billing_attention" });
+      }
       setError(body.error ?? "Something went wrong — try again.");
     } catch {
       setError("Something went wrong — try again.");
     }
     setBusy(false);
+  }
+
+  if (view.kind === "legacy-access") {
+    return (
+      <div className="flex flex-col items-center gap-2 sm:items-start">
+        <a href="/app" className={buttonPrimary}>
+          Open DoodleNote
+        </a>
+        <p className="text-xs text-stone">
+          Sync access is already active for this account.
+        </p>
+      </div>
+    );
   }
 
   if (view.kind === "subscribed") {
@@ -75,7 +85,9 @@ export function CheckoutButton() {
         <p className="text-xs text-stone">
           {view.reason === "trialing"
             ? "You're on the free trial."
-            : "Your subscription is active."}
+            : view.reason === "past_due" || view.reason === "billing_attention"
+              ? "Your billing needs attention."
+              : "Your subscription is active."}
         </p>
         {error && <p className="text-xs text-red-700">{error}</p>}
       </div>
@@ -89,7 +101,24 @@ export function CheckoutButton() {
           Get started
         </a>
         <p className="text-xs text-stone">
-          Billing is temporarily unavailable — try again soon.
+          Billing is temporarily unavailable. Try again soon.
+        </p>
+      </div>
+    );
+  }
+
+  if (view.kind === "error") {
+    return (
+      <div className="flex flex-col items-center gap-2 sm:items-start">
+        <button
+          type="button"
+          className={buttonPrimary}
+          onClick={() => window.location.reload()}
+        >
+          Try again
+        </button>
+        <p role="alert" className="text-xs text-red-700">
+          We could not check billing status. No subscription was started.
         </p>
       </div>
     );
@@ -116,7 +145,11 @@ export function CheckoutButton() {
         disabled={busy || view.kind === "loading"}
         onClick={() => void go("checkout")}
       >
-        {busy ? "Opening checkout…" : "Start your 15-day free trial"}
+        {busy
+          ? "Opening checkout…"
+          : view.kind === "loading"
+            ? "Checking billing…"
+            : "Start your 15-day free trial"}
       </button>
       <p className="text-xs text-stone">
         Card up front, cancel anytime. Beta code? Enter it at checkout.

--- a/apps/web/app/pricing/checkout-button.tsx
+++ b/apps/web/app/pricing/checkout-button.tsx
@@ -7,16 +7,14 @@ import { buttonPrimary } from "../ui";
 type BillingView =
   | { kind: "loading" }
   | { kind: "signed-out" }
-  | { kind: "disabled" } // billing not enabled yet — early access continues
+  | { kind: "disabled" } // Stripe env incomplete — checkout unavailable
   | { kind: "start-trial" }
-  | { kind: "subscribed"; reason: string }
-  | { kind: "grandfathered" };
+  | { kind: "subscribed"; reason: string };
 
 /**
  * The Sync plan's call to action, state-aware: signed-out visitors go to
  * login, new users to Stripe Checkout (15-day trial), subscribers to the
- * billing portal, and grandfathered accounts get a thank-you instead of
- * a checkout.
+ * billing portal.
  */
 export function CheckoutButton() {
   const [view, setView] = useState<BillingView>({ kind: "loading" });
@@ -31,7 +29,6 @@ export function CheckoutButton() {
         const body = await res.json();
         if (!body.billingEnabled) setView({ kind: "disabled" });
         else if (body.reason === "signed-out") setView({ kind: "signed-out" });
-        else if (body.reason === "grandfathered") setView({ kind: "grandfathered" });
         else if (body.entitled) setView({ kind: "subscribed", reason: body.reason });
         else setView({ kind: "start-trial" });
       })
@@ -64,14 +61,6 @@ export function CheckoutButton() {
     setBusy(false);
   }
 
-  if (view.kind === "grandfathered") {
-    return (
-      <p className="rounded-lg bg-sage-fill px-3 py-2 text-sm text-sage-deep">
-        You&rsquo;re an early supporter — Sync is free on your account, forever.
-      </p>
-    );
-  }
-
   if (view.kind === "subscribed") {
     return (
       <div className="flex flex-col items-center gap-2 sm:items-start">
@@ -100,7 +89,7 @@ export function CheckoutButton() {
           Get started
         </a>
         <p className="text-xs text-stone">
-          Free during early access — billing starts when Sync leaves beta.
+          Billing is temporarily unavailable — try again soon.
         </p>
       </div>
     );

--- a/apps/web/app/pricing/checkout-button.tsx
+++ b/apps/web/app/pricing/checkout-button.tsx
@@ -107,6 +107,19 @@ export function CheckoutButton() {
     );
   }
 
+  if (view.kind === "configuration-error") {
+    return (
+      <div className="flex flex-col items-center gap-2 sm:items-start">
+        <button type="button" className={buttonPrimary} disabled>
+          Billing unavailable
+        </button>
+        <p role="alert" className="text-xs text-red-700">
+          Cloud Sync billing is not configured correctly. Please try again later.
+        </p>
+      </div>
+    );
+  }
+
   if (view.kind === "error") {
     return (
       <div className="flex flex-col items-center gap-2 sm:items-start">

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -134,11 +134,8 @@ export default function PricingPage() {
         {/* Sync */}
         <section className="mt-16">
           <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
-            <h2 className="flex items-baseline gap-2.5 font-display text-2xl font-semibold tracking-tight text-ink">
+            <h2 className="font-display text-2xl font-semibold tracking-tight text-ink">
               Sync
-              <span className="rounded-full bg-sage-fill px-2.5 py-0.5 text-xs font-medium text-sage-deep">
-                Early access
-              </span>
             </h2>
             <p className="font-display text-2xl font-semibold tracking-tight text-ink">
               $10{" "}

--- a/apps/web/lib/billing-state.ts
+++ b/apps/web/lib/billing-state.ts
@@ -88,8 +88,11 @@ export function subscriptionUsesPrice(
   subscription: Stripe.Subscription,
   priceId: string,
 ): boolean {
-  return subscription.items.data.some(
-    (item) => item.price.id === priceId && (item.quantity ?? 1) === 1,
+  const items = subscription.items.data;
+  return (
+    items.length === 1 &&
+    items[0]?.price.id === priceId &&
+    (items[0].quantity ?? 1) === 1
   );
 }
 

--- a/apps/web/lib/billing-state.ts
+++ b/apps/web/lib/billing-state.ts
@@ -1,0 +1,133 @@
+import { createHash } from "node:crypto";
+
+import type Stripe from "stripe";
+
+import type { BillingMode } from "./runtime-config";
+
+export type EntitlementReason =
+  | "grandfathered"
+  | "trialing"
+  | "active"
+  | "past_due"
+  | "self-hosted"
+  | "development"
+  | "configuration_error"
+  | "none"
+  | "lapsed";
+
+export interface Entitlement {
+  entitled: boolean;
+  reason: EntitlementReason;
+  /** ISO date the current paid/trial period ends, when known. */
+  periodEnd?: string;
+  /** Raw persisted Stripe status for server-side recovery and Checkout guards. */
+  subscriptionStatus?: string;
+}
+
+export interface SubscriptionState {
+  status: string;
+  grandfathered: boolean;
+  currentPeriodEnd: Date | null;
+}
+
+const SERVING_STATUSES = new Set(["trialing", "active", "past_due"]);
+const CHECKOUT_RETRY_STATUSES = new Set([
+  "none",
+  "canceled",
+  "incomplete_expired",
+  "invalid_price",
+]);
+
+export function entitlementFrom(
+  mode: BillingMode,
+  subscription?: SubscriptionState,
+): Entitlement {
+  if (mode === "self-hosted" || mode === "development") {
+    return { entitled: true, reason: mode };
+  }
+  if (mode === "misconfigured") {
+    return { entitled: false, reason: "configuration_error" };
+  }
+  if (!subscription) return { entitled: false, reason: "none" };
+
+  if (subscription.grandfathered) {
+    return {
+      entitled: true,
+      reason: "grandfathered",
+      subscriptionStatus: subscription.status,
+    };
+  }
+  if (SERVING_STATUSES.has(subscription.status)) {
+    return {
+      entitled: true,
+      reason: subscription.status as "trialing" | "active" | "past_due",
+      ...(subscription.currentPeriodEnd
+        ? { periodEnd: subscription.currentPeriodEnd.toISOString() }
+        : {}),
+      subscriptionStatus: subscription.status,
+    };
+  }
+  return {
+    entitled: false,
+    reason: subscription.status === "none" ? "none" : "lapsed",
+    subscriptionStatus: subscription.status,
+  };
+}
+
+/** Prevent a second subscription while access or a recoverable attempt exists. */
+export function checkoutBlocked(entitlement: Entitlement): boolean {
+  if (entitlement.entitled || entitlement.reason === "configuration_error") {
+    return true;
+  }
+  return entitlement.subscriptionStatus
+    ? !CHECKOUT_RETRY_STATUSES.has(entitlement.subscriptionStatus)
+    : false;
+}
+
+export function subscriptionUsesPrice(
+  subscription: Stripe.Subscription,
+  priceId: string,
+): boolean {
+  return subscription.items.data.some(
+    (item) => item.price.id === priceId && (item.quantity ?? 1) === 1,
+  );
+}
+
+function subscriptionPriority(status: Stripe.Subscription.Status): number {
+  if (SERVING_STATUSES.has(status)) return 3;
+  if (status === "incomplete" || status === "paused" || status === "unpaid") {
+    return 2;
+  }
+  return 1;
+}
+
+/**
+ * Stripe does not guarantee webhook order. Reconcile against the current
+ * subscription list, preferring a serving/recoverable subscription over a
+ * late terminal event and ignoring products outside the configured Price.
+ */
+export function selectEffectiveSubscription(
+  subscriptions: Stripe.Subscription[],
+  priceId: string,
+): Stripe.Subscription | undefined {
+  return subscriptions
+    .filter((subscription) => subscriptionUsesPrice(subscription, priceId))
+    .sort((left, right) => {
+      const byState =
+        subscriptionPriority(right.status) - subscriptionPriority(left.status);
+      return byState || right.created - left.created;
+    })[0];
+}
+
+/** A short-lived stable key makes concurrent/retried Checkout POSTs idempotent. */
+export function checkoutIdempotencyKey(
+  userId: string,
+  next: string,
+  now = new Date(),
+): string {
+  const halfHour = Math.floor(now.getTime() / (30 * 60 * 1000));
+  const digest = createHash("sha256")
+    .update(`${userId}\0${next}\0${halfHour}`)
+    .digest("hex");
+  return `doodlenote-checkout-${digest}`;
+}

--- a/apps/web/lib/billing.ts
+++ b/apps/web/lib/billing.ts
@@ -5,7 +5,7 @@ import { resolveBillingMode } from "./runtime-config";
 
 /**
  * Cloud-sync billing: $10/month per user, 15-day trial for everyone (card
- * up front), users with a linked device before launch grandfathered free.
+ * up front). Entitlement comes from an active Stripe subscription only.
  *
  * Local development and explicitly self-hosted installations bypass official
  * DoodleNote billing. Hosted production fails closed unless the full Stripe
@@ -30,7 +30,7 @@ export function getStripe(): Stripe {
 
 export interface Entitlement {
   entitled: boolean;
-  /** Why: grandfathered | trialing | active | self-hosted | development | configuration_error | none | lapsed */
+  /** Why: trialing | active | self-hosted | development | configuration_error | none | lapsed */
   reason: string;
   /** ISO date the current paid/trial period ends, when known. */
   periodEnd?: string;
@@ -59,7 +59,6 @@ export async function entitlementFor(userId: string): Promise<Entitlement> {
     .limit(1);
   const sub = rows[0];
   if (!sub) return { entitled: false, reason: "none" };
-  if (sub.grandfathered) return { entitled: true, reason: "grandfathered" };
   if (SERVING_STATUSES.has(sub.status)) {
     return {
       entitled: true,

--- a/apps/web/lib/billing.ts
+++ b/apps/web/lib/billing.ts
@@ -1,11 +1,22 @@
+import { createHash } from "node:crypto";
+
 import Stripe from "stripe";
 import { eq, getDb, subscriptions } from "@repo/db";
 
+import {
+  checkoutBlocked,
+  entitlementFrom,
+  selectEffectiveSubscription,
+  subscriptionUsesPrice,
+  type Entitlement,
+} from "./billing-state";
 import { resolveBillingMode } from "./runtime-config";
+
+export type { Entitlement, EntitlementReason } from "./billing-state";
 
 /**
  * Cloud-sync billing: $10/month per user, 15-day trial for everyone (card
- * up front). Entitlement comes from an active Stripe subscription only.
+ * up front), with existing legacy access preserved until a separate migration.
  *
  * Local development and explicitly self-hosted installations bypass official
  * DoodleNote billing. Hosted production fails closed unless the full Stripe
@@ -15,6 +26,7 @@ import { resolveBillingMode } from "./runtime-config";
 export const TRIAL_DAYS = 15;
 
 let stripeClient: Stripe | null = null;
+let verifiedStripe: Promise<Stripe> | null = null;
 
 export function billingEnabled(): boolean {
   return resolveBillingMode() === "stripe";
@@ -28,29 +40,36 @@ export function getStripe(): Stripe {
   return stripeClient;
 }
 
-export interface Entitlement {
-  entitled: boolean;
-  /** Why: trialing | active | self-hosted | development | configuration_error | none | lapsed */
-  reason: string;
-  /** ISO date the current paid/trial period ends, when known. */
-  periodEnd?: string;
+/** Confirm the secret key belongs to the explicitly configured Stripe account. */
+export async function getVerifiedStripe(): Promise<Stripe> {
+  if (!verifiedStripe) {
+    const stripe = getStripe();
+    const expectedAccountId = process.env.STRIPE_ACCOUNT_ID;
+    verifiedStripe = stripe.accounts
+      .retrieveCurrent()
+      .then((account) => {
+        if (!expectedAccountId || account.id !== expectedAccountId) {
+          throw new Error("Stripe account does not match STRIPE_ACCOUNT_ID");
+        }
+        return stripe;
+      })
+      .catch((error: unknown) => {
+        verifiedStripe = null;
+        throw error;
+      });
+  }
+  return verifiedStripe;
 }
-
-/** Statuses Stripe considers "keep serving". past_due gets a grace pass so a
- *  failed card doesn't cut sync mid-retry cycle; Stripe cancels it for us. */
-const SERVING_STATUSES = new Set(["trialing", "active", "past_due"]);
 
 export async function entitlementFor(userId: string): Promise<Entitlement> {
   const mode = resolveBillingMode();
-  if (mode === "self-hosted" || mode === "development") {
-    return { entitled: true, reason: mode };
-  }
   if (mode === "misconfigured") {
     console.error(
       "[billing] Production billing is incomplete. Configure Stripe or set DOODLENOTE_SELF_HOSTED=true.",
     );
-    return { entitled: false, reason: "configuration_error" };
   }
+  if (mode !== "stripe") return entitlementFrom(mode);
+
   const db = getDb();
   const rows = await db
     .select()
@@ -58,17 +77,7 @@ export async function entitlementFor(userId: string): Promise<Entitlement> {
     .where(eq(subscriptions.userId, userId))
     .limit(1);
   const sub = rows[0];
-  if (!sub) return { entitled: false, reason: "none" };
-  if (SERVING_STATUSES.has(sub.status)) {
-    return {
-      entitled: true,
-      reason: sub.status,
-      ...(sub.currentPeriodEnd
-        ? { periodEnd: sub.currentPeriodEnd.toISOString() }
-        : {}),
-    };
-  }
-  return { entitled: false, reason: sub.status === "none" ? "none" : "lapsed" };
+  return entitlementFrom(mode, sub);
 }
 
 /** Create-or-fetch the Stripe customer for a user, persisting the mapping. */
@@ -85,10 +94,16 @@ export async function ensureCustomer(
   const existing = rows[0];
   if (existing?.stripeCustomerId) return existing.stripeCustomerId;
 
-  const customer = await getStripe().customers.create({
-    email,
-    metadata: { doodlenoteUserId: userId },
-  });
+  const stripe = await getVerifiedStripe();
+  const customer = await stripe.customers.create(
+    {
+      email,
+      metadata: { doodlenoteUserId: userId },
+    },
+    {
+      idempotencyKey: `doodlenote-customer-${createHash("sha256").update(userId).digest("hex")}`,
+    },
+  );
   await db
     .insert(subscriptions)
     .values({ userId, stripeCustomerId: customer.id, status: "none" })
@@ -122,13 +137,18 @@ export async function recordSubscription(sub: Stripe.Subscription): Promise<void
   }
 
   const periodEnd = sub.items.data[0]?.current_period_end;
+  const configuredPriceId = process.env.STRIPE_PRICE_ID;
+  const status =
+    configuredPriceId && subscriptionUsesPrice(sub, configuredPriceId)
+      ? sub.status
+      : "invalid_price";
   await db
     .insert(subscriptions)
     .values({
       userId: targetUserId,
       stripeCustomerId: customerId,
       stripeSubscriptionId: sub.id,
-      status: sub.status,
+      status,
       currentPeriodEnd: periodEnd ? new Date(periodEnd * 1000) : null,
     })
     .onConflictDoUpdate({
@@ -136,9 +156,59 @@ export async function recordSubscription(sub: Stripe.Subscription): Promise<void
       set: {
         stripeCustomerId: customerId,
         stripeSubscriptionId: sub.id,
-        status: sub.status,
+        status,
         currentPeriodEnd: periodEnd ? new Date(periodEnd * 1000) : null,
         updatedAt: new Date(),
       },
     });
+}
+
+/**
+ * Re-read the customer's current Stripe subscriptions for every lifecycle
+ * event. Stripe can deliver events more than once and out of order, so the
+ * event body alone is not authoritative enough to overwrite current access.
+ */
+export async function reconcileSubscription(
+  incoming: Stripe.Subscription,
+): Promise<void> {
+  const customerId =
+    typeof incoming.customer === "string"
+      ? incoming.customer
+      : incoming.customer.id;
+  const priceId = process.env.STRIPE_PRICE_ID;
+  if (!priceId) throw new Error("STRIPE_PRICE_ID is not set");
+
+  const stripe = await getVerifiedStripe();
+  const current = await stripe.subscriptions.list({
+    customer: customerId,
+    status: "all",
+    limit: 100,
+  });
+  await recordSubscription(
+    selectEffectiveSubscription(current.data, priceId) ?? incoming,
+  );
+}
+
+/** Return the current configured-Price subscription when Checkout must stop. */
+export async function blockingSubscriptionForCustomer(
+  customerId: string,
+): Promise<Stripe.Subscription | undefined> {
+  const priceId = process.env.STRIPE_PRICE_ID;
+  if (!priceId) throw new Error("STRIPE_PRICE_ID is not set");
+
+  const stripe = await getVerifiedStripe();
+  const current = await stripe.subscriptions.list({
+    customer: customerId,
+    status: "all",
+    limit: 100,
+  });
+  const subscription = selectEffectiveSubscription(current.data, priceId);
+  if (!subscription) return undefined;
+
+  const entitlement = entitlementFrom("stripe", {
+    status: subscription.status,
+    grandfathered: false,
+    currentPeriodEnd: null,
+  });
+  return checkoutBlocked(entitlement) ? subscription : undefined;
 }

--- a/apps/web/lib/runtime-config.ts
+++ b/apps/web/lib/runtime-config.ts
@@ -55,6 +55,7 @@ export function resolveBillingMode(
 
   const stripeValues = [
     env.STRIPE_SECRET_KEY,
+    env.STRIPE_ACCOUNT_ID,
     env.STRIPE_PRICE_ID,
     env.STRIPE_WEBHOOK_SECRET,
   ];

--- a/apps/web/scripts/billing-e2e-utils.mjs
+++ b/apps/web/scripts/billing-e2e-utils.mjs
@@ -26,3 +26,24 @@ export function stripeCheckoutUrl(value) {
     return null;
   }
 }
+
+export function billingBaseUrl(value = "http://localhost:4040") {
+  try {
+    const url = new URL(value);
+    const localHttp =
+      url.protocol === "http:" &&
+      (url.hostname === "localhost" || url.hostname === "127.0.0.1");
+    if (
+      (!localHttp && url.protocol !== "https:") ||
+      url.username !== "" ||
+      url.password !== ""
+    ) {
+      throw new Error("invalid");
+    }
+    return url.origin;
+  } catch {
+    throw new Error(
+      "BILLING_E2E_BASE_URL must be HTTPS or a credential-free localhost URL",
+    );
+  }
+}

--- a/apps/web/scripts/billing-e2e-utils.test.mjs
+++ b/apps/web/scripts/billing-e2e-utils.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { billingTestIdentity, stripeCheckoutUrl } from "./billing-e2e-utils.mjs";
+import {
+  billingBaseUrl,
+  billingTestIdentity,
+  stripeCheckoutUrl,
+} from "./billing-e2e-utils.mjs";
 
 describe("billing E2E helpers", () => {
   it("creates independent, non-predictable test credentials", () => {
@@ -34,5 +38,17 @@ describe("billing E2E helpers", () => {
     ];
 
     for (const value of rejected) assert.equal(stripeCheckoutUrl(value), null, value);
+  });
+
+  it("accepts an explicit HTTPS preview or local development base URL", () => {
+    assert.equal(billingBaseUrl(), "http://localhost:4040");
+    assert.equal(
+      billingBaseUrl("https://preview.example.com/path"),
+      "https://preview.example.com",
+    );
+    assert.throws(
+      () => billingBaseUrl("http://preview.example.com"),
+      /BILLING_E2E_BASE_URL/,
+    );
   });
 });

--- a/apps/web/scripts/billing-e2e.mjs
+++ b/apps/web/scripts/billing-e2e.mjs
@@ -1,6 +1,7 @@
 /**
- * Billing end-to-end against a local dev server (port 4040) with Stripe
- * TEST keys in apps/web/.env.local. Exercises the whole loop:
+ * Billing end-to-end against a local dev server or BILLING_E2E_BASE_URL with
+ * Stripe TEST values in the process environment or apps/web/.env.local.
+ * Exercises the whole loop:
  *
  *   sign-up → status(none) → checkout session minted → trial subscription
  *   created in Stripe → SIGNED webhook delivered → status(trialing) →
@@ -11,16 +12,22 @@
  * the same subscription the checkout would (same price, same trial, same
  * metadata) and drives our REAL webhook route with properly signed events.
  */
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import Stripe from "stripe";
-import { billingTestIdentity, stripeCheckoutUrl } from "./billing-e2e-utils.mjs";
+import {
+  billingBaseUrl,
+  billingTestIdentity,
+  stripeCheckoutUrl,
+} from "./billing-e2e-utils.mjs";
 
-const BASE = "http://localhost:4040";
 const here = import.meta.dirname;
-const envText = readFileSync(join(here, "..", ".env.local"), "utf8");
-const env = (key) => envText.match(new RegExp(`^${key}=(.*)$`, "m"))?.[1]?.trim();
+const envPath = join(here, "..", ".env.local");
+const envText = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
+const env = (key) =>
+  process.env[key] ?? envText.match(new RegExp(`^${key}=(.*)$`, "m"))?.[1]?.trim();
+const BASE = billingBaseUrl(env("BILLING_E2E_BASE_URL"));
 
 const stripe = new Stripe(env("STRIPE_SECRET_KEY"));
 const PRICE_ID = env("STRIPE_PRICE_ID");

--- a/apps/web/scripts/billing-e2e.mjs
+++ b/apps/web/scripts/billing-e2e.mjs
@@ -21,6 +21,10 @@ import {
   billingTestIdentity,
   stripeCheckoutUrl,
 } from "./billing-e2e-utils.mjs";
+import {
+  assertExpectedAccount,
+  stripeKeyMode,
+} from "./stripe-setup-utils.mjs";
 
 const here = import.meta.dirname;
 const envPath = join(here, "..", ".env.local");
@@ -29,10 +33,16 @@ const env = (key) =>
   process.env[key] ?? envText.match(new RegExp(`^${key}=(.*)$`, "m"))?.[1]?.trim();
 const BASE = billingBaseUrl(env("BILLING_E2E_BASE_URL"));
 
-const stripe = new Stripe(env("STRIPE_SECRET_KEY"));
+const STRIPE_SECRET_KEY = env("STRIPE_SECRET_KEY");
+if (!STRIPE_SECRET_KEY || stripeKeyMode(STRIPE_SECRET_KEY) !== "test") {
+  throw new Error("Billing E2E requires a Stripe test-mode secret or restricted key");
+}
+const stripe = new Stripe(STRIPE_SECRET_KEY);
 const PRICE_ID = env("STRIPE_PRICE_ID");
 const WEBHOOK_SECRET = env("STRIPE_WEBHOOK_SECRET");
 if (!PRICE_ID || !WEBHOOK_SECRET) throw new Error("Stripe env missing in .env.local");
+const account = await stripe.accounts.retrieveCurrent();
+assertExpectedAccount(account.id, env("STRIPE_ACCOUNT_ID"));
 
 const { email: EMAIL, password: PASSWORD } = billingTestIdentity();
 let cookie = "";

--- a/apps/web/scripts/stripe-setup-utils.mjs
+++ b/apps/web/scripts/stripe-setup-utils.mjs
@@ -5,6 +5,12 @@ export const WEBHOOK_EVENTS = [
   "checkout.session.completed",
 ];
 
+export function stripeKeyMode(key) {
+  if (/^(?:sk|rk)_live_/.test(key)) return "LIVE";
+  if (/^(?:sk|rk)_test_/.test(key)) return "test";
+  throw new Error("STRIPE_SECRET_KEY must be a Stripe secret or restricted key");
+}
+
 export function assertExpectedAccount(actualAccountId, expectedAccountId) {
   if (!expectedAccountId) {
     throw new Error("Set STRIPE_ACCOUNT_ID to the exact intended Stripe account");

--- a/apps/web/scripts/stripe-setup-utils.mjs
+++ b/apps/web/scripts/stripe-setup-utils.mjs
@@ -1,0 +1,46 @@
+export const WEBHOOK_EVENTS = [
+  "customer.subscription.created",
+  "customer.subscription.updated",
+  "customer.subscription.deleted",
+  "checkout.session.completed",
+];
+
+export function assertExpectedAccount(actualAccountId, expectedAccountId) {
+  if (!expectedAccountId) {
+    throw new Error("Set STRIPE_ACCOUNT_ID to the exact intended Stripe account");
+  }
+  if (actualAccountId !== expectedAccountId) {
+    throw new Error(
+      `Stripe account mismatch: authenticated ${actualAccountId}, expected ${expectedAccountId}`,
+    );
+  }
+}
+
+export function assertMonthlyPrice(price) {
+  const valid =
+    price?.active === true &&
+    price?.currency === "usd" &&
+    price?.unit_amount === 1000 &&
+    price?.recurring?.interval === "month";
+  if (!valid) {
+    throw new Error(
+      `Existing Price ${price?.id ?? "unknown"} does not match active USD $10/month`,
+    );
+  }
+}
+
+export function webhookUrl(value) {
+  try {
+    const url = new URL(value);
+    if (
+      url.protocol !== "https:" ||
+      url.username !== "" ||
+      url.password !== ""
+    ) {
+      throw new Error("invalid");
+    }
+    return url;
+  } catch {
+    throw new Error("STRIPE_WEBHOOK_URL must be a valid credential-free HTTPS URL");
+  }
+}

--- a/apps/web/scripts/stripe-setup-utils.test.mjs
+++ b/apps/web/scripts/stripe-setup-utils.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  assertExpectedAccount,
+  assertMonthlyPrice,
+  webhookUrl,
+} from "./stripe-setup-utils.mjs";
+
+describe("Stripe provisioning guardrails", () => {
+  it("requires the authenticated Stripe account to match the intended account", () => {
+    assert.doesNotThrow(() => assertExpectedAccount("acct_expected", "acct_expected"));
+    assert.throws(
+      () => assertExpectedAccount("acct_other", "acct_expected"),
+      /Stripe account mismatch/,
+    );
+  });
+
+  it("rejects a lookup key that points at the wrong price contract", () => {
+    assert.doesNotThrow(() =>
+      assertMonthlyPrice({
+        id: "price_expected",
+        active: true,
+        currency: "usd",
+        unit_amount: 1000,
+        recurring: { interval: "month" },
+      }),
+    );
+    assert.throws(
+      () =>
+        assertMonthlyPrice({
+          id: "price_wrong",
+          active: true,
+          currency: "usd",
+          unit_amount: 900,
+          recurring: { interval: "month" },
+        }),
+      /does not match/,
+    );
+  });
+
+  it("accepts only credential-free HTTPS webhook URLs", () => {
+    assert.equal(
+      webhookUrl("https://preview.example.com/api/billing/webhook").href,
+      "https://preview.example.com/api/billing/webhook",
+    );
+    for (const value of [
+      "http://preview.example.com/api/billing/webhook",
+      "https://user:pass@preview.example.com/api/billing/webhook",
+      "not a url",
+    ]) {
+      assert.throws(() => webhookUrl(value), /valid credential-free HTTPS/);
+    }
+  });
+});

--- a/apps/web/scripts/stripe-setup-utils.test.mjs
+++ b/apps/web/scripts/stripe-setup-utils.test.mjs
@@ -4,10 +4,19 @@ import { describe, it } from "node:test";
 import {
   assertExpectedAccount,
   assertMonthlyPrice,
+  stripeKeyMode,
   webhookUrl,
 } from "./stripe-setup-utils.mjs";
 
 describe("Stripe provisioning guardrails", () => {
+  it("recognizes standard and restricted key modes", () => {
+    assert.equal(stripeKeyMode("sk_test_fixture"), "test");
+    assert.equal(stripeKeyMode("rk_test_fixture"), "test");
+    assert.equal(stripeKeyMode("sk_live_fixture"), "LIVE");
+    assert.equal(stripeKeyMode("rk_live_fixture"), "LIVE");
+    assert.throws(() => stripeKeyMode("not-a-stripe-key"), /secret or restricted/);
+  });
+
   it("requires the authenticated Stripe account to match the intended account", () => {
     assert.doesNotThrow(() => assertExpectedAccount("acct_expected", "acct_expected"));
     assert.throws(

--- a/apps/web/scripts/stripe-setup.mjs
+++ b/apps/web/scripts/stripe-setup.mjs
@@ -2,8 +2,16 @@
  * One-time Stripe provisioning for DoodleNote Cloud Sync. Idempotent —
  * looks up by lookup_key/url before creating. Run once per mode:
  *
- *   STRIPE_SECRET_KEY=sk_test_… node scripts/stripe-setup.mjs   # test mode
+ *   STRIPE_SECRET_KEY=sk_test_… \
+ *     STRIPE_ACCOUNT_ID=acct_… \
+ *     node scripts/stripe-setup.mjs                            # test catalog
+ *   STRIPE_SECRET_KEY=sk_test_… \
+ *     STRIPE_ACCOUNT_ID=acct_… \
+ *     STRIPE_WEBHOOK_URL=https://preview.example/api/billing/webhook \
+ *     STRIPE_WEBHOOK_SECRET_OUTPUT=/secure/new-file.env \
+ *     node scripts/stripe-setup.mjs                            # test preview
  *   STRIPE_SECRET_KEY=sk_live_… \
+ *     STRIPE_ACCOUNT_ID=acct_… \
  *     STRIPE_WEBHOOK_SECRET_OUTPUT=/secure/new-file.env \
  *     node scripts/stripe-setup.mjs                            # go-live
  *
@@ -12,6 +20,12 @@
  */
 import Stripe from "stripe";
 import { reserveSecretEnvFile } from "./secure-secret-output.mjs";
+import {
+  assertExpectedAccount,
+  assertMonthlyPrice,
+  WEBHOOK_EVENTS,
+  webhookUrl,
+} from "./stripe-setup-utils.mjs";
 
 const key = process.env.STRIPE_SECRET_KEY;
 if (!key) {
@@ -20,7 +34,17 @@ if (!key) {
 }
 const stripe = new Stripe(key);
 const mode = key.startsWith("sk_live_") ? "LIVE" : "test";
-const WEBHOOK_URL = "https://www.doodlenote.ai/api/billing/webhook";
+const expectedAccountId = process.env.STRIPE_ACCOUNT_ID;
+const account = await stripe.accounts.retrieveCurrent();
+assertExpectedAccount(account.id, expectedAccountId);
+console.log(`verified Stripe account ${account.id} (${mode})`);
+
+const requestedWebhookUrl =
+  process.env.STRIPE_WEBHOOK_URL ??
+  (mode === "LIVE" ? "https://www.doodlenote.ai/api/billing/webhook" : "");
+const targetWebhookUrl = requestedWebhookUrl
+  ? webhookUrl(requestedWebhookUrl).href
+  : null;
 const LOOKUP_KEY = "doodle-sync-monthly";
 
 // Price (creates its product inline) — found again by lookup_key on re-runs.
@@ -37,35 +61,42 @@ if (!price) {
   });
   console.log(`created price ${price.id} ($10/mo)`);
 } else {
+  assertMonthlyPrice(price);
   console.log(`price exists: ${price.id}`);
 }
 
-// Webhook endpoint (skipped in test mode — use `stripe listen` locally).
+// Create an explicitly targeted endpoint in either mode. Test mode remains
+// local-listener-only unless STRIPE_WEBHOOK_URL is deliberately supplied.
 let webhookSecretPath = "";
-if (mode === "LIVE") {
+if (targetWebhookUrl) {
   const existing = (await stripe.webhookEndpoints.list({ limit: 100 })).data.find(
-    (e) => e.url === WEBHOOK_URL,
+    (endpoint) => endpoint.url === targetWebhookUrl,
   );
   if (existing) {
+    const missingEvents = WEBHOOK_EVENTS.filter(
+      (event) =>
+        !existing.enabled_events.includes("*") &&
+        !existing.enabled_events.includes(event),
+    );
+    if (missingEvents.length) {
+      throw new Error(
+        `Webhook ${existing.id} is missing required events: ${missingEvents.join(", ")}`,
+      );
+    }
     console.log(`webhook exists: ${existing.id} (secret not retrievable; reuse the saved one)`);
   } else {
     const output = process.env.STRIPE_WEBHOOK_SECRET_OUTPUT;
     if (!output) {
       throw new Error(
-        "Set STRIPE_WEBHOOK_SECRET_OUTPUT to a new secure file before creating the live webhook",
+        "Set STRIPE_WEBHOOK_SECRET_OUTPUT to a new secure file before creating the webhook",
       );
     }
     const reservation = reserveSecretEnvFile(output);
     let endpoint;
     try {
       endpoint = await stripe.webhookEndpoints.create({
-        url: WEBHOOK_URL,
-        enabled_events: [
-          "customer.subscription.created",
-          "customer.subscription.updated",
-          "customer.subscription.deleted",
-          "checkout.session.completed",
-        ],
+        url: targetWebhookUrl,
+        enabled_events: WEBHOOK_EVENTS,
       });
     } catch (error) {
       reservation.abort();
@@ -91,10 +122,13 @@ if (mode === "LIVE") {
     console.log(`created webhook ${endpoint.id}`);
   }
 } else {
-  console.log("test mode: run `stripe listen --forward-to localhost:4040/api/billing/webhook`");
+  console.log(
+    "test mode without STRIPE_WEBHOOK_URL: use `stripe listen --forward-to localhost:4040/api/billing/webhook`",
+  );
 }
 
 console.log(`\n--- env for ${mode} ---`);
 console.log("STRIPE_SECRET_KEY=<already supplied>");
+console.log(`STRIPE_ACCOUNT_ID=${account.id}`);
 console.log(`STRIPE_PRICE_ID=${price.id}`);
 if (webhookSecretPath) console.log(`STRIPE_WEBHOOK_SECRET written to ${webhookSecretPath}`);

--- a/apps/web/scripts/stripe-setup.mjs
+++ b/apps/web/scripts/stripe-setup.mjs
@@ -23,17 +23,18 @@ import { reserveSecretEnvFile } from "./secure-secret-output.mjs";
 import {
   assertExpectedAccount,
   assertMonthlyPrice,
+  stripeKeyMode,
   WEBHOOK_EVENTS,
   webhookUrl,
 } from "./stripe-setup-utils.mjs";
 
 const key = process.env.STRIPE_SECRET_KEY;
 if (!key) {
-  console.error("Set STRIPE_SECRET_KEY (sk_test_… or sk_live_…)");
+  console.error("Set STRIPE_SECRET_KEY to a Stripe secret or restricted key");
   process.exit(1);
 }
 const stripe = new Stripe(key);
-const mode = key.startsWith("sk_live_") ? "LIVE" : "test";
+const mode = stripeKeyMode(key);
 const expectedAccountId = process.env.STRIPE_ACCOUNT_ID;
 const account = await stripe.accounts.retrieveCurrent();
 assertExpectedAccount(account.id, expectedAccountId);

--- a/apps/web/tests/billing-persistence.test.ts
+++ b/apps/web/tests/billing-persistence.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import type Stripe from "stripe";
+import { eq, subscriptions, user } from "@repo/db";
+import { createInMemoryDb, type InMemoryDb } from "@repo/db/testing";
+
+let mem: InMemoryDb;
+let recordSubscription: (subscription: Stripe.Subscription) => Promise<void>;
+
+function subscription(priceId = "price_sync"): Stripe.Subscription {
+  return {
+    id: "sub_fixture",
+    object: "subscription",
+    created: 1_800_000_000,
+    status: "active",
+    customer: "cus_fixture",
+    metadata: { doodlenoteUserId: "billing-user" },
+    items: {
+      object: "list",
+      data: [
+        {
+          id: "si_fixture",
+          object: "subscription_item",
+          created: 1_800_000_000,
+          current_period_end: 1_900_000_000,
+          current_period_start: 1_800_000_000,
+          discounts: [],
+          metadata: {},
+          price: { id: priceId },
+          quantity: 1,
+          subscription: "sub_fixture",
+          tax_rates: [],
+        } as unknown as Stripe.SubscriptionItem,
+      ],
+      has_more: false,
+      url: "/v1/subscription_items?subscription=sub_fixture",
+    },
+  } as unknown as Stripe.Subscription;
+}
+
+before(async () => {
+  process.env.STRIPE_PRICE_ID = "price_sync";
+  mem = await createInMemoryDb();
+  (globalThis as { __repoDbClient?: unknown }).__repoDbClient = mem.db;
+  ({ recordSubscription } = await import("../lib/billing"));
+  await mem.db.insert(user).values({
+    id: "billing-user",
+    name: "Billing User",
+    email: "billing-user@example.com",
+    emailVerified: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+});
+
+after(async () => {
+  delete (globalThis as { __repoDbClient?: unknown }).__repoDbClient;
+  await mem.close();
+});
+
+describe("subscription persistence", () => {
+  it("is effect-idempotent for a repeated subscription event", async () => {
+    await recordSubscription(subscription());
+    await recordSubscription(subscription());
+
+    const rows = await mem.db
+      .select()
+      .from(subscriptions)
+      .where(eq(subscriptions.userId, "billing-user"));
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]?.stripeSubscriptionId, "sub_fixture");
+    assert.equal(rows[0]?.status, "active");
+  });
+
+  it("does not grant access for a subscription on another Price", async () => {
+    await recordSubscription(subscription("price_other"));
+
+    const row = await mem.db
+      .select()
+      .from(subscriptions)
+      .where(eq(subscriptions.userId, "billing-user"))
+      .limit(1);
+    assert.equal(row[0]?.status, "invalid_price");
+  });
+});

--- a/apps/web/tests/billing-state.test.ts
+++ b/apps/web/tests/billing-state.test.ts
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type Stripe from "stripe";
+
+import {
+  checkoutBlocked,
+  checkoutIdempotencyKey,
+  entitlementFrom,
+  selectEffectiveSubscription,
+  subscriptionUsesPrice,
+} from "../lib/billing-state";
+
+function subscription(
+  id: string,
+  status: Stripe.Subscription.Status,
+  priceId = "price_sync",
+  created = 1,
+): Stripe.Subscription {
+  return {
+    id,
+    object: "subscription",
+    created,
+    status,
+    customer: "cus_fixture",
+    metadata: { doodlenoteUserId: "user-1" },
+    items: {
+      object: "list",
+      data: [
+        {
+          id: `si_${id}`,
+          object: "subscription_item",
+          created,
+          current_period_end: 1_800_000_000,
+          current_period_start: 1_700_000_000,
+          discounts: [],
+          metadata: {},
+          price: { id: priceId },
+          quantity: 1,
+          subscription: id,
+          tax_rates: [],
+        } as unknown as Stripe.SubscriptionItem,
+      ],
+      has_more: false,
+      url: `/v1/subscription_items?subscription=${id}`,
+    },
+  } as unknown as Stripe.Subscription;
+}
+
+describe("billing entitlement state", () => {
+  it("preserves explicit self-hosted and development access", () => {
+    assert.deepEqual(entitlementFrom("development"), {
+      entitled: true,
+      reason: "development",
+    });
+    assert.deepEqual(entitlementFrom("self-hosted"), {
+      entitled: true,
+      reason: "self-hosted",
+    });
+  });
+
+  it("fails closed for incomplete hosted configuration", () => {
+    assert.deepEqual(entitlementFrom("misconfigured"), {
+      entitled: false,
+      reason: "configuration_error",
+    });
+  });
+
+  it("preserves grandfathered access without marketing it as a new offer", () => {
+    assert.deepEqual(
+      entitlementFrom("stripe", {
+        status: "canceled",
+        grandfathered: true,
+        currentPeriodEnd: null,
+      }),
+      {
+        entitled: true,
+        reason: "grandfathered",
+        subscriptionStatus: "canceled",
+      },
+    );
+  });
+
+  it("serves trialing, active, and past-due subscriptions", () => {
+    const periodEnd = new Date("2026-09-12T12:00:00.000Z");
+    for (const status of ["trialing", "active", "past_due"] as const) {
+      assert.deepEqual(
+        entitlementFrom("stripe", {
+          status,
+          grandfathered: false,
+          currentPeriodEnd: periodEnd,
+        }),
+        {
+          entitled: true,
+          reason: status,
+          periodEnd: periodEnd.toISOString(),
+          subscriptionStatus: status,
+        },
+      );
+    }
+  });
+
+  it("keeps non-serving Stripe statuses bounded behind lapsed", () => {
+    for (const status of ["canceled", "unpaid", "incomplete", "paused"] as const) {
+      assert.deepEqual(
+        entitlementFrom("stripe", {
+          status,
+          grandfathered: false,
+          currentPeriodEnd: null,
+        }),
+        {
+          entitled: false,
+          reason: "lapsed",
+          subscriptionStatus: status,
+        },
+      );
+    }
+  });
+});
+
+describe("checkout and subscription reconciliation", () => {
+  it("blocks checkout for entitled and recoverable subscriptions", () => {
+    assert.equal(checkoutBlocked({ entitled: true, reason: "active" }), true);
+    assert.equal(
+      checkoutBlocked({
+        entitled: false,
+        reason: "lapsed",
+        subscriptionStatus: "incomplete",
+      }),
+      true,
+    );
+    assert.equal(
+      checkoutBlocked({
+        entitled: false,
+        reason: "lapsed",
+        subscriptionStatus: "unpaid",
+      }),
+      true,
+    );
+  });
+
+  it("allows checkout for a new or terminal subscription", () => {
+    assert.equal(checkoutBlocked({ entitled: false, reason: "none" }), false);
+    assert.equal(
+      checkoutBlocked({
+        entitled: false,
+        reason: "lapsed",
+        subscriptionStatus: "canceled",
+      }),
+      false,
+    );
+    assert.equal(
+      checkoutBlocked({
+        entitled: false,
+        reason: "lapsed",
+        subscriptionStatus: "incomplete_expired",
+      }),
+      false,
+    );
+  });
+
+  it("accepts only the configured recurring price", () => {
+    assert.equal(subscriptionUsesPrice(subscription("sub_1", "active"), "price_sync"), true);
+    assert.equal(subscriptionUsesPrice(subscription("sub_2", "active", "price_other"), "price_sync"), false);
+  });
+
+  it("selects current serving state instead of a late terminal event", () => {
+    const selected = selectEffectiveSubscription(
+      [
+        subscription("sub_old", "canceled", "price_sync", 10),
+        subscription("sub_current", "active", "price_sync", 20),
+        subscription("sub_other", "active", "price_other", 30),
+      ],
+      "price_sync",
+    );
+    assert.equal(selected?.id, "sub_current");
+  });
+
+  it("uses a stable, non-identifying idempotency key for the same attempt", () => {
+    const first = checkoutIdempotencyKey(
+      "person@example.com",
+      "/app",
+      new Date("2026-08-28T21:10:00Z"),
+    );
+    const retry = checkoutIdempotencyKey(
+      "person@example.com",
+      "/app",
+      new Date("2026-08-28T21:29:59Z"),
+    );
+    const nextAttempt = checkoutIdempotencyKey(
+      "person@example.com",
+      "/app",
+      new Date("2026-08-28T21:30:00Z"),
+    );
+
+    assert.equal(first, retry);
+    assert.notEqual(first, nextAttempt);
+    assert.doesNotMatch(first, /person|example/);
+  });
+});

--- a/apps/web/tests/billing-state.test.ts
+++ b/apps/web/tests/billing-state.test.ts
@@ -163,6 +163,18 @@ describe("checkout and subscription reconciliation", () => {
     assert.equal(subscriptionUsesPrice(subscription("sub_2", "active", "price_other"), "price_sync"), false);
   });
 
+  it("rejects mixed-price and multi-seat subscriptions", () => {
+    const mixed = subscription("sub_mixed", "active");
+    mixed.items.data.push(
+      subscription("sub_other", "active", "price_other").items.data[0]!,
+    );
+    assert.equal(subscriptionUsesPrice(mixed, "price_sync"), false);
+
+    const multiSeat = subscription("sub_multi", "active");
+    multiSeat.items.data[0]!.quantity = 2;
+    assert.equal(subscriptionUsesPrice(multiSeat, "price_sync"), false);
+  });
+
   it("selects current serving state instead of a late terminal event", () => {
     const selected = selectEffectiveSubscription(
       [

--- a/apps/web/tests/billing-view.test.ts
+++ b/apps/web/tests/billing-view.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+import { billingViewFromStatus } from "../app/pricing/billing-view";
+
+describe("pricing billing status", () => {
+  it("does not mislabel a failed status request as signed out", () => {
+    assert.deepEqual(billingViewFromStatus(false, { error: "database unavailable" }), {
+      kind: "error",
+    });
+    assert.deepEqual(billingViewFromStatus(true, null), { kind: "error" });
+  });
+
+  it("keeps signed-out, disabled, trial, and subscription states explicit", () => {
+    assert.deepEqual(
+      billingViewFromStatus(true, {
+        entitled: false,
+        reason: "signed-out",
+        billingEnabled: true,
+      }),
+      { kind: "signed-out" },
+    );
+    assert.deepEqual(
+      billingViewFromStatus(true, {
+        entitled: false,
+        reason: "configuration_error",
+        billingEnabled: false,
+      }),
+      { kind: "disabled" },
+    );
+    assert.deepEqual(
+      billingViewFromStatus(true, {
+        entitled: false,
+        reason: "none",
+        billingEnabled: true,
+      }),
+      { kind: "start-trial" },
+    );
+    assert.deepEqual(
+      billingViewFromStatus(true, {
+        entitled: true,
+        reason: "trialing",
+        billingEnabled: true,
+      }),
+      { kind: "subscribed", reason: "trialing" },
+    );
+  });
+
+  it("represents legacy access without a forever-free claim", () => {
+    assert.deepEqual(
+      billingViewFromStatus(true, {
+        entitled: true,
+        reason: "grandfathered",
+        billingEnabled: true,
+      }),
+      { kind: "legacy-access" },
+    );
+
+    const button = readFileSync(
+      new URL("../app/pricing/checkout-button.tsx", import.meta.url),
+      "utf8",
+    );
+    const page = readFileSync(
+      new URL("../app/pricing/page.tsx", import.meta.url),
+      "utf8",
+    );
+    assert.doesNotMatch(button, /early supporter|Sync is free on your account/i);
+    assert.doesNotMatch(page, /Early access/);
+    assert.match(page, /\/ user \/ month/);
+  });
+});

--- a/apps/web/tests/billing-view.test.ts
+++ b/apps/web/tests/billing-view.test.ts
@@ -12,7 +12,7 @@ describe("pricing billing status", () => {
     assert.deepEqual(billingViewFromStatus(true, null), { kind: "error" });
   });
 
-  it("keeps signed-out, disabled, trial, and subscription states explicit", () => {
+  it("keeps signed-out, disabled, configuration, trial, and subscription states explicit", () => {
     assert.deepEqual(
       billingViewFromStatus(true, {
         entitled: false,
@@ -25,6 +25,14 @@ describe("pricing billing status", () => {
       billingViewFromStatus(true, {
         entitled: false,
         reason: "configuration_error",
+        billingEnabled: false,
+      }),
+      { kind: "configuration-error" },
+    );
+    assert.deepEqual(
+      billingViewFromStatus(true, {
+        entitled: true,
+        reason: "development",
         billingEnabled: false,
       }),
       { kind: "disabled" },
@@ -44,6 +52,14 @@ describe("pricing billing status", () => {
         billingEnabled: true,
       }),
       { kind: "subscribed", reason: "trialing" },
+    );
+    assert.deepEqual(
+      billingViewFromStatus(true, {
+        entitled: true,
+        reason: "unexpected",
+        billingEnabled: true,
+      }),
+      { kind: "error" },
     );
   });
 

--- a/apps/web/tests/billing-webhook.test.ts
+++ b/apps/web/tests/billing-webhook.test.ts
@@ -1,17 +1,32 @@
 import assert from "node:assert/strict";
-import { before, describe, it } from "node:test";
+import { after, before, describe, it } from "node:test";
 import Stripe from "stripe";
 
 const WEBHOOK_SECRET = "whsec_fixture_secret";
 let post: (request: Request) => Promise<Response>;
 const stripe = new Stripe("sk_test_fixture");
+let originalSelfHosted: string | undefined;
 
 before(async () => {
+  originalSelfHosted = process.env.DOODLENOTE_SELF_HOSTED;
+  delete process.env.DOODLENOTE_SELF_HOSTED;
   process.env.STRIPE_SECRET_KEY = "sk_test_fixture";
   process.env.STRIPE_ACCOUNT_ID = "acct_fixture";
   process.env.STRIPE_PRICE_ID = "price_fixture";
   process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
   ({ POST: post } = await import("../app/api/billing/webhook/route"));
+});
+
+after(() => {
+  if (originalSelfHosted === undefined) {
+    delete process.env.DOODLENOTE_SELF_HOSTED;
+  } else {
+    process.env.DOODLENOTE_SELF_HOSTED = originalSelfHosted;
+  }
+  delete process.env.STRIPE_SECRET_KEY;
+  delete process.env.STRIPE_ACCOUNT_ID;
+  delete process.env.STRIPE_PRICE_ID;
+  delete process.env.STRIPE_WEBHOOK_SECRET;
 });
 
 function request(payload: string, signature: string) {

--- a/apps/web/tests/billing-webhook.test.ts
+++ b/apps/web/tests/billing-webhook.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import Stripe from "stripe";
+
+const WEBHOOK_SECRET = "whsec_fixture_secret";
+let post: (request: Request) => Promise<Response>;
+const stripe = new Stripe("sk_test_fixture");
+
+before(async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_fixture";
+  process.env.STRIPE_ACCOUNT_ID = "acct_fixture";
+  process.env.STRIPE_PRICE_ID = "price_fixture";
+  process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
+  ({ POST: post } = await import("../app/api/billing/webhook/route"));
+});
+
+function request(payload: string, signature: string) {
+  return new Request("http://localhost/api/billing/webhook", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "stripe-signature": signature,
+    },
+    body: payload,
+  });
+}
+
+describe("Stripe webhook signature boundary", () => {
+  const payload = JSON.stringify({
+    id: "evt_fixture",
+    object: "event",
+    api_version: "2026-02-25.clover",
+    created: 1_800_000_000,
+    data: { object: { id: "seti_fixture", object: "setup_intent" } },
+    livemode: false,
+    pending_webhooks: 1,
+    request: null,
+    type: "setup_intent.created",
+  });
+
+  it("rejects an invalid signature", async () => {
+    const response = await post(request(payload, "invalid"));
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { error: "Bad signature" });
+  });
+
+  it("accepts a valid signature without logging or returning the payload", async () => {
+    const signature = stripe.webhooks.generateTestHeaderString({
+      payload,
+      secret: WEBHOOK_SECRET,
+    });
+    const response = await post(request(payload, signature));
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { received: true });
+  });
+});

--- a/apps/web/tests/runtime-config.test.ts
+++ b/apps/web/tests/runtime-config.test.ts
@@ -75,6 +75,16 @@ test("hosted production requires the complete Stripe group", () => {
       STRIPE_PRICE_ID: "price",
       STRIPE_WEBHOOK_SECRET: "webhook",
     }),
+    "misconfigured",
+  );
+  assert.equal(
+    resolveBillingMode({
+      NODE_ENV: "production",
+      STRIPE_SECRET_KEY: "secret",
+      STRIPE_ACCOUNT_ID: "acct_test",
+      STRIPE_PRICE_ID: "price",
+      STRIPE_WEBHOOK_SECRET: "webhook",
+    }),
     "stripe",
   );
 });

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -205,10 +205,9 @@ export const agentTokens = pgTable(
 );
 
 /**
- * Per-user cloud-sync billing. A user syncs when their Stripe subscription
- * is trialing, active, or past_due (grace). The grandfathered column is
- * retained for historical rows but no longer grants Sync access. No row =
- * never subscribed.
+ * Per-user cloud-sync billing. A user syncs when grandfathered (had a
+ * linked device before launch) or their Stripe subscription is trialing,
+ * active, or past_due (grace). No row = never subscribed.
  */
 export const subscriptions = pgTable("subscriptions", {
   userId: text("user_id")

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -205,9 +205,10 @@ export const agentTokens = pgTable(
 );
 
 /**
- * Per-user cloud-sync billing. A user syncs when grandfathered (had a
- * linked device before billing launched) or their Stripe subscription is
- * trialing/active. No row = never subscribed.
+ * Per-user cloud-sync billing. A user syncs when their Stripe subscription
+ * is trialing, active, or past_due (grace). The grandfathered column is
+ * retained for historical rows but no longer grants Sync access. No row =
+ * never subscribed.
  */
 export const subscriptions = pgTable("subscriptions", {
   userId: text("user_id")


### PR DESCRIPTION
## Linear Issue

- [ONY-214: Restore and verify paid DoodleNote Sync billing](https://linear.app/onyxdevlabs/issue/ONY-214/restore-and-verify-paid-doodlenote-sync-billing)

## Outcome

- Restores the official DoodleNote Cloud Sync purchase path at $10 per user per month with a 15-day trial.
- Removes early-access and forever-free Sync marketing while preserving existing legacy entitlement.
- Keeps Checkout, Customer Portal, webhooks, device linking, and Sync access on one server-controlled billing state.

## What Changed

- Requires `STRIPE_ACCOUNT_ID` and verifies the Stripe account before API mutations.
- Allows only one unit of the configured Price. Mixed-price and multi-seat subscriptions cannot grant access.
- Prevents duplicate subscriptions through persisted-state guards, current Stripe reconciliation, open Checkout reuse, and idempotent Stripe POSTs.
- Reconciles duplicate and out-of-order webhook events against current Stripe subscription state.
- Separates loading, signed-out, disabled, configuration-error, Checkout-error, portal-error, legacy, active, and payment-attention states.
- Keeps automated billing E2E tooling test-mode-only and rejects a mismatched Stripe account.
- Supports both standard and restricted Stripe keys in provisioning safeguards.

## Acceptance Criteria Evidence

- [x] Configured account and Price are server-controlled and fail closed on mismatch.
- [x] Mixed-price, wrong-price, and multi-seat subscriptions cannot grant entitlement.
- [x] Duplicate Checkout and recoverable-subscription paths are guarded.
- [x] Invalid webhook signatures are rejected and repeated persistence is effect-idempotent.
- [x] Out-of-order subscription events reconcile to current Stripe state.
- [x] Grandfathered users retain access without early-access or forever-free marketing.
- [x] Billing UI states are explicit and subscribed reasons are bounded.
- [x] Test-preview QA previously completed the real Stripe test journey, including Checkout, webhook entitlement, Customer Portal, device linking, Sync, cancellation, and post-cancel rejection.
- [ ] Production purchase, webhook, portal, and cancellation validation follows merge and deployment.

## Verification

- `pnpm install --frozen-lockfile` passed.
- `pnpm --filter web test` passed, 62 tests.
- `pnpm --filter web lint` passed.
- `pnpm --filter web typecheck` passed.
- `pnpm --filter web build` passed with Next.js 16.2.11.
- `pnpm lint` passed.
- `pnpm audit --prod --audit-level=low` found no known vulnerabilities.
- Refreshed GitHub CI, Windows packaging, CodeQL, and Vercel Preview checks passed at `f5a9298`.
- Preview smoke passed: pricing 200, login 200, signed-out billing status 200, unauthenticated Checkout 401.
- Secret-pattern scan of changed files found no committed credentials.

## Production Readiness

- Live Product: `prod_VAbDeJaLhaXrfH`.
- Live Price: `price_1UAG1IGnaJCgN4Md0cxdlJD5`, USD $10/month.
- Live webhook: `we_1UAG2mGnaJCgN4MdTa3kW5dg` for the four required billing events.
- Production-only Stripe account, Price, restricted runtime key, and webhook-secret variables are staged in Vercel as sensitive values.
- No database schema migration is required.
- Production remains on deployment `dpl_6muqe18eyyZypmrAcTkojCRGmASp` until this PR is merged.

## Human QA After Deployment

1. Sign in to production with the approved validation account.
2. Start hosted Checkout and confirm the $10/month plan with a 15-day trial.
3. Complete Checkout using a Sean-controlled payment method.
4. Confirm the webhook grants trial entitlement and the Customer Portal opens.
5. Cancel the validation subscription before the trial ends.
6. Confirm the webhook-backed post-cancel entitlement state.

## Risks and Rollback

- Merge to `main` automatically triggers the Vercel Production deployment.
- The validation Checkout stores a payment method. Cancel before the trial ends to prevent the first $10 renewal charge.
- Legacy access remains unchanged. Its migration is separate work.
- Code rollback is a revert of the PR merge followed by the normal Vercel deployment.
- Stripe rollback is cancellation of the validation subscription. The approved Product, Price, webhook, and dedicated runtime key can remain staged for the corrected deployment.

## Remaining Gate

- Required code-owner approval from `@alectribble` before merge.
