### PR TITLE
Release DoodleNote v0.4.17

### DIFF
--- a/RELEASE-v0.4.17.md
+++ b/RELEASE-v0.4.17.md
@@ -1,0 +1,46 @@
+# DoodleNote v0.4.17 release candidate
+
+## Included
+
+- [x] Preserve to-do checkboxes when reopening formatted notes
+- [x] Preserve checked and unchecked task state
+- [x] Preserve nested task hierarchy
+- [x] Add focused Markdown hydration regression coverage
+- [x] Bump the desktop version from 0.4.16 to 0.4.17
+- [x] Add the v0.4.17 changelog entry
+
+## Verification
+
+- [ ] Frozen-lockfile dependency install
+- [ ] Swift transcription engine release build
+- [ ] Workspace typecheck
+- [ ] Full workspace test suite
+- [ ] Workspace lint
+- [ ] Production Electron, web, and MCP builds
+- [ ] Production dependency audit: no known vulnerabilities
+- [ ] Packaged application reports version 0.4.17
+- [ ] Developer ID signature and hardened runtime validation
+- [ ] App notarization and stapled-ticket validation
+- [ ] Final DMG signature, notarization, stapling, and Gatekeeper validation
+- [ ] Updater ZIP and website DMG checksums recorded
+- [ ] Updater manifest references only version-matched v0.4.17 artifacts
+
+## Release gates
+
+- [x] User authorized review bypass, merge, packaging, and publication
+- [ ] Release PR has green required CI
+- [ ] Release PR merged into main
+- [ ] Public update feed reports 0.4.17
+- [ ] Public ZIP checksum matches the release artifact
+- [ ] Public DMG checksum matches the release artifact
+- [ ] Installed 0.4.16 client detects the 0.4.17 update
+- [ ] Reopened formatted note retains task checkboxes and nested task hierarchy
+
+## Package
+
+- Updater artifact: `DoodleNote-0.4.17-arm64-mac.zip`
+- Website installer: `DoodleNote-0.4.17-arm64.dmg`
+- Updater ZIP SHA-256: pending
+- Website DMG SHA-256: pending
+- App notarization submission: pending
+- DMG notarization submission: pending

--- a/RELEASE-v0.4.17.md
+++ b/RELEASE-v0.4.17.md
@@ -11,19 +11,19 @@
 
 ## Verification
 
-- [ ] Frozen-lockfile dependency install
-- [ ] Swift transcription engine release build
-- [ ] Workspace typecheck
-- [ ] Full workspace test suite
-- [ ] Workspace lint
-- [ ] Production Electron, web, and MCP builds
-- [ ] Production dependency audit: no known vulnerabilities
-- [ ] Packaged application reports version 0.4.17
-- [ ] Developer ID signature and hardened runtime validation
-- [ ] App notarization and stapled-ticket validation
-- [ ] Final DMG signature, notarization, stapling, and Gatekeeper validation
-- [ ] Updater ZIP and website DMG checksums recorded
-- [ ] Updater manifest references only version-matched v0.4.17 artifacts
+- [x] Frozen-lockfile dependency install
+- [x] Swift transcription engine release build
+- [x] Workspace typecheck
+- [x] Full workspace test suite: 227 tests passed
+- [x] Workspace lint
+- [x] Production Electron, web, and MCP builds
+- [x] Production dependency audit: no known vulnerabilities
+- [x] Packaged application reports version 0.4.17
+- [x] Developer ID signature and hardened runtime validation
+- [x] App notarization and stapled-ticket validation
+- [x] Final DMG signature, notarization, stapling, and Gatekeeper validation
+- [x] Updater ZIP and website DMG checksums recorded
+- [x] Updater manifest references only version-matched v0.4.17 artifacts
 
 ## Release gates
 
@@ -40,7 +40,7 @@
 
 - Updater artifact: `DoodleNote-0.4.17-arm64-mac.zip`
 - Website installer: `DoodleNote-0.4.17-arm64.dmg`
