### PR TITLE
Fix account verification and trial checkout handoff

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -24,6 +24,7 @@
 
 # Workspace invitations
 # RESEND_API_KEY=
+# AUTH_FROM_EMAIL=DoodleNote <no-reply@doodlenote.ai>
 # INVITATION_FROM_EMAIL=
 
 # Official hosted Sync billing ($10 / user / month at doodlenote.ai)

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -29,6 +29,7 @@ No external service is required for the basic local development path:
 | Auth origin and production secret | `BETTER_AUTH_URL`, `BETTER_AUTH_SECRET`                                                                                              |
 | Microsoft sign-in                 | `MICROSOFT_CLIENT_ID`, `MICROSOFT_CLIENT_SECRET`                                                                                     |
 | Google sign-in                    | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`                                                                                           |
+| Account verification              | `RESEND_API_KEY`, `AUTH_FROM_EMAIL`                                                                                                  |
 | Workspace invitations             | `RESEND_API_KEY`, `INVITATION_FROM_EMAIL`                                                                                            |
 | Billing                           | `STRIPE_SECRET_KEY`, `STRIPE_ACCOUNT_ID`, `STRIPE_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`                                                  |
 | Voice features                    | `TWILIO_ACCOUNT_SID`, `TWILIO_API_KEY_SID`, `TWILIO_API_KEY_SECRET`, `TWILIO_TWIML_APP_SID`, `TWILIO_CALLER_ID`, `TWILIO_AUTH_TOKEN` |

--- a/apps/web/app/login/login-form.tsx
+++ b/apps/web/app/login/login-form.tsx
@@ -50,10 +50,12 @@ function MicrosoftLogo() {
 export function LoginForm({
   googleEnabled,
   microsoftEnabled,
+  emailVerificationEnabled,
   next = "/app",
 }: {
   googleEnabled: boolean;
   microsoftEnabled: boolean;
+  emailVerificationEnabled: boolean;
   next?: string;
 }) {
   const router = useRouter();
@@ -63,6 +65,10 @@ export function LoginForm({
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
+  const [verificationEmail, setVerificationEmail] = useState<string | null>(null);
+  const [verificationMessage, setVerificationMessage] = useState<string | null>(
+    null,
+  );
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
@@ -70,15 +76,53 @@ export function LoginForm({
     setPending(true);
     const result =
       mode === "sign-up"
-        ? await authClient.signUp.email({ name, email, password })
-        : await authClient.signIn.email({ email, password });
+        ? await authClient.signUp.email({
+            name,
+            email,
+            password,
+            callbackURL: next,
+          })
+        : await authClient.signIn.email({ email, password, callbackURL: next });
     setPending(false);
     if (result.error) {
+      const code =
+        "code" in result.error && typeof result.error.code === "string"
+          ? result.error.code
+          : null;
+      if (code === "EMAIL_NOT_VERIFIED") {
+        setVerificationEmail(email);
+        setVerificationMessage("We sent you a fresh verification link.");
+        return;
+      }
       setError(result.error.message ?? "Something went wrong");
+      return;
+    }
+    if (mode === "sign-up" && emailVerificationEnabled) {
+      setVerificationEmail(email);
+      setVerificationMessage("We sent you a verification link.");
       return;
     }
     router.push(next);
     router.refresh();
+  }
+
+  async function resendVerification() {
+    if (!verificationEmail) return;
+    setError(null);
+    setVerificationMessage(null);
+    setPending(true);
+    const result = await authClient.sendVerificationEmail({
+      email: verificationEmail,
+      callbackURL: next,
+    });
+    setPending(false);
+    if (result.error) {
+      setError(
+        result.error.message ?? "We could not send another verification email.",
+      );
+      return;
+    }
+    setVerificationMessage("A new verification link is on its way.");
   }
 
   /**
@@ -130,7 +174,54 @@ export function LoginForm({
         </p>
       </div>
 
-      <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      {verificationEmail ? (
+        <div className="rounded-xl border border-sand bg-white p-5 text-center shadow-sm">
+          <h1 className="font-display text-xl font-semibold text-ink">
+            Check your email
+          </h1>
+          <p className="mt-2 text-sm leading-relaxed text-stone">
+            Verify{" "}
+            <strong className="font-medium text-bark">
+              {verificationEmail}
+            </strong>
+            {next.includes("checkout=1")
+              ? " and we will continue to Stripe Checkout."
+              : " to finish signing in."}
+          </p>
+          {verificationMessage && (
+            <p role="status" className="mt-3 text-sm text-sage-deep">
+              {verificationMessage}
+            </p>
+          )}
+          {error && (
+            <p role="alert" className="mt-3 text-sm text-red-700">
+              {error}
+            </p>
+          )}
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() => void resendVerification()}
+            className={`mt-4 w-full ${buttonPrimary}`}
+          >
+            {pending ? "Sending…" : "Resend verification email"}
+          </button>
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() => {
+              setVerificationEmail(null);
+              setVerificationMessage(null);
+              setError(null);
+            }}
+            className="mt-3 text-sm underline underline-offset-2 hover:text-ink"
+          >
+            Use a different email
+          </button>
+        </div>
+      ) : (
+        <>
+          <form onSubmit={handleSubmit} className="flex flex-col gap-3">
         {mode === "sign-up" && (
           <label className="text-xs font-medium text-bark">
             Name
@@ -184,9 +275,9 @@ export function LoginForm({
               ? "Sign in"
               : "Create account"}
         </button>
-      </form>
+          </form>
 
-      {microsoftEnabled && (
+          {microsoftEnabled && (
         <button
           type="button"
           disabled={pending}
@@ -196,9 +287,9 @@ export function LoginForm({
           <MicrosoftLogo />
           Sign in with Microsoft
         </button>
-      )}
+          )}
 
-      {googleEnabled && (
+          {googleEnabled && (
         <button
           type="button"
           disabled={pending}
@@ -208,9 +299,9 @@ export function LoginForm({
           <GoogleLogo />
           Continue with Google
         </button>
-      )}
+          )}
 
-      <p className="mt-6 text-center text-sm text-stone">
+          <p className="mt-6 text-center text-sm text-stone">
         {mode === "sign-in" ? (
           <>
             No account?{" "}
@@ -240,7 +331,9 @@ export function LoginForm({
             </button>
           </>
         )}
-      </p>
+          </p>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 
 import { auth } from "@/lib/auth";
 import { googleEnabled, microsoftEnabled } from "@/lib/create-auth";
+import { resolveAuthEmailEnabled } from "@/lib/runtime-config";
 
 import { LoginForm } from "./login-form";
 
@@ -25,6 +26,7 @@ export default async function LoginPage({
       <LoginForm
         googleEnabled={googleEnabled()}
         microsoftEnabled={microsoftEnabled()}
+        emailVerificationEnabled={resolveAuthEmailEnabled()}
         next={nextPath}
       />
     </main>

--- a/apps/web/app/pricing/checkout-button.tsx
+++ b/apps/web/app/pricing/checkout-button.tsx
@@ -1,22 +1,31 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { buttonPrimary } from "../ui";
 import {
   billingViewFromStatus,
   type BillingView,
 } from "./billing-view";
+import {
+  shouldAutoStartTrialCheckout,
+  TRIAL_LOGIN_PATH,
+} from "./trial-flow";
 
 /**
  * The Sync plan's call to action, state-aware: signed-out visitors go to
  * login, new users to Stripe Checkout (15-day trial), subscribers to the
  * billing portal.
  */
-export function CheckoutButton() {
+export function CheckoutButton({
+  autoCheckout = false,
+}: {
+  autoCheckout?: boolean;
+}) {
   const [view, setView] = useState<BillingView>({ kind: "loading" });
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const autoCheckoutAttempted = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -34,7 +43,7 @@ export function CheckoutButton() {
     };
   }, []);
 
-  async function go(endpoint: "checkout" | "portal") {
+  const go = useCallback(async (endpoint: "checkout" | "portal") => {
     setBusy(true);
     setError(null);
     try {
@@ -56,7 +65,23 @@ export function CheckoutButton() {
       setError("Something went wrong — try again.");
     }
     setBusy(false);
-  }
+  }, []);
+
+  useEffect(() => {
+    if (
+      !shouldAutoStartTrialCheckout({
+        requested: autoCheckout,
+        attempted: autoCheckoutAttempted.current,
+        viewKind: view.kind,
+      })
+    ) {
+      return;
+    }
+
+    autoCheckoutAttempted.current = true;
+    window.history.replaceState(null, "", "/pricing");
+    void go("checkout");
+  }, [autoCheckout, go, view.kind]);
 
   if (view.kind === "legacy-access") {
     return (
@@ -140,7 +165,7 @@ export function CheckoutButton() {
   if (view.kind === "signed-out") {
     return (
       <div className="flex flex-col items-center gap-2 sm:items-start">
-        <a href="/login?next=/pricing" className={buttonPrimary}>
+        <a href={TRIAL_LOGIN_PATH} className={buttonPrimary}>
           Start your 15-day free trial
         </a>
         <p className="text-xs text-stone">

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -78,7 +78,13 @@ function FeatureList({ items }: { items: string[] }) {
   );
 }
 
-export default function PricingPage() {
+export default async function PricingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ checkout?: string }>;
+}) {
+  const { checkout } = await searchParams;
+
   return (
     <div className="flex flex-1 flex-col bg-cream text-bark">
       <SiteHeader
@@ -149,7 +155,7 @@ export default function PricingPage() {
           </p>
           <FeatureList items={SYNC_FEATURES} />
           <div className="mt-7">
-            <CheckoutButton />
+            <CheckoutButton autoCheckout={checkout === "1"} />
           </div>
         </section>
 

--- a/apps/web/app/pricing/trial-flow.ts
+++ b/apps/web/app/pricing/trial-flow.ts
@@ -1,0 +1,14 @@
+export const TRIAL_CHECKOUT_PATH = "/pricing?checkout=1";
+export const TRIAL_LOGIN_PATH = `/login?next=${encodeURIComponent(TRIAL_CHECKOUT_PATH)}`;
+
+export function shouldAutoStartTrialCheckout({
+  requested,
+  attempted,
+  viewKind,
+}: {
+  requested: boolean;
+  attempted: boolean;
+  viewKind: string;
+}): boolean {
+  return requested && !attempted && viewKind === "start-trial";
+}

--- a/apps/web/lib/auth-email.ts
+++ b/apps/web/lib/auth-email.ts
@@ -1,0 +1,57 @@
+import "server-only";
+
+function html(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+async function sendAuthEmail({
+  to,
+  subject,
+  text,
+  body,
+}: {
+  to: string;
+  subject: string;
+  text: string;
+  body: string;
+}): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.AUTH_FROM_EMAIL;
+  if (!apiKey || !from) {
+    throw new Error("Authentication email delivery is not configured.");
+  }
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ from, to: [to], subject, text, html: body }),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(
+      `Authentication email delivery failed (${response.status}): ${detail.slice(0, 300)}`,
+    );
+  }
+}
+
+export async function sendAuthVerificationEmail(data: {
+  user: { email: string };
+  url: string;
+}): Promise<void> {
+  const url = html(data.url);
+  await sendAuthEmail({
+    to: data.user.email,
+    subject: "Verify your DoodleNote email",
+    text: `Verify your DoodleNote email: ${data.url}`,
+    body: `<div style="font-family:Arial,sans-serif;line-height:1.6;color:#26281f"><h2>Verify your email</h2><p>Confirm this email address to finish creating your DoodleNote account.</p><p><a href="${url}" style="display:inline-block;padding:10px 16px;border-radius:8px;background:#26281f;color:#f7f5ee;text-decoration:none">Verify email</a></p><p style="color:#6f7367;font-size:13px">This link expires in one hour. If you did not create a DoodleNote account, you can ignore this email.</p></div>`,
+  });
+}

--- a/apps/web/lib/auth-email.ts
+++ b/apps/web/lib/auth-email.ts
@@ -47,11 +47,55 @@ export async function sendAuthVerificationEmail(data: {
   user: { email: string };
   url: string;
 }): Promise<void> {
-  const url = html(data.url);
+  const verificationUrl = html(data.url);
+  const mascotUrl = html(new URL("/mascot.png", data.url).toString());
   await sendAuthEmail({
     to: data.user.email,
     subject: "Verify your DoodleNote email",
-    text: `Verify your DoodleNote email: ${data.url}`,
-    body: `<div style="font-family:Arial,sans-serif;line-height:1.6;color:#26281f"><h2>Verify your email</h2><p>Confirm this email address to finish creating your DoodleNote account.</p><p><a href="${url}" style="display:inline-block;padding:10px 16px;border-radius:8px;background:#26281f;color:#f7f5ee;text-decoration:none">Verify email</a></p><p style="color:#6f7367;font-size:13px">This link expires in one hour. If you did not create a DoodleNote account, you can ignore this email.</p></div>`,
+    text: `Welcome to DoodleNote.\n\nConfirm your email address to finish creating your account:\n${data.url}\n\nThis link expires in one hour. If you did not create a DoodleNote account, you can safely ignore this email.`,
+    body: `<!doctype html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="light">
+    <title>Verify your DoodleNote email</title>
+  </head>
+  <body style="margin:0;padding:0;background:#f7f5ee;color:#26281f;font-family:Arial,Helvetica,sans-serif;">
+    <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;">One quick check, then your DoodleNote account is ready.</div>
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="width:100%;background:#f7f5ee;">
+      <tr>
+        <td align="center" style="padding:36px 16px;">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="width:100%;max-width:560px;background:#ffffff;border:1px solid #e7e3d8;border-radius:20px;overflow:hidden;">
+            <tr>
+              <td style="padding:28px 32px 20px;text-align:center;background:#e9efe0;border-bottom:1px solid #e7e3d8;">
+                <img src="${mascotUrl}" width="88" height="88" alt="DoodleNote mascot" style="display:block;width:88px;height:88px;margin:0 auto 12px;border:0;">
+                <div style="font-size:22px;line-height:28px;font-weight:700;letter-spacing:-0.3px;color:#26281f;">DoodleNote</div>
+                <div style="margin-top:5px;font-size:13px;line-height:20px;color:#506941;">Local-first. Cloud only when you opt in.</div>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:34px 32px 30px;">
+                <h1 style="margin:0 0 14px;font-size:26px;line-height:34px;font-weight:700;letter-spacing:-0.4px;color:#26281f;">One quick check, then you&rsquo;re in</h1>
+                <p style="margin:0 0 24px;font-size:16px;line-height:25px;color:#3a3d33;">Confirm your email address to finish creating your DoodleNote account.</p>
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                  <tr>
+                    <td style="border-radius:10px;background:#506941;">
+                      <a href="${verificationUrl}" style="display:inline-block;padding:13px 22px;font-size:16px;line-height:20px;font-weight:700;color:#ffffff;text-decoration:none;border-radius:10px;">Verify my email</a>
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin:24px 0 8px;font-size:13px;line-height:20px;color:#6f7367;">This link expires in one hour. If the button does not work, copy and paste this link into your browser:</p>
+                <p style="margin:0;font-size:12px;line-height:18px;word-break:break-all;"><a href="${verificationUrl}" style="color:#506941;text-decoration:underline;">${verificationUrl}</a></p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:20px 32px;background:#fdfcf8;border-top:1px solid #e7e3d8;font-size:12px;line-height:19px;color:#6f7367;">If you did not create a DoodleNote account, you can safely ignore this email.</td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`,
   });
 }

