### PR TITLE
Fix transcript recovery and dead Generate notes states

### DIFF
--- a/apps/desktop/src/main/meeting-recovery.test.ts
+++ b/apps/desktop/src/main/meeting-recovery.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  isStoredCloudProvider,
+  meetingPrimaryAction,
+  transcriptCheckpointDelayMs
+} from '../shared/meeting-recovery'
+
+test('saved audio with no transcript offers transcription recovery', () => {
+  assert.equal(
+    meetingPrimaryAction({
+      capturing: false,
+      segmentCount: 0,
+      audioPartCount: 1,
+      modelReady: false,
+      enhancedPresent: false,
+      generating: false,
+      retranscribing: false
+    }),
+    'transcribe'
+  )
+})
+
+test('a meeting with transcript but no notes model offers model setup', () => {
+  assert.equal(
+    meetingPrimaryAction({
+      capturing: false,
+      segmentCount: 4,
+      audioPartCount: 1,
+      modelReady: false,
+      enhancedPresent: false,
+      generating: false,
+      retranscribing: false
+    }),
+    'configure-model'
+  )
+})
+
+test('live transcript segments are checkpointed before a normal stop', () => {
+  assert.equal(transcriptCheckpointDelayMs('recording', 4), 1_000)
+  assert.equal(transcriptCheckpointDelayMs('finishing', 4), 400)
+  assert.equal(transcriptCheckpointDelayMs('ended', 4), 0)
+  assert.equal(transcriptCheckpointDelayMs('idle', 4), null)
+  assert.equal(transcriptCheckpointDelayMs('recording', 0), null)
+})
+
+test('every supported cloud provider survives settings reload', () => {
+  for (const provider of ['anthropic', 'openai', 'groq', 'openrouter', 'ollama']) {
+    assert.equal(isStoredCloudProvider(provider), true, provider)
+  }
+  assert.equal(isStoredCloudProvider('not-a-provider'), false)
+})

--- a/apps/desktop/src/main/notes-service.ts
+++ b/apps/desktop/src/main/notes-service.ts
@@ -42,6 +42,7 @@ import {
   type NotesSettingsView
 } from '../shared/notes-api'
 import type { MeetingRecord } from '../shared/meetings-api'
+import { isStoredCloudProvider } from '../shared/meeting-recovery'
 import type { MeetingsService } from './meetings-service'
 
 /**
@@ -568,14 +569,16 @@ export class NotesService {
       const cloud = raw.cloud
       if (
         cloud &&
-        (cloud.provider === 'anthropic' || cloud.provider === 'openai') &&
-        typeof cloud.apiKeyEncrypted === 'string' &&
-        cloud.apiKeyEncrypted.length > 0
+        isStoredCloudProvider(cloud.provider) &&
+        (cloud.provider === 'ollama' ||
+          (typeof cloud.apiKeyEncrypted === 'string' && cloud.apiKeyEncrypted.length > 0))
       ) {
         settings.cloud = {
           provider: cloud.provider,
           ...(typeof cloud.model === 'string' && cloud.model ? { model: cloud.model } : {}),
-          apiKeyEncrypted: cloud.apiKeyEncrypted
+          ...(typeof cloud.apiKeyEncrypted === 'string'
+            ? { apiKeyEncrypted: cloud.apiKeyEncrypted }
+            : {})
         }
       }
       return settings

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -619,7 +619,10 @@ function App(): React.JSX.Element {
             }
             onDiscardDraft={() => discardNewDraft(meetingId)}
             onBack={goHome}
-            onOpenSettings={() => setView('settings')}
+            onOpenSettings={() => {
+              setSettingsJump({ section: 'model', n: Date.now() })
+              setView('settings')
+            }}
           />
         </div>
       )}

--- a/apps/desktop/src/renderer/src/MeetingView.tsx
+++ b/apps/desktop/src/renderer/src/MeetingView.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../shared/audio-api'
 import type { FolderRecord } from '../../shared/folders-api'
 import type { MeetingChatEntry, MeetingRecord } from '../../shared/meetings-api'
+import { meetingPrimaryAction, transcriptCheckpointDelayMs } from '../../shared/meeting-recovery'
 import {
   defaultSpeakerId,
   defaultSpeakerLabel,
@@ -699,6 +700,16 @@ export default function MeetingView({
       ),
     [savedSegments, state.segments, roster]
   )
+  const transcriptCheckpointRef = useRef({
+    segments: allSegments,
+    echoSuppressed: savedEcho + state.echoCount
+  })
+  useEffect(() => {
+    transcriptCheckpointRef.current = {
+      segments: allSegments,
+      echoSuppressed: savedEcho + state.echoCount
+    }
+  }, [allSegments, savedEcho, state.echoCount])
 
   /** Assign a name once and apply it to every line that speaker owns. */
   const applyRename = useCallback(
@@ -714,19 +725,39 @@ export default function MeetingView({
   )
 
   useEffect(() => {
-    if (phase !== 'ended') return
-    if (sessionSaveTimerRef.current !== null) clearTimeout(sessionSaveTimerRef.current)
-    // No cleanup on unmount: the timeout only persists (no setState), so
-    // letting it fire after the view is gone still lands the final flush.
-    sessionSaveTimerRef.current = setTimeout(() => {
+    const delay = transcriptCheckpointDelayMs(phase, allSegments.length)
+    if (delay === null) {
+      if (sessionSaveTimerRef.current !== null) {
+        clearTimeout(sessionSaveTimerRef.current)
+        sessionSaveTimerRef.current = null
+      }
+      return
+    }
+    const saveTranscript = (): void => {
       sessionSaveTimerRef.current = null
+      const checkpoint = transcriptCheckpointRef.current
       persist({
-        segments: allSegments,
-        echoSuppressed: savedEcho + state.echoCount,
-        endedAt: new Date().toISOString()
+        segments: checkpoint.segments,
+        echoSuppressed: checkpoint.echoSuppressed,
+        ...(phase === 'ended' ? { endedAt: new Date().toISOString() } : {})
       })
-    }, 400)
-  }, [phase, allSegments, savedEcho, state.echoCount, persist])
+    }
+    if (delay === 0) {
+      if (sessionSaveTimerRef.current !== null) {
+        clearTimeout(sessionSaveTimerRef.current)
+        sessionSaveTimerRef.current = null
+      }
+      saveTranscript()
+      return
+    }
+    // Throttle rather than debounce. Continuous speech can add segments every
+    // second; resetting this timer on every segment would postpone the first
+    // crash-safe checkpoint indefinitely.
+    if (sessionSaveTimerRef.current !== null) return
+    sessionSaveTimerRef.current = setTimeout(() => {
+      saveTranscript()
+    }, delay)
+  }, [phase, allSegments.length, persist])
 
   // A session that ends with zero transcript is otherwise indistinguishable
   // from success ("I hit stop and nothing happened") — say so explicitly.