-- Updater ZIP SHA-256: pending
-- Website DMG SHA-256: pending
-- App notarization submission: pending
-- DMG notarization submission: pending
+- Updater ZIP SHA-256: `5d5d63eb3070ee4914d83f8cc7e4d9356b5bdf8eb621bf02a2facbcd0e2a0be9`
+- Website DMG SHA-256: `33eccc1433755409966ed76d21fad6ef3f935de947b23978798dd80e0d2a0d6e`
+- App notarization submission: `4ebd8609-0e69-4cca-ba64-317c8b6f3473` (Accepted)
+- DMG notarization submission: `2b57dc52-da15-4a7c-9aa4-b496eb594d9c` (Accepted)

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "private": true,
   "description": "DoodleNote desktop app for privacy-first local capture, transcription, and AI meeting notes",
   "main": "./out/main/index.js",

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,13 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.17",
+    date: "August 30, 2026",
+    highlights: [
+      "Keep to-do checkboxes, checked state, and nested task structure when reopening formatted notes",
+    ],
+  },
+  {
     version: "0.4.16",
     date: "August 28, 2026",
     highlights: [

--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,11 +1,11 @@
-version: 0.4.16
+version: 0.4.17
 files:
-  - url: DoodleNote-0.4.16-arm64-mac.zip
-    sha512: UPwWjclINA+pifw+v2QGdQw2xJggP81YYLerEtznTtpDjFRSKIlWXiCczPf+wArVwJq1OpLqcnzKxPRfOmJWNA==
-    size: 185921800
-  - url: DoodleNote-0.4.16-arm64.dmg
-    sha512: SU6kU6udSoFIaf+aEgPmiA25PUACCU28OIp2rH7aPpTWsH5lOx3P7Nc0I3fX2aboVy1QvyaJmnSWCbkfC3Phqg==
-    size: 187845191
-path: DoodleNote-0.4.16-arm64-mac.zip
-sha512: UPwWjclINA+pifw+v2QGdQw2xJggP81YYLerEtznTtpDjFRSKIlWXiCczPf+wArVwJq1OpLqcnzKxPRfOmJWNA==
-releaseDate: '2026-08-28T22:30:22.446Z'
+  - url: DoodleNote-0.4.17-arm64-mac.zip
+    sha512: ztoix3BatTcS37mWntEnfN4JG+swy+aCNhlr5x7rV5xXyrRi6226k3wTSBAUpLNVmbN/GzXqojVHImWf+gHqHQ==
+    size: 185925884
+  - url: DoodleNote-0.4.17-arm64.dmg
+    sha512: 9WZhmt7CxwRrJqAjULk2yMaUmNgyp8p/4mLlnC9gUiDZH5fvCVYU2Q/D2FLsbn/pbMExDVPpUAoatHsHfiWDvQ==
+    size: 187873839
+path: DoodleNote-0.4.17-arm64-mac.zip
+sha512: ztoix3BatTcS37mWntEnfN4JG+swy+aCNhlr5x7rV5xXyrRi6226k3wTSBAUpLNVmbN/GzXqojVHImWf+gHqHQ==
+releaseDate: '2026-08-30T20:07:39.470Z'


### PR DESCRIPTION
## Summary
- release the ONY-213 formatted-note persistence fix in desktop v0.4.17
- publish a matching signed and notarized macOS updater ZIP and DMG
- update the website changelog and static updater manifest

## Verification
- frozen dependency install passed
- Swift release engine build passed
- workspace typecheck, lint, and production builds passed
- 227 tests passed, including checkbox save and reopen coverage
- production dependency audit found no known vulnerabilities
- packaged app reports 0.4.17 and passes Developer ID, hardened runtime, notarization, stapling, and Gatekeeper checks
- final DMG is separately Developer ID signed, notarized, stapled, and Gatekeeper accepted
- updater manifest SHA-512 values and sizes match the final ZIP and DMG

## Release evidence
- App notarization: `4ebd8609-0e69-4cca-ba64-317c8b6f3473`
- DMG notarization: `2b57dc52-da15-4a7c-9aa4-b496eb594d9c`
- ZIP SHA-256: `5d5d63eb3070ee4914d83f8cc7e4d9356b5bdf8eb621bf02a2facbcd0e2a0be9`
- DMG SHA-256: `33eccc1433755409966ed76d21fad6ef3f935de947b23978798dd80e0d2a0d6e`

## Remaining gates
- required CI
- merge and production deployment
- public feed and artifact checksum verification
- installed v0.4.16 update detection and user QA