--- a/apps/web/lib/create-auth.ts
+++ b/apps/web/lib/create-auth.ts
@@ -5,8 +5,13 @@ import { organization } from "better-auth/plugins";
 
 import { fullSchema, type Db } from "@repo/db";
 
+import { sendAuthVerificationEmail } from "./auth-email";
 import { sendWorkspaceInvitationEmail } from "./invitation-email";
-import { resolveAuthBaseUrl, resolveAuthSecret } from "./runtime-config";
+import {
+  resolveAuthBaseUrl,
+  resolveAuthEmailEnabled,
+  resolveAuthSecret,
+} from "./runtime-config";
 
 /** Production canonical site; social OAuth callbacks must match this origin. */
 const PRODUCTION_ORIGINS = [
@@ -60,6 +65,8 @@ function socialProviders() {
  * so smoke tests can construct an instance against a throwaway database.
  */
 export function createAuth(db: Db) {
+  const emailVerificationEnabled = resolveAuthEmailEnabled();
+
   return betterAuth({
     database: drizzleAdapter(db, { provider: "pg", schema: fullSchema }),
     secret: resolveAuthSecret(),
@@ -67,7 +74,17 @@ export function createAuth(db: Db) {
     trustedOrigins: trustedOrigins(),
     emailAndPassword: {
       enabled: true,
+      requireEmailVerification: emailVerificationEnabled,
     },
+    emailVerification: emailVerificationEnabled
+      ? {
+          sendVerificationEmail: sendAuthVerificationEmail,
+          sendOnSignUp: true,
+          sendOnSignIn: true,
+          autoSignInAfterVerification: true,
+          expiresIn: 60 * 60,
+        }
+      : undefined,
     socialProviders: socialProviders(),
     plugins: [
       organization({

--- a/apps/web/lib/runtime-config.ts
+++ b/apps/web/lib/runtime-config.ts
@@ -12,6 +12,19 @@ export type BillingMode =
   | "development"
   | "misconfigured";
 
+export function resolveAuthEmailEnabled(
+  env: RuntimeEnvironment = process.env,
+): boolean {
+  const configured = Boolean(env.RESEND_API_KEY && env.AUTH_FROM_EMAIL);
+  if (configured) return true;
+  if (env.NODE_ENV === "production" && !isProductionBuild(env)) {
+    throw new Error(
+      "Production authentication requires RESEND_API_KEY and AUTH_FROM_EMAIL.",
+    );
+  }
+  return false;
+}
+
 /**
  * Local development stays zero-config, but a production server must never
  * start with a public, predictable session-signing secret.

--- a/apps/web/scripts/auth-smoke.ts
+++ b/apps/web/scripts/auth-smoke.ts
@@ -5,7 +5,7 @@
  * PGlite database (all drizzle migrations applied), then exercises the server
  * API directly — no HTTP server:
  *
- *   sign up -> sign in -> create organization -> list organizations
+ *   sign up -> verify email -> auto sign in -> create organization -> list organizations
  *
  * Run with: pnpm --filter web auth-smoke
  */
@@ -14,6 +14,23 @@
 // in main) so the smoke run doesn't trip the dev-only-secret warning.
 process.env.BETTER_AUTH_SECRET ??= "gV3qLZ0e8kXnR5tYwB7uJ2mCa9PdF4hSiK6oQ1rTxE0="; // smoke-only
 process.env.BETTER_AUTH_URL ??= "http://localhost:4040";
+process.env.RESEND_API_KEY ??= "re_smoke_only";
+process.env.AUTH_FROM_EMAIL ??= "DoodleNote <no-reply@doodlenote.ai>";
+
+let verificationUrl: string | null = null;
+const realFetch = globalThis.fetch;
+globalThis.fetch = async (input, init) => {
+  if (input === "https://api.resend.com/emails") {
+    const payload = JSON.parse(String(init?.body)) as { text?: unknown };
+    const match =
+      typeof payload.text === "string"
+        ? payload.text.match(/https?:\/\/\S+/)
+        : null;
+    verificationUrl = match?.[0] ?? null;
+    return Response.json({ id: "smoke-email" });
+  }
+  return realFetch(input, init);
+};
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(`auth smoke FAILED: ${message}`);
@@ -46,17 +63,35 @@ async function main(): Promise<void> {
   // 1. Sign up (email + password).
   const signUp = await auth.api.signUpEmail({
     body: { name: "Smoke Tester", email, password },
-  });
-  assert(signUp.user.email === email, `sign-up returned wrong email: ${signUp.user.email}`);
-
-  // 2. Sign in, capturing the session cookie for authenticated calls.
-  const signIn = await auth.api.signInEmail({
-    body: { email, password },
     returnHeaders: true,
   });
-  assert(signIn.response.user.email === email, "sign-in returned wrong user");
-  const cookie = toCookieHeader(signIn.headers);
-  assert(cookie.length > 0, "sign-in did not set a session cookie");
+  assert(
+    signUp.response.user.email === email,
+    `sign-up returned wrong email: ${signUp.response.user.email}`,
+  );
+  assert(
+    signUp.response.token === null,
+    "unverified sign-up unexpectedly created a session",
+  );
+  assert(
+    toCookieHeader(signUp.headers).length === 0,
+    "unverified sign-up set a session cookie",
+  );
+  assert(verificationUrl, "sign-up did not send a verification email");
+
+  // 2. Verify the email. The verification endpoint should create the session.
+  const token = new URL(verificationUrl).searchParams.get("token");
+  assert(token, "verification email did not include a token");
+  const verification = await auth.api.verifyEmail({
+    query: { token },
+    returnHeaders: true,
+  });
+  assert(
+    verification.response?.status === true,
+    "email verification did not succeed",
+  );
+  const cookie = toCookieHeader(verification.headers);
+  assert(cookie.length > 0, "email verification did not auto-sign in the user");
   const authedHeaders = new Headers({ cookie });
 
   // 3. Create an organization.
@@ -82,10 +117,11 @@ async function main(): Promise<void> {
   assert(org.slug === orgSlug, `listed org has wrong slug: ${org.slug}`);
 
   console.log(
-    `auth smoke OK: signed up + signed in ${email}, created organization "${org.name}" (${org.slug}), list returned exactly 1 — against fresh in-memory PGlite`,
+    `auth smoke OK: signed up + verified ${email}, auto-signed in, created organization "${org.name}" (${org.slug}), list returned exactly 1 — against fresh in-memory PGlite`,
   );
 
   await close();
+  globalThis.fetch = realFetch;
 }
 
 main().catch((error) => {

--- a/apps/web/scripts/auth-smoke.ts
+++ b/apps/web/scripts/auth-smoke.ts
@@ -18,15 +18,21 @@ process.env.RESEND_API_KEY ??= "re_smoke_only";
 process.env.AUTH_FROM_EMAIL ??= "DoodleNote <no-reply@doodlenote.ai>";
 
 let verificationUrl: string | null = null;
+let verificationHtml: string | null = null;
 const realFetch = globalThis.fetch;
 globalThis.fetch = async (input, init) => {
   if (input === "https://api.resend.com/emails") {
-    const payload = JSON.parse(String(init?.body)) as { text?: unknown };
+    const payload = JSON.parse(String(init?.body)) as {
+      html?: unknown;
+      text?: unknown;
+    };
     const match =
       typeof payload.text === "string"
         ? payload.text.match(/https?:\/\/\S+/)
         : null;
     verificationUrl = match?.[0] ?? null;
+    verificationHtml =
+      typeof payload.html === "string" ? payload.html : null;
     return Response.json({ id: "smoke-email" });
   }
   return realFetch(input, init);
@@ -78,6 +84,13 @@ async function main(): Promise<void> {
     "unverified sign-up set a session cookie",
   );
   assert(verificationUrl, "sign-up did not send a verification email");
+  assert(verificationHtml, "verification email did not include an HTML body");
+  assert(
+    verificationHtml.includes("DoodleNote mascot") &&
+      verificationHtml.includes("Verify my email") &&
+      verificationHtml.includes("Local-first. Cloud only when you opt in."),
+    "verification email did not include the branded DoodleNote content",
+  );
 
   // 2. Verify the email. The verification endpoint should create the session.
   const token = new URL(verificationUrl).searchParams.get("token");

--- a/apps/web/tests/runtime-config.test.ts
+++ b/apps/web/tests/runtime-config.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   resolveAuthBaseUrl,
+  resolveAuthEmailEnabled,
   resolveAuthSecret,
   resolveBillingMode,
 } from "../lib/runtime-config";
@@ -57,6 +58,30 @@ test("a Next.js production build does not require live auth credentials", () => 
   };
   assert.match(resolveAuthSecret(env), /dev-only-insecure/);
   assert.equal(resolveAuthBaseUrl(env), "http://localhost:4040");
+  assert.equal(resolveAuthEmailEnabled(env), false);
+});
+
+test("production auth requires a complete email delivery configuration", () => {
+  assert.throws(
+    () => resolveAuthEmailEnabled({ NODE_ENV: "production" }),
+    /RESEND_API_KEY and AUTH_FROM_EMAIL/,
+  );
+  assert.throws(
+    () =>
+      resolveAuthEmailEnabled({
+        NODE_ENV: "production",
+        RESEND_API_KEY: "secret",
+      }),
+    /RESEND_API_KEY and AUTH_FROM_EMAIL/,
+  );
+  assert.equal(
+    resolveAuthEmailEnabled({
+      NODE_ENV: "production",
+      RESEND_API_KEY: "secret",
+      AUTH_FROM_EMAIL: "DoodleNote <no-reply@doodlenote.ai>",
+    }),
+    true,
+  );
 });
 
 test("hosted production requires the complete Stripe group", () => {

--- a/apps/web/tests/trial-flow.test.ts
+++ b/apps/web/tests/trial-flow.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  TRIAL_CHECKOUT_PATH,
+  TRIAL_LOGIN_PATH,
+  shouldAutoStartTrialCheckout,
+} from "../app/pricing/trial-flow";
+
+describe("trial checkout handoff", () => {
+  it("preserves the checkout intent through authentication", () => {
+    assert.equal(TRIAL_CHECKOUT_PATH, "/pricing?checkout=1");
+    assert.equal(
+      TRIAL_LOGIN_PATH,
+      "/login?next=%2Fpricing%3Fcheckout%3D1",
+    );
+  });
+
+  it("starts checkout once only after an eligible billing status is loaded", () => {
+    assert.equal(
+      shouldAutoStartTrialCheckout({
+        requested: true,
+        attempted: false,
+        viewKind: "start-trial",
+      }),
+      true,
+    );
+    assert.equal(
+      shouldAutoStartTrialCheckout({
+        requested: true,
+        attempted: true,
+        viewKind: "start-trial",
+      }),
+      false,
+    );
+    assert.equal(
+      shouldAutoStartTrialCheckout({
+        requested: true,
+        attempted: false,
+        viewKind: "signed-out",
+      }),
+      false,
+    );
+    assert.equal(
+      shouldAutoStartTrialCheckout({
+        requested: false,
+        attempted: false,
+        viewKind: "start-trial",
+      }),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Bug\nNew password accounts received no verification email or resend option. Starting the Cloud Sync trial also lost the purchase intent during authentication, forcing users to click the pricing CTA a second time.\n\n## Root cause\nBetter Auth only enabled email/password authentication; no verification sender was configured. The pricing CTA returned users to `/pricing` after login, but did not retain an instruction to create a Stripe Checkout Session.\n\n## Fix\n- add Resend-backed account verification with a one-hour link\n- require verification for password accounts when production email delivery is configured\n- auto-sign in after verification and show a resend-verification screen\n- preserve the trial intent through email/password and social authentication\n- create Stripe Checkout once after the authenticated user returns to pricing\n- fail closed at production runtime when the required email variables are missing\n\n## Verification\n- `pnpm --filter web test`\n- `pnpm --filter web auth-smoke`\n- `pnpm --filter web lint`\n- `pnpm --filter web typecheck`\n- `pnpm --filter web build`\n\n## Deployment notes\nProduction and the PR Preview require `RESEND_API_KEY` and `AUTH_FROM_EMAIL`. The Resend domain is verified. No production deployment is included in this PR.\n\n## Risk and rollback\nExisting unverified password accounts will receive a verification email on their next sign-in. OAuth users are unchanged. Rollback is the PR revert plus removal of the two email environment variables if needed.