@@ -881,7 +912,9 @@ export default function MeetingView({
     if (retranscribing || capturing) return
     if (
       !window.confirm(
-        'Re-transcribe this meeting from its saved recording? The current transcript is replaced; your notes are kept.'
+        allSegments.length > 0
+          ? 'Re-transcribe this meeting from its saved recording? The current transcript is replaced; your notes are kept.'
+          : 'Transcribe this meeting from its saved recording? Your notes are kept.'
       )
     ) {
       return
@@ -940,6 +973,15 @@ export default function MeetingView({
   const cloudReady = settings?.engineChoice === 'cloud' && settings.cloud?.hasKey === true
   const modelReady = cloudReady || anyDownloaded
   const canEnhance = allSegments.length > 0 && modelReady && enhanceStatus !== 'running'
+  const primaryAction = meetingPrimaryAction({
+    capturing,
+    segmentCount: allSegments.length,
+    audioPartCount: audioParts.length,
+    modelReady,
+    enhancedPresent: enhancedMarkdown !== null,
+    generating: enhanceStatus === 'running',
+    retranscribing
+  })
 
   const runEnhance = async (selectedTemplateId = templateId): Promise<void> => {
     if (!editor || enhanceStatus === 'running') return
@@ -1705,35 +1747,61 @@ export default function MeetingView({
         </div>
       )}
 
-      {!capturing && allSegments.length > 0 && enhancedMarkdown === null && (
+      {primaryAction !== 'hidden' && (
         <div className="generate-cta-wrap tpl-anchor">
           <button
             type="button"
             className="generate-cta"
-            disabled={!canEnhance}
-            title={!modelReady ? 'Activate a notes model in Settings first' : 'Generate notes'}
-            onClick={() => void runEnhance()}
+            disabled={primaryAction === 'generating' || primaryAction === 'transcribing'}
+            title={
+              primaryAction === 'configure-model'
+                ? 'Choose a local model or connect an AI provider'
+                : primaryAction === 'transcribe' || primaryAction === 'transcribing'
+                  ? 'Build a transcript from the saved recording'
+                  : 'Generate notes'
+            }
+            onClick={() => {
+              if (primaryAction === 'configure-model') onOpenSettings()
+              else if (primaryAction === 'transcribe') void runRetranscribe()
+              else if (primaryAction === 'generate') void runEnhance()
+            }}
           >
             {enhanceStatus === 'running' ? (
               <DoodlingIndicator statusText={enhanceProgressText} />
+            ) : primaryAction === 'transcribing' ? (
+              <>
+                <span className="spinner" aria-hidden="true" /> Transcribing recording…
+              </>
+            ) : primaryAction === 'transcribe' ? (
+              <>
+                <SparkleIcon size={14} /> Transcribe recording
+              </>
+            ) : primaryAction === 'configure-model' ? (
+              <>
+                <SparkleIcon size={14} /> Set up notes model
+              </>
             ) : (
               <>
                 <SparkleIcon size={14} /> Generate notes
               </>
             )}
           </button>
-          <button
-            type="button"
-            className="generate-cta generate-cta-arrow"
-            disabled={!canEnhance}
-            title="Choose a note template"
-            aria-label="Choose a note template"
-            aria-expanded={tplMenuOpen}
-            onClick={() => setTplMenuOpen((o) => !o)}
-          >
-            ▾
-          </button>
-          {tplMenuOpen && templateMenu}
+          {(primaryAction === 'generate' || primaryAction === 'generating') && (
+            <>
+              <button
+                type="button"
+                className="generate-cta generate-cta-arrow"
+                disabled={!canEnhance}
+                title="Choose a note template"
+                aria-label="Choose a note template"
+                aria-expanded={tplMenuOpen}
+                onClick={() => setTplMenuOpen((o) => !o)}
+              >
+                ▾
+              </button>
+              {tplMenuOpen && templateMenu}
+            </>
+          )}
         </div>
       )}
 

--- a/apps/desktop/src/shared/meeting-recovery.ts
+++ b/apps/desktop/src/shared/meeting-recovery.ts
@@ -1,0 +1,51 @@
+export type MeetingPrimaryAction =
+  'hidden' | 'generate' | 'generating' | 'transcribe' | 'transcribing' | 'configure-model'
+
+export interface MeetingPrimaryActionInput {
+  capturing: boolean
+  segmentCount: number
+  audioPartCount: number
+  modelReady: boolean
+  enhancedPresent: boolean
+  generating: boolean
+  retranscribing: boolean
+}
+
+/** Resolve the meeting CTA so recovery and setup states stay actionable. */
+export function meetingPrimaryAction(input: MeetingPrimaryActionInput): MeetingPrimaryAction {
+  if (input.capturing || input.enhancedPresent) return 'hidden'
+  if (input.segmentCount === 0) {
+    if (input.audioPartCount === 0) return 'hidden'
+    return input.retranscribing ? 'transcribing' : 'transcribe'
+  }
+  if (input.generating) return 'generating'
+  if (!input.modelReady) return 'configure-model'
+  return 'generate'
+}
+
+export type TranscriptCheckpointPhase = 'idle' | 'starting' | 'recording' | 'finishing' | 'ended'
+
+/** Delay before the renderer persists the transcript for the current phase. */
+export function transcriptCheckpointDelayMs(
+  phase: TranscriptCheckpointPhase,
+  segmentCount: number
+): number | null {
+  if (segmentCount === 0) return null
+  if (phase === 'recording') return 1_000
+  if (phase === 'finishing') return 400
+  if (phase === 'ended') return 0
+  return null
+}
+
+/** Providers whose encrypted settings can be restored after an app restart. */
+export function isStoredCloudProvider(
+  value: unknown
+): value is 'anthropic' | 'openai' | 'groq' | 'openrouter' | 'ollama' {
+  return (
+    value === 'anthropic' ||
+    value === 'openai' ||
+    value === 'groq' ||
+    value === 'openrouter' ||
+    value === 'ollama'
+  )
+}


### PR DESCRIPTION
## Bug

A long recording could retain recoverable audio but lose its transcript when the app exited before the normal stop path. Meetings with saved audio and no transcript then had no primary recovery action. Separately, Generate notes looked hung when no notes model was configured because the control was silently disabled. Groq, OpenRouter, and Ollama settings were also dropped on restart.

## Root cause

Transcript segments were only persisted to the meeting record after the renderer reached the normal ended phase. The notes CTA hid empty-transcript recordings and disabled itself for missing model configuration without an actionable explanation. Settings reload accepted only Anthropic and OpenAI.

## Fix

- Checkpoint live transcript segments during recording and persist immediately on normal completion.
- Show Transcribe recording when saved audio has no transcript.
- Show Set up notes model and open the Notes model settings section when AI notes are not configured.
- Restore every supported cloud provider, including keyless Ollama, after restart.
- Add focused regression coverage for all four failure modes.

## Verification

- pnpm --filter desktop test: 131 passed, 3 skipped, 0 failed
- pnpm --filter desktop run lint
- pnpm --filter desktop run typecheck
- pnpm --filter desktop run build
- git diff --check

## Risk and follow-up

Transcript checkpoints add local meeting writes while recording. Writes are throttled so continuous speech cannot postpone crash protection indefinitely. This PR does not install, release, merge, or deploy the app.