### PR TITLE
Release DoodleNote v0.4.16

### DIFF
--- a/RELEASE-v0.4.16.md
+++ b/RELEASE-v0.4.16.md
@@ -1,0 +1,46 @@
+# DoodleNote v0.4.16 release candidate
+
+## Included
+
+- [x] Checkpoint transcript segments while a recording is active
+- [x] Offer transcription recovery when saved audio has no transcript
+- [x] Route an unavailable Generate notes action to Notes model setup
+- [x] Restore Groq, OpenRouter, and Ollama settings after restart
+- [x] Add focused regression coverage for all four failure modes
+- [x] Bump the desktop version from the stale source value 0.4.14 to 0.4.16, following the live 0.4.15 release
+- [x] Add the v0.4.16 changelog entry
+
+## Verification
+
+- [ ] Frozen-lockfile dependency install
+- [ ] Swift transcription engine release build
+- [ ] Workspace typecheck
+- [ ] Full desktop test suite
+- [ ] Desktop lint
+- [ ] Production Electron and web builds
+- [ ] Production dependency audit
+- [ ] Packaged application reports version 0.4.16
+- [ ] Developer ID signature and hardened runtime validation
+- [ ] App notarization and stapled-ticket validation
+- [ ] Final DMG signature, notarization, stapling, and Gatekeeper validation
+- [ ] Updater ZIP and website DMG checksums recorded
+- [ ] Updater manifest references only version-matched v0.4.16 artifacts
+
+## Release gates
+
+- [x] User authorized review bypass, merge, packaging, and publication
+- [ ] Release PR has green required CI
+- [ ] Release PR merged into main
+- [ ] Public update feed reports 0.4.16
+- [ ] Public ZIP checksum matches the release artifact
+- [ ] Public DMG checksum matches the release artifact
+- [ ] Installed 0.4.15 client detects the 0.4.16 update
+
+## Package
+
+- Updater artifact: `DoodleNote-0.4.16-arm64-mac.zip`
+- Website installer: `DoodleNote-0.4.16-arm64.dmg`
+- Updater ZIP SHA-256: pending
+- Website DMG SHA-256: pending
+- App notarization submission: pending
+- DMG notarization submission: pending

--- a/RELEASE-v0.4.16.md
+++ b/RELEASE-v0.4.16.md
@@ -12,19 +12,19 @@
 
 ## Verification
 
-- [ ] Frozen-lockfile dependency install
-- [ ] Swift transcription engine release build
-- [ ] Workspace typecheck
-- [ ] Full desktop test suite
-- [ ] Desktop lint
-- [ ] Production Electron and web builds
-- [ ] Production dependency audit
-- [ ] Packaged application reports version 0.4.16
-- [ ] Developer ID signature and hardened runtime validation
-- [ ] App notarization and stapled-ticket validation
-- [ ] Final DMG signature, notarization, stapling, and Gatekeeper validation
-- [ ] Updater ZIP and website DMG checksums recorded
-- [ ] Updater manifest references only version-matched v0.4.16 artifacts
+- [x] Frozen-lockfile dependency install
+- [x] Swift transcription engine release build
+- [x] Workspace typecheck
+- [x] Full workspace test suite: 220 tests passed
+- [x] Desktop lint
+- [x] Production Electron, web, and MCP builds
+- [x] Production dependency audit: no known vulnerabilities
+- [x] Packaged application reports version 0.4.16
+- [x] Developer ID signature and hardened runtime validation
+- [x] App notarization and stapled-ticket validation
+- [x] Final DMG signature, notarization, stapling, and Gatekeeper validation
+- [x] Updater ZIP and website DMG checksums recorded
+- [x] Updater manifest references only version-matched v0.4.16 artifacts
 
 ## Release gates
 
@@ -40,7 +40,7 @@
 
 - Updater artifact: `DoodleNote-0.4.16-arm64-mac.zip`
 - Website installer: `DoodleNote-0.4.16-arm64.dmg`
