### PR TITLE
docs: publish v0.4.15 changelog

### DIFF
--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,13 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.15",
+    date: "August 28, 2026",
+    highlights: [
+      "Keep to-do checkboxes and checked state when reopening regular notes and meeting notes",
+    ],
+  },
+  {
     version: "0.4.14",
     date: "August 27, 2026",
     highlights: [


### PR DESCRIPTION
Publishes the existing DoodleNote 0.4.15 release note for ONY-213. This is a changelog-only production follow-up and does not merge PR #92.