### PR TITLE
Fix verification contrast and add billing settings

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -32,6 +32,7 @@
 # STRIPE_ACCOUNT_ID=
 # STRIPE_PRICE_ID=
 # STRIPE_WEBHOOK_SECRET=
+# STRIPE_PORTAL_CONFIGURATION_ID=
 
 # Billing integration test target. Defaults to http://localhost:4040.
 # BILLING_E2E_BASE_URL=

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -31,7 +31,7 @@ No external service is required for the basic local development path:
 | Google sign-in                    | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`                                                                                           |
 | Account verification              | `RESEND_API_KEY`, `AUTH_FROM_EMAIL`                                                                                                  |
 | Workspace invitations             | `RESEND_API_KEY`, `INVITATION_FROM_EMAIL`                                                                                            |
-| Billing                           | `STRIPE_SECRET_KEY`, `STRIPE_ACCOUNT_ID`, `STRIPE_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`                                                  |
+| Billing                           | `STRIPE_SECRET_KEY`, `STRIPE_ACCOUNT_ID`, `STRIPE_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PORTAL_CONFIGURATION_ID`                |
 | Voice features                    | `TWILIO_ACCOUNT_SID`, `TWILIO_API_KEY_SID`, `TWILIO_API_KEY_SECRET`, `TWILIO_TWIML_APP_SID`, `TWILIO_CALLER_ID`, `TWILIO_AUTH_TOKEN` |
 
 A commented template is in [`.env.example`](.env.example). Store local
@@ -50,8 +50,9 @@ self-hosted instance set `DATABASE_URL`, `BETTER_AUTH_URL`,
 Official **$10 / user / month** Sync billing is the doodlenote.ai
 hosted product (Stripe). The explicit self-hosted flag bypasses that
 entitlement gate. Official production fails closed when the Stripe
-configuration is missing or incomplete. This repository does not ship
-a production Docker Compose stack yet; see
+configuration is missing or incomplete. Portal sessions must use a dedicated
+DoodleNote Customer Portal configuration instead of the Stripe account default.
+This repository does not ship a production Docker Compose stack yet; see
 [`SELF-HOSTING.md`](../../SELF-HOSTING.md).
 
 ## Stripe test setup

--- a/apps/web/app/api/billing/portal/route.ts
+++ b/apps/web/app/api/billing/portal/route.ts
@@ -14,6 +14,10 @@ export async function POST(request: Request) {
   if (!billingEnabled()) {
     return NextResponse.json({ error: "Billing is not enabled" }, { status: 503 });
   }
+  const portalConfigurationId = process.env.STRIPE_PORTAL_CONFIGURATION_ID;
+  if (!portalConfigurationId) {
+    return NextResponse.json({ error: "Billing is not enabled" }, { status: 503 });
+  }
 
   const rows = await getDb()
     .select({ customerId: subscriptions.stripeCustomerId })
@@ -30,7 +34,8 @@ export async function POST(request: Request) {
     const stripe = await getVerifiedStripe();
     const portal = await stripe.billingPortal.sessions.create({
       customer: customerId,
-      return_url: `${origin}/app`,
+      configuration: portalConfigurationId,
+      return_url: `${origin}/app/settings/billing`,
     });
     return NextResponse.json({ url: portal.url });
   } catch {

--- a/apps/web/app/app/app-header.tsx
+++ b/apps/web/app/app/app-header.tsx
@@ -91,6 +91,12 @@ export function AppHeader({
               Workspace settings
             </Link>
             <Link
+              href="/app/settings/billing"
+              className="block rounded-md px-2 py-2 text-sm text-bark hover:bg-sage-fill hover:text-ink"
+            >
+              Billing
+            </Link>
+            <Link
               href="/app/settings/security"
               className="block rounded-md px-2 py-2 text-sm text-bark hover:bg-sage-fill hover:text-ink"
             >

--- a/apps/web/app/app/settings/billing/billing-portal-button.tsx
+++ b/apps/web/app/app/settings/billing/billing-portal-button.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+
+import { buttonPrimary } from "@/app/ui";
+
+export function BillingPortalButton() {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function openPortal() {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/billing/portal", { method: "POST" });
+      const body = (await response.json().catch(() => null)) as {
+        error?: string;
+        url?: string;
+      } | null;
+      if (response.ok && body?.url) {
+        window.location.assign(body.url);
+        return;
+      }
+      setError(body?.error ?? "Stripe billing is temporarily unavailable.");
+    } catch {
+      setError("Stripe billing is temporarily unavailable.");
+    }
+    setBusy(false);
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        className={buttonPrimary}
+        disabled={busy}
+        onClick={() => void openPortal()}
+      >
+        {busy ? "Opening Stripe…" : "Manage subscription"}
+      </button>
+      {error && (
+        <p role="alert" className="mt-2 text-sm text-red-700 dark:text-red-300">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/settings/billing/billing-settings-state.ts
+++ b/apps/web/app/app/settings/billing/billing-settings-state.ts
@@ -3,6 +3,7 @@ export type BillingSettingsKind =
   | "legacy"
   | "trialing"
   | "active"
+  | "canceling"
   | "attention"
   | "inactive";
 
@@ -10,6 +11,7 @@ export interface BillingSubscriptionSummary {
   status: string;
   grandfathered: boolean;
   stripeCustomerId: string | null;
+  cancellationDate?: Date | null;
 }
 
 export interface BillingSettingsState {
@@ -62,6 +64,19 @@ export function billingSettingsState(
     };
   }
 
+  if (
+    subscription.cancellationDate &&
+    (subscription.status === "trialing" || subscription.status === "active")
+  ) {
+    return {
+      kind: "canceling",
+      title: "Cancellation scheduled",
+      description: "Cloud Sync remains available until the cancellation date.",
+      canManage: Boolean(subscription.stripeCustomerId),
+      canStart: false,
+    };
+  }
+
   if (subscription.status === "trialing") {
     return {
       kind: "trialing",
@@ -93,4 +108,14 @@ export function billingSettingsState(
     canManage: Boolean(subscription.stripeCustomerId),
     canStart: false,
   };
+}
+
+export function stripeCancellationDate(
+  cancelAt: number | null,
+  cancelAtPeriodEnd: boolean,
+  currentPeriodEnd?: number | null,
+): Date | null {
+  const timestamp =
+    cancelAt ?? (cancelAtPeriodEnd ? currentPeriodEnd : null) ?? null;
+  return timestamp ? new Date(timestamp * 1000) : null;
 }

--- a/apps/web/app/app/settings/billing/billing-settings-state.ts
+++ b/apps/web/app/app/settings/billing/billing-settings-state.ts
@@ -1,0 +1,96 @@
+export type BillingSettingsKind =
+  | "unavailable"
+  | "legacy"
+  | "trialing"
+  | "active"
+  | "attention"
+  | "inactive";
+
+export interface BillingSubscriptionSummary {
+  status: string;
+  grandfathered: boolean;
+  stripeCustomerId: string | null;
+}
+
+export interface BillingSettingsState {
+  kind: BillingSettingsKind;
+  title: string;
+  description: string;
+  canManage: boolean;
+  canStart: boolean;
+}
+
+const INACTIVE_STATUSES = new Set([
+  "none",
+  "canceled",
+  "incomplete_expired",
+  "invalid_price",
+]);
+
+export function billingSettingsState(
+  enabled: boolean,
+  subscription?: BillingSubscriptionSummary,
+): BillingSettingsState {
+  if (!enabled) {
+    return {
+      kind: "unavailable",
+      title: "Billing unavailable",
+      description: "Cloud Sync billing is not enabled for this installation.",
+      canManage: false,
+      canStart: false,
+    };
+  }
+
+  if (subscription?.grandfathered) {
+    return {
+      kind: "legacy",
+      title: "Cloud Sync access",
+      description:
+        "This account has legacy Cloud Sync access and is not billed through Stripe.",
+      canManage: false,
+      canStart: false,
+    };
+  }
+
+  if (!subscription || INACTIVE_STATUSES.has(subscription.status)) {
+    return {
+      kind: "inactive",
+      title: "No active subscription",
+      description: "Start a 15-day Cloud Sync trial when you are ready.",
+      canManage: Boolean(subscription?.stripeCustomerId),
+      canStart: true,
+    };
+  }
+
+  if (subscription.status === "trialing") {
+    return {
+      kind: "trialing",
+      title: "Free trial active",
+      description: "Cloud Sync is available during your 15-day trial.",
+      canManage: Boolean(subscription.stripeCustomerId),
+      canStart: false,
+    };
+  }
+
+  if (subscription.status === "active") {
+    return {
+      kind: "active",
+      title: "Cloud Sync active",
+      description: "Your Cloud Sync subscription is active.",
+      canManage: Boolean(subscription.stripeCustomerId),
+      canStart: false,
+    };
+  }
+
+  return {
+    kind: "attention",
+    title:
+      subscription.status === "past_due"
+        ? "Payment needs attention"
+        : "Subscription needs attention",
+    description:
+      "Open Stripe to review the subscription or update the payment method.",
+    canManage: Boolean(subscription.stripeCustomerId),
+    canStart: false,
+  };
+}

--- a/apps/web/app/app/settings/billing/page.tsx
+++ b/apps/web/app/app/settings/billing/page.tsx
@@ -5,10 +5,13 @@ import { eq, getDb, subscriptions } from "@repo/db";
 
 import { buttonSecondary } from "@/app/ui";
 import { getAppWorkspace } from "@/lib/app-workspace";
-import { billingEnabled } from "@/lib/billing";
+import { billingEnabled, getVerifiedStripe } from "@/lib/billing";
 
 import { BillingPortalButton } from "./billing-portal-button";
-import { billingSettingsState } from "./billing-settings-state";
+import {
+  billingSettingsState,
+  stripeCancellationDate,
+} from "./billing-settings-state";
 
 export const metadata = { title: "Billing — DoodleNote" };
 
@@ -29,23 +32,52 @@ export default async function BillingSettingsPage() {
       grandfathered: subscriptions.grandfathered,
       currentPeriodEnd: subscriptions.currentPeriodEnd,
       stripeCustomerId: subscriptions.stripeCustomerId,
+      stripeSubscriptionId: subscriptions.stripeSubscriptionId,
     })
     .from(subscriptions)
     .where(eq(subscriptions.userId, workspace.session.user.id))
     .limit(1);
 
-  const state = billingSettingsState(billingEnabled(), subscription);
+  const enabled = billingEnabled();
+  let cancellationDate: Date | null = null;
+  if (enabled && subscription?.stripeSubscriptionId) {
+    try {
+      const stripe = await getVerifiedStripe();
+      const current = await stripe.subscriptions.retrieve(
+        subscription.stripeSubscriptionId,
+      );
+      cancellationDate = stripeCancellationDate(
+        current.cancel_at,
+        current.cancel_at_period_end,
+        current.items.data[0]?.current_period_end,
+      );
+    } catch (error) {
+      console.error(
+        "[billing] Unable to refresh the scheduled cancellation",
+        subscription.stripeSubscriptionId,
+        error,
+      );
+    }
+  }
+
+  const state = billingSettingsState(
+    enabled,
+    subscription ? { ...subscription, cancellationDate } : undefined,
+  );
   const periodLabel =
-    subscription?.currentPeriodEnd &&
-    (state.kind === "trialing"
-      ? `Trial ends ${formatDate(subscription.currentPeriodEnd)}`
-      : state.kind === "active" || state.kind === "attention"
-        ? `Current billing period ends ${formatDate(subscription.currentPeriodEnd)}`
-        : null);
+    state.kind === "canceling" && cancellationDate
+      ? `Cancels ${formatDate(cancellationDate)}`
+      : subscription?.currentPeriodEnd
+        ? state.kind === "trialing"
+          ? `Trial ends ${formatDate(subscription.currentPeriodEnd)}`
+          : state.kind === "active" || state.kind === "attention"
+            ? `Current billing period ends ${formatDate(subscription.currentPeriodEnd)}`
+            : null
+        : null;
   const statusTone =
     state.kind === "active" || state.kind === "trialing" || state.kind === "legacy"
       ? "bg-sage-fill text-sage-deep"
-      : state.kind === "attention"
+      : state.kind === "attention" || state.kind === "canceling"
         ? "bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-200"
         : "bg-card-soft text-stone";
 
@@ -75,9 +107,11 @@ export default async function BillingSettingsPage() {
             {periodLabel && (
               <p className="mt-2 text-sm font-medium text-bark">{periodLabel}</p>
             )}
-            <p className="mt-3 text-sm text-bark">
-              15-day trial, then $10 USD per month. Cancel anytime.
-            </p>
+            {state.kind !== "canceling" && (
+              <p className="mt-3 text-sm text-bark">
+                15-day trial, then $10 USD per month. Cancel anytime.
+              </p>
+            )}
           </div>
 
           <div className="flex shrink-0 flex-col items-start gap-2 sm:items-end">

--- a/apps/web/app/app/settings/billing/page.tsx
+++ b/apps/web/app/app/settings/billing/page.tsx
@@ -1,0 +1,120 @@
+import Link from "next/link";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { eq, getDb, subscriptions } from "@repo/db";
+
+import { buttonSecondary } from "@/app/ui";
+import { getAppWorkspace } from "@/lib/app-workspace";
+import { billingEnabled } from "@/lib/billing";
+
+import { BillingPortalButton } from "./billing-portal-button";
+import { billingSettingsState } from "./billing-settings-state";
+
+export const metadata = { title: "Billing — DoodleNote" };
+
+function formatDate(value: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "long",
+    timeZone: "UTC",
+  }).format(value);
+}
+
+export default async function BillingSettingsPage() {
+  const workspace = await getAppWorkspace(await headers());
+  if (!workspace) redirect("/login");
+
+  const [subscription] = await getDb()
+    .select({
+      status: subscriptions.status,
+      grandfathered: subscriptions.grandfathered,
+      currentPeriodEnd: subscriptions.currentPeriodEnd,
+      stripeCustomerId: subscriptions.stripeCustomerId,
+    })
+    .from(subscriptions)
+    .where(eq(subscriptions.userId, workspace.session.user.id))
+    .limit(1);
+
+  const state = billingSettingsState(billingEnabled(), subscription);
+  const periodLabel =
+    subscription?.currentPeriodEnd &&
+    (state.kind === "trialing"
+      ? `Trial ends ${formatDate(subscription.currentPeriodEnd)}`
+      : state.kind === "active" || state.kind === "attention"
+        ? `Current billing period ends ${formatDate(subscription.currentPeriodEnd)}`
+        : null);
+  const statusTone =
+    state.kind === "active" || state.kind === "trialing" || state.kind === "legacy"
+      ? "bg-sage-fill text-sage-deep"
+      : state.kind === "attention"
+        ? "bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-200"
+        : "bg-card-soft text-stone";
+
+  return (
+    <section className="min-w-0">
+      <h2 className="font-display text-xl font-semibold text-ink">Billing</h2>
+      <p className="mt-1 text-sm text-stone">
+        Manage the subscription that powers DoodleNote Cloud Sync.
+      </p>
+
+      <section className="mt-5 overflow-hidden rounded-xl border border-sand bg-card">
+        <div className="flex flex-col gap-5 p-5 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="font-display text-lg font-semibold text-ink">
+                Cloud Sync
+              </h3>
+              <span
+                className={`rounded-full px-2.5 py-1 text-xs font-semibold ${statusTone}`}
+              >
+                {state.title}
+              </span>
+            </div>
+            <p className="mt-2 text-sm leading-relaxed text-stone">
+              {state.description}
+            </p>
+            {periodLabel && (
+              <p className="mt-2 text-sm font-medium text-bark">{periodLabel}</p>
+            )}
+            <p className="mt-3 text-sm text-bark">
+              15-day trial, then $10 USD per month. Cancel anytime.
+            </p>
+          </div>
+
+          <div className="flex shrink-0 flex-col items-start gap-2 sm:items-end">
+            {state.canManage && <BillingPortalButton />}
+            {state.canStart && (
+              <Link href="/pricing?checkout=1" className={buttonSecondary}>
+                Start Cloud Sync
+              </Link>
+            )}
+          </div>
+        </div>
+        <div className="border-t border-sand bg-card-soft px-5 py-4 text-sm leading-relaxed text-stone">
+          Stripe securely handles your card details, invoices, and cancellation.
+          DoodleNote never receives your full card number.
+        </div>
+      </section>
+
+      <div className="mt-5 grid gap-4 sm:grid-cols-2">
+        <section className="rounded-xl border border-sand bg-card p-5">
+          <h3 className="font-display text-base font-semibold text-ink">
+            Payment method
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-stone">
+            Open the Stripe portal to replace an expired card or use a different
+            payment method for future renewals.
+          </p>
+        </section>
+        <section className="rounded-xl border border-sand bg-card p-5">
+          <h3 className="font-display text-base font-semibold text-ink">
+            Cancel Cloud Sync
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-stone">
+            Cancellation is completed in Stripe. Stripe shows when Cloud Sync
+            access will end before you confirm the change.
+          </p>
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/app/settings/settings-nav.tsx
+++ b/apps/web/app/app/settings/settings-nav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 
 const items = [
   ["/app/settings/sync", "Sync & devices"],
+  ["/app/settings/billing", "Billing"],
   ["/app/settings/workspace", "Workspace"],
   ["/app/settings/members", "Members"],
   ["/app/settings/invitations", "Invitations"],

--- a/apps/web/app/login/login-form.tsx
+++ b/apps/web/app/login/login-form.tsx
@@ -175,7 +175,7 @@ export function LoginForm({
       </div>
 
       {verificationEmail ? (
-        <div className="rounded-xl border border-sand bg-white p-5 text-center shadow-sm">
+        <div className="rounded-xl border border-sand bg-card p-5 text-center text-bark shadow-sm">
           <h1 className="font-display text-xl font-semibold text-ink">
             Check your email
           </h1>

--- a/apps/web/app/pricing/checkout-button.tsx
+++ b/apps/web/app/pricing/checkout-button.tsx
@@ -15,7 +15,7 @@ import {
 /**
  * The Sync plan's call to action, state-aware: signed-out visitors go to
  * login, new users to Stripe Checkout (15-day trial), subscribers to the
- * billing portal.
+ * in-app billing settings page.
  */
 export function CheckoutButton({
   autoCheckout = false,
@@ -43,11 +43,11 @@ export function CheckoutButton({
     };
   }, []);
 
-  const go = useCallback(async (endpoint: "checkout" | "portal") => {
+  const go = useCallback(async () => {
     setBusy(true);
     setError(null);
     try {
-      const res = await fetch(`/api/billing/${endpoint}`, {
+      const res = await fetch("/api/billing/checkout", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ next: "/app" }),
@@ -60,9 +60,9 @@ export function CheckoutButton({
       if (body.manageBilling === true) {
         setView({ kind: "subscribed", reason: "billing_attention" });
       }
-      setError(body.error ?? "Something went wrong — try again.");
+      setError(body.error ?? "Something went wrong. Try again.");
     } catch {
-      setError("Something went wrong — try again.");
+      setError("Something went wrong. Try again.");
     }
     setBusy(false);
   }, []);
@@ -80,7 +80,7 @@ export function CheckoutButton({
 
     autoCheckoutAttempted.current = true;
     window.history.replaceState(null, "", "/pricing");
-    void go("checkout");
+    void go();
   }, [autoCheckout, go, view.kind]);
 
   if (view.kind === "legacy-access") {
@@ -99,14 +99,9 @@ export function CheckoutButton({
   if (view.kind === "subscribed") {
     return (
       <div className="flex flex-col items-center gap-2 sm:items-start">
-        <button
-          type="button"
-          className={buttonPrimary}
-          disabled={busy}
-          onClick={() => void go("portal")}
-        >
-          Manage billing
-        </button>
+        <a href="/app/settings/billing" className={buttonPrimary}>
+          Manage subscription
+        </a>
         <p className="text-xs text-stone">
           {view.reason === "trialing"
             ? "You're on the free trial."
@@ -181,7 +176,7 @@ export function CheckoutButton({
         type="button"
         className={buttonPrimary}
         disabled={busy || view.kind === "loading"}
-        onClick={() => void go("checkout")}
+        onClick={() => void go()}
       >
         {busy
           ? "Opening checkout…"

--- a/apps/web/lib/runtime-config.ts
+++ b/apps/web/lib/runtime-config.ts
@@ -71,6 +71,7 @@ export function resolveBillingMode(
     env.STRIPE_ACCOUNT_ID,
     env.STRIPE_PRICE_ID,
     env.STRIPE_WEBHOOK_SECRET,
+    env.STRIPE_PORTAL_CONFIGURATION_ID,
   ];
   if (stripeValues.every(Boolean)) return "stripe";
   if (stripeValues.some(Boolean)) return "misconfigured";

--- a/apps/web/tests/billing-settings.test.ts
+++ b/apps/web/tests/billing-settings.test.ts
@@ -4,7 +4,10 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it, test } from "node:test";
 
-import { billingSettingsState } from "../app/app/settings/billing/billing-settings-state";
+import {
+  billingSettingsState,
+  stripeCancellationDate,
+} from "../app/app/settings/billing/billing-settings-state";
 
 function relativeLuminance(hex: string): number {
   const channels = hex
@@ -64,6 +67,37 @@ describe("billing settings state", () => {
       canManage: false,
       canStart: true,
     });
+  });
+
+  it("shows a scheduled cancellation while access remains active", () => {
+    const cancellationDate = new Date("2026-09-14T00:00:00.000Z");
+    assert.deepEqual(
+      billingSettingsState(true, {
+        status: "trialing",
+        grandfathered: false,
+        stripeCustomerId: "cus_canceling",
+        cancellationDate,
+      }),
+      {
+        kind: "canceling",
+        title: "Cancellation scheduled",
+        description: "Cloud Sync remains available until the cancellation date.",
+        canManage: true,
+        canStart: false,
+      },
+    );
+  });
+
+  it("maps Stripe cancellation fields to the effective end date", () => {
+    assert.equal(
+      stripeCancellationDate(1_789_430_400, false)?.toISOString(),
+      "2026-09-15T00:00:00.000Z",
+    );
+    assert.equal(
+      stripeCancellationDate(null, true, 1_789_430_400)?.toISOString(),
+      "2026-09-15T00:00:00.000Z",
+    );
+    assert.equal(stripeCancellationDate(null, false, 1_789_430_400), null);
   });
 
   it("keeps legacy access outside Stripe billing", () => {

--- a/apps/web/tests/billing-settings.test.ts
+++ b/apps/web/tests/billing-settings.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, test } from "node:test";
+
+import { billingSettingsState } from "../app/app/settings/billing/billing-settings-state";
+
+function relativeLuminance(hex: string): number {
+  const channels = hex
+    .slice(1)
+    .match(/.{2}/g)
+    ?.map((value) => Number.parseInt(value, 16) / 255)
+    .map((value) =>
+      value <= 0.04045
+        ? value / 12.92
+        : Math.pow((value + 0.055) / 1.055, 2.4),
+    );
+  assert.ok(channels && channels.length === 3, `invalid hex color: ${hex}`);
+  return channels[0]! * 0.2126 + channels[1]! * 0.7152 + channels[2]! * 0.0722;
+}
+
+function contrastRatio(left: string, right: string): number {
+  const lighter = Math.max(relativeLuminance(left), relativeLuminance(right));
+  const darker = Math.min(relativeLuminance(left), relativeLuminance(right));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe("billing settings state", () => {
+  it("shows active subscribers a Stripe management action", () => {
+    assert.deepEqual(
+      billingSettingsState(true, {
+        status: "active",
+        grandfathered: false,
+        stripeCustomerId: "cus_active",
+      }),
+      {
+        kind: "active",
+        title: "Cloud Sync active",
+        description: "Your Cloud Sync subscription is active.",
+        canManage: true,
+        canStart: false,
+      },
+    );
+  });
+
+  it("sends past-due subscribers to Stripe to change their card", () => {
+    const state = billingSettingsState(true, {
+      status: "past_due",
+      grandfathered: false,
+      stripeCustomerId: "cus_past_due",
+    });
+    assert.equal(state.kind, "attention");
+    assert.equal(state.title, "Payment needs attention");
+    assert.equal(state.canManage, true);
+    assert.equal(state.canStart, false);
+  });
+
+  it("offers Checkout only when there is no active subscription", () => {
+    assert.deepEqual(billingSettingsState(true), {
+      kind: "inactive",
+      title: "No active subscription",
+      description: "Start a 15-day Cloud Sync trial when you are ready.",
+      canManage: false,
+      canStart: true,
+    });
+  });
+
+  it("keeps legacy access outside Stripe billing", () => {
+    const state = billingSettingsState(true, {
+      status: "none",
+      grandfathered: true,
+      stripeCustomerId: null,
+    });
+    assert.equal(state.kind, "legacy");
+    assert.equal(state.canManage, false);
+    assert.equal(state.canStart, false);
+  });
+});
+
+test("verification and subscription management surfaces stay discoverable and theme-safe", () => {
+  const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const login = readFileSync(join(root, "app/login/login-form.tsx"), "utf8");
+  const settingsNav = readFileSync(
+    join(root, "app/app/settings/settings-nav.tsx"),
+    "utf8",
+  );
+  const portal = readFileSync(
+    join(root, "app/api/billing/portal/route.ts"),
+    "utf8",
+  );
+
+  assert.match(
+    login,
+    /rounded-xl border border-sand bg-card p-5 text-center text-bark/,
+  );
+  assert.doesNotMatch(login, /border border-sand bg-white p-5 text-center/);
+  assert.match(settingsNav, /\/app\/settings\/billing/);
+  assert.match(portal, /configuration: portalConfigurationId/);
+  assert.match(portal, /return_url: `\$\{origin\}\/app\/settings\/billing`/);
+});
+
+test("dark verification card colors meet normal-text contrast", () => {
+  const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const styles = readFileSync(join(root, "app/globals.css"), "utf8");
+  const darkCard = "#262922";
+
+  assert.match(styles, /--color-card: #262922/);
+  assert.match(styles, /--color-ink: #f0eee2/);
+  assert.match(styles, /--color-bark: #cfcdbe/);
+  assert.match(styles, /--color-stone: #aeb19d/);
+  assert.match(styles, /--color-sage-deep: #aac996/);
+  assert.ok(contrastRatio(darkCard, "#f0eee2") >= 4.5, "ink contrast");
+  assert.ok(contrastRatio(darkCard, "#cfcdbe") >= 4.5, "body contrast");
+  assert.ok(contrastRatio(darkCard, "#aeb19d") >= 4.5, "muted contrast");
+  assert.ok(contrastRatio(darkCard, "#aac996") >= 4.5, "status contrast");
+});

--- a/apps/web/tests/billing-webhook.test.ts
+++ b/apps/web/tests/billing-webhook.test.ts
@@ -14,6 +14,7 @@ before(async () => {
   process.env.STRIPE_ACCOUNT_ID = "acct_fixture";
   process.env.STRIPE_PRICE_ID = "price_fixture";
   process.env.STRIPE_WEBHOOK_SECRET = WEBHOOK_SECRET;
+  process.env.STRIPE_PORTAL_CONFIGURATION_ID = "bpc_fixture";
   ({ POST: post } = await import("../app/api/billing/webhook/route"));
 });
 
@@ -27,6 +28,7 @@ after(() => {
   delete process.env.STRIPE_ACCOUNT_ID;
   delete process.env.STRIPE_PRICE_ID;
   delete process.env.STRIPE_WEBHOOK_SECRET;
+  delete process.env.STRIPE_PORTAL_CONFIGURATION_ID;
 });
 
 function request(payload: string, signature: string) {

--- a/apps/web/tests/runtime-config.test.ts
+++ b/apps/web/tests/runtime-config.test.ts
@@ -109,6 +109,7 @@ test("hosted production requires the complete Stripe group", () => {
       STRIPE_ACCOUNT_ID: "acct_test",
       STRIPE_PRICE_ID: "price",
       STRIPE_WEBHOOK_SECRET: "webhook",
+      STRIPE_PORTAL_CONFIGURATION_ID: "bpc_doodlenote",
     }),
     "stripe",
   );


### PR DESCRIPTION
## Summary

- Fixes the email-verification card in dark mode with theme-aware card and text colors.
- Preserves the trial intent through login and email verification so eligible users reach Stripe Checkout without repeating the action.
- Adds an authenticated Billing settings page for Cloud Sync status and subscription management.
- Routes card changes, invoice history, and cancellation through a dedicated DoodleNote Stripe Customer Portal configuration.
- Refreshes scheduled cancellation state from Stripe when Billing opens, so active access is shown with the exact cancellation date.
- Adds Billing to settings navigation, the account menu, and subscribed pricing states.

## Root cause of the cancellation display mismatch

Stripe keeps a scheduled cancellation separate from the subscription's active or trialing status. DoodleNote mirrored the serving status correctly but did not read the scheduled end date, so it continued to show only "Free trial active" after cancellation.

The Billing page now retrieves the current subscription from Stripe on this low-frequency management surface and maps either `cancel_at` or `cancel_at_period_end` to the effective date. The sync entitlement path remains database-backed and unchanged.

## Affected surfaces

Web authentication UI, pricing handoff, Billing settings, Stripe portal session creation, runtime configuration, tests, and setup documentation. No database migration.

## Verification

- [x] `pnpm --filter web test`: 73 passed
- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [x] `pnpm --filter web build`
- [x] `git diff --check`
- [x] Dark verification card contrast exceeds WCAG AA for normal text
- [x] Preview signup and branded Resend verification
- [x] One-click post-verification Stripe Checkout handoff
- [x] Stripe test trial, payment method replacement, invoice history, and cancel-at-period-end flow
- [x] Dedicated test and live DoodleNote portal configurations
- [x] Production-only Vercel configuration staged

## Privacy, compatibility, and release impact

- [x] No real meeting content, credentials, tokens, signing files, or personal data are included
- [x] Documentation reflects the dedicated Stripe portal configuration requirement
- [x] Hosted billing fails closed when required Stripe or email configuration is incomplete
- [x] Local and explicitly self-hosted installations retain the documented billing bypass

Production should be verified after merge with a real account, email verification, live Checkout, webhook delivery, card management, invoice access, and cancellation. Revert the merge if the Production billing path fails verification.