-- Updater ZIP SHA-256: pending
-- Website DMG SHA-256: pending
-- App notarization submission: pending
-- DMG notarization submission: pending
+- Updater ZIP SHA-256: `4ce66c7b54f10afb4f9221af6da7a68c7effdf7f89d5192b3246183f5fb5d60b`
+- Website DMG SHA-256: `06434cc947b4618f188075f847e357463480fab6510b5fce56da76009a4f0942`
+- App notarization submission: `b7b1bf42-27ca-4495-948c-2236b93a77fa` (Accepted)
+- DMG notarization submission: `4db73b9e-ee89-44f4-ac90-c24854eb5b3a` (Accepted)

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.14",
+  "version": "0.4.16",
   "private": true,
   "description": "DoodleNote desktop app for privacy-first local capture, transcription, and AI meeting notes",
   "main": "./out/main/index.js",

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,16 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.16",
+    date: "August 28, 2026",
+    highlights: [
+      "Checkpoint transcripts during recording so an unexpected quit cannot erase an entire meeting transcript",
+      "Show Transcribe recording when saved audio needs its transcript rebuilt",
+      "Turn an unavailable Generate notes button into a direct Notes model setup action",
+      "Keep Groq, OpenRouter, and Ollama notes settings active after restarting DoodleNote",
+    ],
+  },
+  {
     version: "0.4.15",
     date: "August 28, 2026",
     highlights: [

--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,11 +1,11 @@
-version: 0.4.15
+version: 0.4.16
 files:
-  - url: DoodleNote-0.4.15-arm64-mac.zip
-    sha512: 4tJvSFFWj1tEDCArSFiH8rrt21SKN0Jcmh/r6pdZ6ZdEY6riwBdlAO51S+MnynidgZUnlN2vpjUfwDuOfwdRJg==
-    size: 185920855
-  - url: DoodleNote-0.4.15-arm64.dmg
-    sha512: ZbCtoQv1a7yWyVGOTGKD4oee31MeYQXpmEL9/lXqDpCt49lWZPME+Lko1qXXI46gjf8yWXz6K25qde41TQPXEQ==
-    size: 187800469
-path: DoodleNote-0.4.15-arm64-mac.zip
-sha512: 4tJvSFFWj1tEDCArSFiH8rrt21SKN0Jcmh/r6pdZ6ZdEY6riwBdlAO51S+MnynidgZUnlN2vpjUfwDuOfwdRJg==
-releaseDate: '2026-08-28T20:47:35.397Z'
+  - url: DoodleNote-0.4.16-arm64-mac.zip
+    sha512: UPwWjclINA+pifw+v2QGdQw2xJggP81YYLerEtznTtpDjFRSKIlWXiCczPf+wArVwJq1OpLqcnzKxPRfOmJWNA==
+    size: 185921800
+  - url: DoodleNote-0.4.16-arm64.dmg
+    sha512: SU6kU6udSoFIaf+aEgPmiA25PUACCU28OIp2rH7aPpTWsH5lOx3P7Nc0I3fX2aboVy1QvyaJmnSWCbkfC3Phqg==
+    size: 187845191
+path: DoodleNote-0.4.16-arm64-mac.zip
+sha512: UPwWjclINA+pifw+v2QGdQw2xJggP81YYLerEtznTtpDjFRSKIlWXiCczPf+wArVwJq1OpLqcnzKxPRfOmJWNA==
+releaseDate: '2026-08-28T22:30:22.446Z'


### PR DESCRIPTION
## Release

Publishes the signed and notarized DoodleNote 0.4.16 updater and website installer.

## Included

- Checkpoint transcript segments during long recordings
- Offer transcription recovery when saved audio has no transcript
- Route unavailable Generate notes to Notes model setup
- Restore Groq, OpenRouter, and Ollama settings after restart
- Add focused regression coverage and release changelog

## Verification

- Frozen dependency install passed
- Swift engine release build passed
- Workspace typecheck and lint passed
- 220 tests passed
- Production desktop, web, and MCP builds passed
- Production dependency audit found no known vulnerabilities
- App and DMG Developer ID signatures validated
- App and DMG notarization accepted and tickets stapled
- Gatekeeper accepted the final DMG

## Artifacts

- ZIP SHA-256: 4ce66c7b54f10afb4f9221af6da7a68c7effdf7f89d5192b3246183f5fb5d60b
- DMG SHA-256: 06434cc947b4618f188075f847e357463480fab6510b5fce56da76009a4f0942
- App notarization: b7b1bf42-27ca-4495-948c-2236b93a77fa
- DMG notarization: 4db73b9e-ee89-44f4-ac90-c24854eb5b3a

## Risk and rollback

The update manifest changes from 0.4.15 to 0.4.16. Rollback is restoring the prior latest-mac.yml manifest. Versioned release artifacts are immutable.