### PR TITLE
Add cancellation emails and Cloud Sync data deletion

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -26,6 +26,7 @@
 # RESEND_API_KEY=
 # AUTH_FROM_EMAIL=DoodleNote <no-reply@doodlenote.ai>
 # INVITATION_FROM_EMAIL=
+# BILLING_FROM_EMAIL=DoodleNote <no-reply@doodlenote.ai>
 
 # Official hosted Sync billing ($10 / user / month at doodlenote.ai)
 # STRIPE_SECRET_KEY=
@@ -33,6 +34,10 @@
 # STRIPE_PRICE_ID=
 # STRIPE_WEBHOOK_SECRET=
 # STRIPE_PORTAL_CONFIGURATION_ID=
+
+# Authenticates the daily retry worker for cancellation emails and deletion.
+# Generate a long, random value and store it only in the deployment platform.
+# CRON_SECRET=
 
 # Billing integration test target. Defaults to http://localhost:4040.
 # BILLING_E2E_BASE_URL=

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -35,7 +35,7 @@
 # STRIPE_WEBHOOK_SECRET=
 # STRIPE_PORTAL_CONFIGURATION_ID=
 
-# Authenticates the daily retry worker for cancellation emails and deletion.
+# Authenticates the hourly retry worker for cancellation emails and deletion.
 # Generate a long, random value and store it only in the deployment platform.
 # CRON_SECRET=
 

--- a/apps/web/app/api/billing/webhook/route.ts
+++ b/apps/web/app/api/billing/webhook/route.ts
@@ -7,6 +7,7 @@ import {
   getVerifiedStripe,
   reconcileSubscription,
 } from "@/lib/billing";
+import { handleSubscriptionLifecycleEvent } from "@/lib/billing-lifecycle";
 
 /**
  * Stripe → us. Subscription lifecycle events keep the subscriptions table
@@ -34,9 +35,11 @@ export async function POST(request: Request) {
   switch (event.type) {
     case "customer.subscription.created":
     case "customer.subscription.updated":
-    case "customer.subscription.deleted":
-      await reconcileSubscription(event.data.object);
+    case "customer.subscription.deleted": {
+      const reconciled = await reconcileSubscription(event.data.object);
+      await handleSubscriptionLifecycleEvent(event, reconciled);
       break;
+    }
     case "checkout.session.completed": {
       // The subscription events above carry the real state; this is just a
       // safety net for the brief window before they arrive.

--- a/apps/web/app/api/cron/billing-lifecycle/route.ts
+++ b/apps/web/app/api/cron/billing-lifecycle/route.ts
@@ -1,0 +1,42 @@
+import { timingSafeEqual } from "node:crypto";
+
+import { NextResponse } from "next/server";
+
+import {
+  processDueDataDeletions,
+  processPendingBillingNotifications,
+} from "@/lib/billing-lifecycle";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+function authorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET;
+  const supplied = request.headers.get("authorization") ?? "";
+  if (!secret) return false;
+  const expected = `Bearer ${secret}`;
+  const left = Buffer.from(supplied);
+  const right = Buffer.from(expected);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+/**
+ * Daily safety worker. Stripe's terminal webhook normally performs the purge
+ * immediately; this route retries durable jobs and emails after transient
+ * provider failures without trusting the browser or a customer session.
+ */
+export async function GET(request: Request) {
+  if (!process.env.CRON_SECRET) {
+    return NextResponse.json(
+      { error: "Billing lifecycle worker is not configured" },
+      { status: 503 },
+    );
+  }
+  if (!authorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const deletions = await processDueDataDeletions();
+  const notifications = await processPendingBillingNotifications();
+  return NextResponse.json({ ok: true, deletions, notifications });
+}

--- a/apps/web/app/api/cron/billing-lifecycle/route.ts
+++ b/apps/web/app/api/cron/billing-lifecycle/route.ts
@@ -21,7 +21,7 @@ function authorized(request: Request): boolean {
 }
 
 /**
- * Daily safety worker. Stripe's terminal webhook normally performs the purge
+ * Hourly safety worker. Stripe's terminal webhook normally performs the purge
  * immediately; this route retries durable jobs and emails after transient
  * provider failures without trusting the browser or a customer session.
  */

--- a/apps/web/app/app/settings/billing/billing-settings-state.ts
+++ b/apps/web/app/app/settings/billing/billing-settings-state.ts
@@ -71,7 +71,8 @@ export function billingSettingsState(
     return {
       kind: "canceling",
       title: "Cancellation scheduled",
-      description: "Cloud Sync remains available until the cancellation date.",
+      description:
+        "Cloud Sync remains available until the cancellation date. That day, DoodleNote permanently deletes the active cloud copy in your Personal workspace and disconnects your linked Cloud Sync devices.",
       canManage: Boolean(subscription.stripeCustomerId),
       canStart: false,
     };

--- a/apps/web/app/app/settings/billing/page.tsx
+++ b/apps/web/app/app/settings/billing/page.tsx
@@ -145,7 +145,11 @@ export default async function BillingSettingsPage() {
           </h3>
           <p className="mt-2 text-sm leading-relaxed text-stone">
             Cancellation is completed in Stripe. Stripe shows when Cloud Sync
-            access will end before you confirm the change.
+            access will end before you confirm the change. On that date,
+            DoodleNote permanently deletes the active cloud copy in your Personal
+            workspace and disconnects linked Cloud Sync devices. Your local
+            notes and recordings remain on your devices. Shared-workspace data
+            is retained for the other workspace members.
           </p>
         </section>
       </div>

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -6,7 +6,7 @@ export const metadata = { title: "Privacy policy | DoodleNote" };
 
 export default function PrivacyPage() {
   return (
-    <LegalPage title="Privacy policy" updated="August 27, 2026">
+    <LegalPage title="Privacy policy" updated="August 31, 2026">
       <p>
         DoodleNote is operated by Onyx Dev Labs. This policy explains how the
         DoodleNote apps, website, and optional hosted Sync service handle
@@ -88,7 +88,26 @@ export default function PrivacyPage() {
           retained while needed to provide your account and Sync service, meet
           legal obligations, resolve disputes, and maintain security records.
           Deleting a synced meeting removes the active cloud record through the
-          normal sync process. To request account or hosted-data deletion, email
+          normal sync process.
+        </p>
+        <p>
+          When you schedule cancellation, Cloud Sync remains available through
+          the date Stripe shows in the billing portal. On that date, DoodleNote
+          permanently deletes the active cloud copy of meetings, transcripts,
+          notes, folders, tags, public share links, and attachments in your
+          Personal workspace and disconnects your linked Sync devices and
+          hosted-agent tokens. Local notes and recordings remain on your
+          devices. Content in shared workspaces is retained for the other
+          workspace members, while your access through the canceled subscription
+          ends. Encrypted provider backups may retain deleted records until they
+          age out through the provider&apos;s normal backup rotation, but those
+          records are not available through the service.
+        </p>
+        <p>
+          Billing, email-delivery, security, and deletion audit records may be
+          retained when required for legal, fraud-prevention, and operational
+          accountability purposes. To request account or other hosted-data
+          deletion, email
           <a
             className="ml-1 text-sage-deep underline"
             href="mailto:team@onyxdev.io"

--- a/apps/web/app/terms/page.tsx
+++ b/apps/web/app/terms/page.tsx
@@ -4,7 +4,7 @@ export const metadata = { title: "Terms of service | DoodleNote" };
 
 export default function TermsPage() {
   return (
-    <LegalPage title="Terms of service" updated="August 27, 2026">
+    <LegalPage title="Terms of service" updated="August 31, 2026">
       <p>
         These terms apply to the official DoodleNote website, signed apps, and
         hosted Sync service operated by Onyx Dev Labs. By creating an account or
@@ -56,8 +56,12 @@ export default function TermsPage() {
           The current official Sync price, trial period, taxes, and renewal
           terms are shown at checkout. Stripe processes payments. Subscriptions
           renew until canceled through the billing portal. Canceling stops
-          future renewals and does not remove meetings stored locally on your
-          devices.
+          future renewals. Cloud Sync remains available through the cancellation
+          date shown by Stripe. On that date, DoodleNote permanently deletes the
+          active cloud copy in your Personal workspace and disconnects your
+          linked Sync devices and hosted-agent tokens. Meetings, notes, and
+          recordings stored locally on your devices are not deleted.
+          Shared-workspace content is retained for the other workspace members.
         </p>
       </LegalSection>
 

--- a/apps/web/lib/billing-cancellation-state.ts
+++ b/apps/web/lib/billing-cancellation-state.ts
@@ -1,0 +1,41 @@
+export interface StripeCancellationFields {
+  cancelAt: number | null;
+  cancelAtPeriodEnd: boolean;
+  currentPeriodEnd?: number | null;
+}
+
+export type CancellationChange =
+  | { kind: "scheduled"; scheduledFor: Date }
+  | { kind: "revoked" }
+  | { kind: "unchanged"; scheduledFor: Date | null };
+
+export function subscriptionCancellationDate(
+  subscription: StripeCancellationFields,
+): Date | null {
+  const timestamp =
+    subscription.cancelAt ??
+    (subscription.cancelAtPeriodEnd
+      ? subscription.currentPeriodEnd ?? null
+      : null);
+  return timestamp ? new Date(timestamp * 1000) : null;
+}
+
+export function cancellationChange(
+  current: StripeCancellationFields,
+  previous: { cancel_at?: number | null; cancel_at_period_end?: boolean },
+): CancellationChange {
+  const scheduledFor = subscriptionCancellationDate(current);
+  const previousWasScheduled =
+    Boolean(previous.cancel_at) || previous.cancel_at_period_end === true;
+  const cancellationFieldsChanged =
+    Object.hasOwn(previous, "cancel_at") ||
+    Object.hasOwn(previous, "cancel_at_period_end");
+
+  if (scheduledFor && cancellationFieldsChanged && !previousWasScheduled) {
+    return { kind: "scheduled", scheduledFor };
+  }
+  if (!scheduledFor && cancellationFieldsChanged && previousWasScheduled) {
+    return { kind: "revoked" };
+  }
+  return { kind: "unchanged", scheduledFor };
+}

--- a/apps/web/lib/billing-email-content.ts
+++ b/apps/web/lib/billing-email-content.ts
@@ -1,0 +1,141 @@
+interface BillingEmailInput {
+  email: string;
+  effectiveAt: Date;
+  manageUrl: string;
+  mascotUrl: string;
+}
+
+export interface BillingEmailMessage {
+  to: string;
+  subject: string;
+  text: string;
+  html: string;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function formatDate(value: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "long",
+    timeZone: "UTC",
+  }).format(value);
+}
+
+function brandedEmail(input: {
+  preview: string;
+  title: string;
+  paragraphs: string[];
+  actionLabel: string;
+  actionUrl: string;
+  mascotUrl: string;
+}): string {
+  const paragraphs = input.paragraphs
+    .map(
+      (paragraph) =>
+        `<p style="margin:0 0 18px;font-size:16px;line-height:25px;color:#3a3d33;">${escapeHtml(paragraph)}</p>`,
+    )
+    .join("");
+  const actionUrl = escapeHtml(input.actionUrl);
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="light">
+    <title>${escapeHtml(input.title)}</title>
+  </head>
+  <body style="margin:0;padding:0;background:#f7f5ee;color:#26281f;font-family:Arial,Helvetica,sans-serif;">
+    <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;">${escapeHtml(input.preview)}</div>
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="width:100%;background:#f7f5ee;">
+      <tr>
+        <td align="center" style="padding:36px 16px;">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="width:100%;max-width:560px;background:#ffffff;border:1px solid #e7e3d8;border-radius:20px;overflow:hidden;">
+            <tr>
+              <td style="padding:28px 32px 20px;text-align:center;background:#e9efe0;border-bottom:1px solid #e7e3d8;">
+                <img src="${escapeHtml(input.mascotUrl)}" width="88" height="88" alt="DoodleNote mascot" style="display:block;width:88px;height:88px;margin:0 auto 12px;border:0;">
+                <div style="font-size:22px;line-height:28px;font-weight:700;letter-spacing:-0.3px;color:#26281f;">DoodleNote</div>
+                <div style="margin-top:5px;font-size:13px;line-height:20px;color:#506941;">Local-first. Cloud only when you opt in.</div>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:34px 32px 30px;">
+                <h1 style="margin:0 0 16px;font-size:26px;line-height:34px;font-weight:700;letter-spacing:-0.4px;color:#26281f;">${escapeHtml(input.title)}</h1>
+                ${paragraphs}
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                  <tr>
+                    <td style="border-radius:10px;background:#506941;">
+                      <a href="${actionUrl}" style="display:inline-block;padding:13px 22px;font-size:16px;line-height:20px;font-weight:700;color:#ffffff;text-decoration:none;border-radius:10px;">${escapeHtml(input.actionLabel)}</a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:20px 32px;background:#fdfcf8;border-top:1px solid #e7e3d8;font-size:12px;line-height:19px;color:#6f7367;">DoodleNote Cloud Sync is an optional hosted service. Your local DoodleNote data remains on your devices.</td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+}
+
+export function buildCancellationScheduledEmail(
+  input: BillingEmailInput,
+): BillingEmailMessage {
+  const date = formatDate(input.effectiveAt);
+  const paragraphs = [
+    `Your DoodleNote Cloud Sync subscription is scheduled to end on ${date}.`,
+    `On ${date}, DoodleNote will permanently delete the active cloud copy of meetings, transcripts, notes, folders, tags, shared links, and attachments in your Personal workspace. Linked Cloud Sync devices and agent access tokens will also be disconnected.`,
+    "Your local notes and recordings are not deleted and remain on your devices.",
+    "Content in shared workspaces is retained for the other workspace members. Your Cloud Sync access to those workspaces will end with your subscription.",
+    "You can resume the subscription before it ends from your billing settings.",
+  ];
+  return {
+    to: input.email,
+    subject: "Your DoodleNote Cloud Sync cancellation is scheduled",
+    text: `${paragraphs.join("\n\n")}\n\nManage subscription: ${input.manageUrl}`,
+    html: brandedEmail({
+      preview: `Cloud Sync and Personal workspace cloud data are scheduled to end on ${date}.`,
+      title: "Cloud Sync cancellation scheduled",
+      paragraphs,
+      actionLabel: "Manage subscription",
+      actionUrl: input.manageUrl,
+      mascotUrl: input.mascotUrl,
+    }),
+  };
+}
+
+export function buildCloudSyncEndedEmail(
+  input: BillingEmailInput,
+): BillingEmailMessage {
+  const date = formatDate(input.effectiveAt);
+  const paragraphs = [
+    `Your DoodleNote Cloud Sync subscription ended on ${date}.`,
+    "The active cloud copy of meetings, transcripts, notes, folders, tags, shared links, and attachments in your Personal workspace has been permanently deleted. Linked Cloud Sync devices and agent access tokens have been disconnected.",
+    "Your local notes and recordings remain on your devices. Content in shared workspaces is retained for the other workspace members.",
+    "You can start a new Cloud Sync subscription whenever you are ready.",
+  ];
+  return {
+    to: input.email,
+    subject: "Your DoodleNote Cloud Sync has ended",
+    text: `${paragraphs.join("\n\n")}\n\nRestart Cloud Sync: ${input.manageUrl}`,
+    html: brandedEmail({
+      preview:
+        "Cloud Sync has ended and your Personal workspace active cloud copy was deleted.",
+      title: "Cloud Sync has ended",
+      paragraphs,
+      actionLabel: "Restart Cloud Sync",
+      actionUrl: input.manageUrl,
+      mascotUrl: input.mascotUrl,
+    }),
+  };
+}

--- a/apps/web/lib/billing-email.ts
+++ b/apps/web/lib/billing-email.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import type { BillingEmailMessage } from "./billing-email-content";
+
+export function billingEmailConfigured(): boolean {
+  return Boolean(
+    process.env.RESEND_API_KEY &&
+      (process.env.BILLING_FROM_EMAIL || process.env.AUTH_FROM_EMAIL),
+  );
+}
+
+export async function sendBillingEmail(
+  message: BillingEmailMessage,
+  idempotencyKey: string,
+): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.BILLING_FROM_EMAIL || process.env.AUTH_FROM_EMAIL;
+  if (!apiKey || !from) {
+    throw new Error("Billing email delivery is not configured.");
+  }
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+      "idempotency-key": idempotencyKey,
+    },
+    body: JSON.stringify({
+      from,
+      to: [message.to],
+      subject: message.subject,
+      text: message.text,
+      html: message.html,
+    }),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(
+      `Billing email delivery failed (${response.status}): ${detail.slice(0, 300)}`,
+    );
+  }
+}

--- a/apps/web/lib/billing-lifecycle.ts
+++ b/apps/web/lib/billing-lifecycle.ts
@@ -1,0 +1,507 @@
+import type Stripe from "stripe";
+import {
+  and,
+  billingDataDeletions,
+  billingNotifications,
+  eq,
+  getDb,
+  isNull,
+  lt,
+  lte,
+  or,
+  user,
+  type Db,
+} from "@repo/db";
+
+import {
+  cancellationChange,
+  subscriptionCancellationDate,
+} from "./billing-cancellation-state";
+import {
+  buildCancellationScheduledEmail,
+  buildCloudSyncEndedEmail,
+  type BillingEmailMessage,
+} from "./billing-email-content";
+import { getVerifiedStripe } from "./billing";
+import { selectEffectiveSubscription } from "./billing-state";
+import { purgePersonalCloudData } from "./cloud-data-purge";
+
+const CLAIM_TIMEOUT_MS = 10 * 60 * 1000;
+const SERVING_STATUSES = new Set(["trialing", "active", "past_due"]);
+
+async function defaultSendBillingEmail(
+  message: BillingEmailMessage,
+  idempotencyKey: string,
+): Promise<void> {
+  const { sendBillingEmail } = await import("./billing-email");
+  await sendBillingEmail(message, idempotencyKey);
+}
+
+type NotificationKind =
+  | "cancellation_scheduled"
+  | "cloud_sync_ended";
+
+export interface ReconciledSubscription {
+  userId: string | null;
+  subscription: Stripe.Subscription;
+}
+
+interface LifecycleDependencies {
+  db?: Db;
+  now?: Date;
+  sendEmail?: (
+    message: BillingEmailMessage,
+    idempotencyKey: string,
+  ) => Promise<void>;
+  purgeData?: typeof purgePersonalCloudData;
+  verifyDeletion?: (
+    job: typeof billingDataDeletions.$inferSelect,
+  ) => Promise<"ended" | "wait" | "canceled">;
+}
+
+function publicOrigin(): string {
+  const raw =
+    process.env.BETTER_AUTH_URL ??
+    (process.env.VERCEL_URL
+      ? `https://${process.env.VERCEL_URL}`
+      : "http://localhost:4040");
+  return new URL(raw).origin;
+}
+
+function stripeCancellationFields(subscription: Stripe.Subscription) {
+  return {
+    cancelAt: subscription.cancel_at,
+    cancelAtPeriodEnd: subscription.cancel_at_period_end,
+    currentPeriodEnd: subscription.items.data[0]?.current_period_end,
+  };
+}
+
+function terminalDate(
+  subscription: Stripe.Subscription,
+  fallback: Date,
+): Date {
+  const timestamp =
+    subscription.ended_at ??
+    subscription.canceled_at ??
+    subscription.items.data[0]?.current_period_end;
+  return timestamp ? new Date(timestamp * 1000) : fallback;
+}
+
+function stripeOperationId(event: Stripe.Event): string {
+  const request =
+    typeof event.request === "string" ? event.request : event.request?.id;
+  return request ?? event.id;
+}
+
+async function scheduleDeletion(input: {
+  db: Db;
+  userId: string;
+  stripeCustomerId: string;
+  stripeSubscriptionId: string;
+  scheduledFor: Date;
+  now: Date;
+}): Promise<void> {
+  const [existing] = await input.db
+    .select({
+      stripeSubscriptionId: billingDataDeletions.stripeSubscriptionId,
+      status: billingDataDeletions.status,
+    })
+    .from(billingDataDeletions)
+    .where(eq(billingDataDeletions.userId, input.userId))
+    .limit(1);
+  if (
+    existing?.stripeSubscriptionId === input.stripeSubscriptionId &&
+    existing.status === "completed"
+  ) {
+    return;
+  }
+
+  await input.db
+    .insert(billingDataDeletions)
+    .values({
+      userId: input.userId,
+      stripeCustomerId: input.stripeCustomerId,
+      stripeSubscriptionId: input.stripeSubscriptionId,
+      scheduledFor: input.scheduledFor,
+      status: "pending",
+      updatedAt: input.now,
+    })
+    .onConflictDoUpdate({
+      target: billingDataDeletions.userId,
+      set: {
+        stripeCustomerId: input.stripeCustomerId,
+        stripeSubscriptionId: input.stripeSubscriptionId,
+        scheduledFor: input.scheduledFor,
+        status: "pending",
+        claimedAt: null,
+        completedAt: null,
+        lastError: null,
+        updatedAt: input.now,
+      },
+    });
+}
+
+async function cancelDeletion(db: Db, userId: string, now: Date) {
+  await db
+    .update(billingDataDeletions)
+    .set({
+      status: "canceled",
+      claimedAt: null,
+      lastError: null,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(billingDataDeletions.userId, userId),
+        eq(billingDataDeletions.status, "pending"),
+      ),
+    );
+}
+
+async function enqueueNotification(input: {
+  db: Db;
+  dedupeKey: string;
+  userId: string;
+  kind: NotificationKind;
+  effectiveAt: Date;
+  now: Date;
+}): Promise<void> {
+  await input.db
+    .insert(billingNotifications)
+    .values({
+      dedupeKey: input.dedupeKey,
+      userId: input.userId,
+      kind: input.kind,
+      effectiveAt: input.effectiveAt,
+      updatedAt: input.now,
+    })
+    .onConflictDoNothing({ target: billingNotifications.dedupeKey });
+}
+
+export async function processBillingNotification(
+  dedupeKey: string,
+  dependencies: LifecycleDependencies = {},
+): Promise<"sent" | "already_sent" | "claimed" | "missing"> {
+  const db = dependencies.db ?? getDb();
+  const now = dependencies.now ?? new Date();
+  const staleBefore = new Date(now.getTime() - CLAIM_TIMEOUT_MS);
+  const [claimed] = await db
+    .update(billingNotifications)
+    .set({ claimedAt: now, updatedAt: now })
+    .where(
+      and(
+        eq(billingNotifications.dedupeKey, dedupeKey),
+        isNull(billingNotifications.sentAt),
+        or(
+          isNull(billingNotifications.claimedAt),
+          lt(billingNotifications.claimedAt, staleBefore),
+        ),
+      ),
+    )
+    .returning();
+  if (!claimed) {
+    const [existing] = await db
+      .select({
+        sentAt: billingNotifications.sentAt,
+        claimedAt: billingNotifications.claimedAt,
+      })
+      .from(billingNotifications)
+      .where(eq(billingNotifications.dedupeKey, dedupeKey))
+      .limit(1);
+    if (!existing) return "missing";
+    return existing.sentAt ? "already_sent" : "claimed";
+  }
+
+  const [recipient] = await db
+    .select({ email: user.email })
+    .from(user)
+    .where(eq(user.id, claimed.userId))
+    .limit(1);
+  if (!recipient) {
+    await db.delete(billingNotifications).where(eq(billingNotifications.id, claimed.id));
+    return "missing";
+  }
+
+  const origin = publicOrigin();
+  const common = {
+    email: recipient.email,
+    effectiveAt: claimed.effectiveAt,
+    mascotUrl: `${origin}/mascot.png`,
+  };
+  const message =
+    claimed.kind === "cancellation_scheduled"
+      ? buildCancellationScheduledEmail({
+          ...common,
+          manageUrl: `${origin}/app/settings/billing`,
+        })
+      : buildCloudSyncEndedEmail({
+          ...common,
+          manageUrl: `${origin}/pricing?checkout=1`,
+        });
+
+  try {
+    await (dependencies.sendEmail ?? defaultSendBillingEmail)(
+      message,
+      claimed.dedupeKey,
+    );
+    await db
+      .update(billingNotifications)
+      .set({ sentAt: now, claimedAt: null, lastError: null, updatedAt: now })
+      .where(eq(billingNotifications.id, claimed.id));
+    return "sent";
+  } catch (error) {
+    await db
+      .update(billingNotifications)
+      .set({
+        claimedAt: null,
+        lastError: String(error instanceof Error ? error.message : error).slice(
+          0,
+          500,
+        ),
+        updatedAt: now,
+      })
+      .where(eq(billingNotifications.id, claimed.id));
+    throw error;
+  }
+}
+
+async function defaultVerifyDeletion(
+  job: typeof billingDataDeletions.$inferSelect,
+): Promise<"ended" | "wait" | "canceled"> {
+  const priceId = process.env.STRIPE_PRICE_ID;
+  if (!priceId) throw new Error("STRIPE_PRICE_ID is not set");
+  const stripe = await getVerifiedStripe();
+  const subscriptionsForCustomer = await stripe.subscriptions.list({
+    customer: job.stripeCustomerId,
+    status: "all",
+    limit: 100,
+  });
+  const current = selectEffectiveSubscription(
+    subscriptionsForCustomer.data,
+    priceId,
+  );
+  if (!current || !SERVING_STATUSES.has(current.status)) return "ended";
+  if (current.id !== job.stripeSubscriptionId) return "canceled";
+  return subscriptionCancellationDate(stripeCancellationFields(current))
+    ? "wait"
+    : "canceled";
+}
+
+export async function processDueDataDeletions(
+  dependencies: LifecycleDependencies & { limit?: number; userId?: string } = {},
+): Promise<{
+  completed: number;
+  waiting: number;
+  canceled: number;
+  failed: number;
+}> {
+  const db = dependencies.db ?? getDb();
+  const now = dependencies.now ?? new Date();
+  const staleBefore = new Date(now.getTime() - CLAIM_TIMEOUT_MS);
+  const filters = [
+    eq(billingDataDeletions.status, "pending"),
+    lte(billingDataDeletions.scheduledFor, now),
+  ];
+  if (dependencies.userId) {
+    filters.push(eq(billingDataDeletions.userId, dependencies.userId));
+  }
+  const due = await db
+    .select()
+    .from(billingDataDeletions)
+    .where(and(...filters))
+    .limit(dependencies.limit ?? 10);
+
+  const result = { completed: 0, waiting: 0, canceled: 0, failed: 0 };
+  for (const candidate of due) {
+    const [job] = await db
+      .update(billingDataDeletions)
+      .set({ claimedAt: now, updatedAt: now })
+      .where(
+        and(
+          eq(billingDataDeletions.userId, candidate.userId),
+          eq(billingDataDeletions.status, "pending"),
+          or(
+            isNull(billingDataDeletions.claimedAt),
+            lt(billingDataDeletions.claimedAt, staleBefore),
+          ),
+        ),
+      )
+      .returning();
+    if (!job) continue;
+
+    try {
+      const verification = await (
+        dependencies.verifyDeletion ?? defaultVerifyDeletion
+      )(job);
+      if (verification === "wait") {
+        await db
+          .update(billingDataDeletions)
+          .set({ claimedAt: null, updatedAt: now })
+          .where(eq(billingDataDeletions.userId, job.userId));
+        result.waiting += 1;
+        continue;
+      }
+      if (verification === "canceled") {
+        await cancelDeletion(db, job.userId, now);
+        result.canceled += 1;
+        continue;
+      }
+
+      await (dependencies.purgeData ?? purgePersonalCloudData)({
+        db,
+        userId: job.userId,
+      });
+      await db
+        .update(billingDataDeletions)
+        .set({
+          status: "completed",
+          claimedAt: null,
+          completedAt: now,
+          lastError: null,
+          updatedAt: now,
+        })
+        .where(eq(billingDataDeletions.userId, job.userId));
+      const finalNotificationKey = `cloud-sync-ended:${job.stripeSubscriptionId}:${job.scheduledFor.toISOString()}`;
+      await enqueueNotification({
+        db,
+        dedupeKey: finalNotificationKey,
+        userId: job.userId,
+        kind: "cloud_sync_ended",
+        effectiveAt: job.scheduledFor,
+        now,
+      });
+      try {
+        await processBillingNotification(finalNotificationKey, dependencies);
+      } catch {
+        // The durable outbox keeps the email retryable without repeating a
+        // successful irreversible data purge.
+      }
+      result.completed += 1;
+    } catch (error) {
+      await db
+        .update(billingDataDeletions)
+        .set({
+          claimedAt: null,
+          lastError: String(error instanceof Error ? error.message : error).slice(
+            0,
+            500,
+          ),
+          updatedAt: now,
+        })
+        .where(eq(billingDataDeletions.userId, job.userId));
+      result.failed += 1;
+    }
+  }
+  return result;
+}
+
+export async function processPendingBillingNotifications(
+  dependencies: LifecycleDependencies & { limit?: number } = {},
+): Promise<{ sent: number; failed: number }> {
+  const db = dependencies.db ?? getDb();
+  const pending = await db
+    .select({ dedupeKey: billingNotifications.dedupeKey })
+    .from(billingNotifications)
+    .where(isNull(billingNotifications.sentAt))
+    .limit(dependencies.limit ?? 20);
+  const result = { sent: 0, failed: 0 };
+  for (const notification of pending) {
+    try {
+      const status = await processBillingNotification(
+        notification.dedupeKey,
+        dependencies,
+      );
+      if (status === "sent") result.sent += 1;
+    } catch {
+      result.failed += 1;
+    }
+  }
+  return result;
+}
+
+export async function handleSubscriptionLifecycleEvent(
+  event: Stripe.Event,
+  reconciled: ReconciledSubscription,
+  dependencies: LifecycleDependencies = {},
+): Promise<void> {
+  if (!reconciled.userId) return;
+  const db = dependencies.db ?? getDb();
+  const now = dependencies.now ?? new Date();
+  const subscription = reconciled.subscription;
+  const customerId =
+    typeof subscription.customer === "string"
+      ? subscription.customer
+      : subscription.customer.id;
+  const previous =
+    event.type === "customer.subscription.updated"
+      ? (event.data.previous_attributes ?? {})
+      : {};
+  const change = cancellationChange(
+    stripeCancellationFields(subscription),
+    previous as { cancel_at?: number | null; cancel_at_period_end?: boolean },
+  );
+  const scheduledFor = subscriptionCancellationDate(
+    stripeCancellationFields(subscription),
+  );
+  const incoming = event.data.object as Stripe.Subscription;
+  const incomingIsAuthoritative = incoming.id === subscription.id;
+
+  if (SERVING_STATUSES.has(subscription.status) && scheduledFor) {
+    await scheduleDeletion({
+      db,
+      userId: reconciled.userId,
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: subscription.id,
+      scheduledFor,
+      now,
+    });
+    if (incomingIsAuthoritative && change.kind === "scheduled") {
+      const dedupeKey =
+        `stripe:${stripeOperationId(event)}:cancellation-scheduled`;
+      await enqueueNotification({
+        db,
+        dedupeKey,
+        userId: reconciled.userId,
+        kind: "cancellation_scheduled",
+        effectiveAt: change.scheduledFor,
+        now,
+      });
+      await processBillingNotification(dedupeKey, dependencies);
+    }
+    return;
+  }
+
+  if (SERVING_STATUSES.has(subscription.status)) {
+    await cancelDeletion(db, reconciled.userId, now);
+    return;
+  }
+
+  if (
+    event.type === "customer.subscription.deleted" &&
+    incomingIsAuthoritative
+  ) {
+    const deletionDate = terminalDate(subscription, now);
+    await scheduleDeletion({
+      db,
+      userId: reconciled.userId,
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: subscription.id,
+      scheduledFor: deletionDate,
+      now,
+    });
+    const result = await processDueDataDeletions({
+      ...dependencies,
+      db,
+      now,
+      userId: reconciled.userId,
+      limit: 1,
+    });
+    if (result.failed > 0) {
+      throw new Error("Cloud data deletion failed and remains queued for retry.");
+    }
+    await processBillingNotification(
+      `cloud-sync-ended:${subscription.id}:${deletionDate.toISOString()}`,
+      dependencies,
+    );
+  }
+}

--- a/apps/web/lib/billing.ts
+++ b/apps/web/lib/billing.ts
@@ -115,7 +115,9 @@ export async function ensureCustomer(
 }
 
 /** Mirror a Stripe subscription event into our table. */
-export async function recordSubscription(sub: Stripe.Subscription): Promise<void> {
+export async function recordSubscription(
+  sub: Stripe.Subscription,
+): Promise<string | null> {
   const userId = sub.metadata?.doodlenoteUserId;
   const customerId =
     typeof sub.customer === "string" ? sub.customer : sub.customer.id;
@@ -133,7 +135,7 @@ export async function recordSubscription(sub: Stripe.Subscription): Promise<void
   }
   if (!targetUserId) {
     console.error("[billing] subscription event with unknown user", sub.id);
-    return;
+    return null;
   }
 
   const periodEnd = sub.items.data[0]?.current_period_end;
@@ -161,6 +163,7 @@ export async function recordSubscription(sub: Stripe.Subscription): Promise<void
         updatedAt: new Date(),
       },
     });
+  return targetUserId;
 }
 
 /**
@@ -170,7 +173,10 @@ export async function recordSubscription(sub: Stripe.Subscription): Promise<void
  */
 export async function reconcileSubscription(
   incoming: Stripe.Subscription,
-): Promise<void> {
+): Promise<{
+  userId: string | null;
+  subscription: Stripe.Subscription;
+}> {
   const customerId =
     typeof incoming.customer === "string"
       ? incoming.customer
@@ -184,9 +190,10 @@ export async function reconcileSubscription(
     status: "all",
     limit: 100,
   });
-  await recordSubscription(
-    selectEffectiveSubscription(current.data, priceId) ?? incoming,
-  );
+  const subscription =
+    selectEffectiveSubscription(current.data, priceId) ?? incoming;
+  const userId = await recordSubscription(subscription);
+  return { userId, subscription };
 }
 
 /** Return the current configured-Price subscription when Checkout must stop. */

--- a/apps/web/lib/cloud-data-purge.ts
+++ b/apps/web/lib/cloud-data-purge.ts
@@ -1,0 +1,91 @@
+import { del, list } from "@vercel/blob";
+import {
+  agentTokens,
+  and,
+  eq,
+  folders,
+  getDb,
+  member,
+  meetingStars,
+  meetings,
+  meetingTags,
+  organization,
+  sql,
+  syncDevices,
+  type Db,
+} from "@repo/db";
+
+export interface CloudDataPurgeResult {
+  personalWorkspaceCount: number;
+  meetingCount: number;
+}
+
+interface PurgePersonalCloudDataInput {
+  userId: string;
+  db?: Db;
+  deleteAttachmentPrefix?: (prefix: string) => Promise<void>;
+}
+
+export async function deleteCloudAttachments(prefix: string): Promise<void> {
+  let cursor: string | undefined;
+  const urls: string[] = [];
+  do {
+    const page = await list({ prefix, cursor, limit: 1000 });
+    urls.push(...page.blobs.map((blob) => blob.url));
+    cursor = page.hasMore ? page.cursor : undefined;
+  } while (cursor);
+
+  for (let offset = 0; offset < urls.length; offset += 1000) {
+    await del(urls.slice(offset, offset + 1000));
+  }
+}
+
+/**
+ * Delete only cloud data that is exclusively owned by this subscriber.
+ * Shared-workspace content belongs to the workspace and must survive one
+ * member's cancellation, but that member's device and agent credentials are
+ * revoked across every workspace.
+ */
+export async function purgePersonalCloudData({
+  userId,
+  db = getDb(),
+  deleteAttachmentPrefix = deleteCloudAttachments,
+}: PurgePersonalCloudDataInput): Promise<CloudDataPurgeResult> {
+  const personalWorkspaces = await db
+    .select({ id: organization.id })
+    .from(member)
+    .innerJoin(organization, eq(organization.id, member.organizationId))
+    .where(
+      and(
+        eq(member.userId, userId),
+        eq(member.role, "owner"),
+        sql`${organization.slug} like 'personal-%'`,
+      ),
+    );
+
+  for (const workspace of personalWorkspaces) {
+    await deleteAttachmentPrefix(`attachments/${workspace.id}/`);
+  }
+
+  await db.delete(syncDevices).where(eq(syncDevices.userId, userId));
+  await db.delete(agentTokens).where(eq(agentTokens.userId, userId));
+  await db.delete(meetingStars).where(eq(meetingStars.userId, userId));
+
+  let meetingCount = 0;
+  for (const workspace of personalWorkspaces) {
+    const deletedMeetings = await db
+      .delete(meetings)
+      .where(eq(meetings.organizationId, workspace.id))
+      .returning();
+    meetingCount += deletedMeetings.length;
+    await db.delete(folders).where(eq(folders.organizationId, workspace.id));
+    await db
+      .delete(meetingTags)
+      .where(eq(meetingTags.organizationId, workspace.id));
+  }
+
+  return {
+    personalWorkspaceCount: personalWorkspaces.length,
+    meetingCount,
+  };
+}

--- a/apps/web/tests/billing-cancellation-lifecycle.test.ts
+++ b/apps/web/tests/billing-cancellation-lifecycle.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  cancellationChange,
+  subscriptionCancellationDate,
+} from "../lib/billing-cancellation-state";
+import {
+  buildCancellationScheduledEmail,
+  buildCloudSyncEndedEmail,
+} from "../lib/billing-email-content";
+
+describe("billing cancellation lifecycle", () => {
+  it("uses Stripe's explicit cancellation time when present", () => {
+    const value = subscriptionCancellationDate({
+      cancelAt: 1_789_430_400,
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: 1_800_000_000,
+    });
+
+    assert.equal(value?.toISOString(), "2026-09-15T00:00:00.000Z");
+  });
+
+  it("uses the period end for cancellation at period end", () => {
+    const value = subscriptionCancellationDate({
+      cancelAt: null,
+      cancelAtPeriodEnd: true,
+      currentPeriodEnd: 1_789_430_400,
+    });
+
+    assert.equal(value?.toISOString(), "2026-09-15T00:00:00.000Z");
+  });
+
+  it("detects scheduling and resumption transitions", () => {
+    assert.deepEqual(
+      cancellationChange(
+        { cancelAt: null, cancelAtPeriodEnd: true, currentPeriodEnd: 1_789_430_400 },
+        { cancel_at_period_end: false },
+      ),
+      {
+        kind: "scheduled",
+        scheduledFor: new Date("2026-09-15T00:00:00.000Z"),
+      },
+    );
+
+    assert.deepEqual(
+      cancellationChange(
+        { cancelAt: null, cancelAtPeriodEnd: false, currentPeriodEnd: 1_789_430_400 },
+        { cancel_at_period_end: true },
+      ),
+      { kind: "revoked" },
+    );
+  });
+});
+
+describe("billing cancellation email content", () => {
+  const input = {
+    email: "billing-user@example.com",
+    effectiveAt: new Date("2026-09-15T00:00:00.000Z"),
+    manageUrl: "https://www.doodlenote.ai/app/settings/billing",
+    mascotUrl: "https://www.doodlenote.ai/mascot.png",
+  };
+
+  it("states the deletion date and distinguishes local and shared data", () => {
+    const message = buildCancellationScheduledEmail(input);
+
+    assert.equal(
+      message.subject,
+      "Your DoodleNote Cloud Sync cancellation is scheduled",
+    );
+    assert.match(message.text, /September 15, 2026/);
+    assert.match(message.text, /permanently delete the active cloud copy/i);
+    assert.match(message.text, /Personal workspace/i);
+    assert.match(message.text, /local notes and recordings.*not deleted/i);
+    assert.match(message.text, /shared workspaces.*retained/i);
+    assert.match(message.html, /Manage subscription/);
+  });
+
+  it("confirms deletion only after Cloud Sync has ended", () => {
+    const message = buildCloudSyncEndedEmail(input);
+
+    assert.equal(message.subject, "Your DoodleNote Cloud Sync has ended");
+    assert.match(message.text, /active cloud copy.*permanently deleted/i);
+    assert.match(message.text, /local notes and recordings.*remain/i);
+    assert.match(message.html, /Restart Cloud Sync/);
+  });
+});

--- a/apps/web/tests/billing-cron.test.ts
+++ b/apps/web/tests/billing-cron.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import { GET } from "../app/api/cron/billing-lifecycle/route";
+
+afterEach(() => {
+  delete process.env.CRON_SECRET;
+});
+
+describe("billing lifecycle worker authentication", () => {
+  it("fails closed when the deployment secret is missing", async () => {
+    const response = await GET(
+      new Request("https://www.doodlenote.ai/api/cron/billing-lifecycle"),
+    );
+
+    assert.equal(response.status, 503);
+  });
+
+  it("rejects callers without the exact bearer secret", async () => {
+    process.env.CRON_SECRET = "fixture-cron-secret";
+    const response = await GET(
+      new Request("https://www.doodlenote.ai/api/cron/billing-lifecycle", {
+        headers: { authorization: "Bearer wrong-secret" },
+      }),
+    );
+
+    assert.equal(response.status, 401);
+  });
+});

--- a/apps/web/tests/billing-lifecycle-processing.test.ts
+++ b/apps/web/tests/billing-lifecycle-processing.test.ts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import type Stripe from "stripe";
+import {
+  billingDataDeletions,
+  billingNotifications,
+  eq,
+  organization,
+  member,
+  subscriptions,
+  user,
+} from "@repo/db";
+import { createInMemoryDb, type InMemoryDb } from "@repo/db/testing";
+
+import type { BillingEmailMessage } from "../lib/billing-email-content";
+import {
+  handleSubscriptionLifecycleEvent,
+  processDueDataDeletions,
+} from "../lib/billing-lifecycle";
+
+let mem: InMemoryDb;
+const userId = "lifecycle-user";
+const subscriptionId = "sub_lifecycle";
+const customerId = "cus_lifecycle";
+const now = new Date("2026-09-01T12:00:00.000Z");
+const scheduledFor = new Date("2026-09-15T00:00:00.000Z");
+
+function stripeSubscription(input: {
+  status: Stripe.Subscription.Status;
+  cancelAtPeriodEnd?: boolean;
+  endedAt?: number | null;
+}): Stripe.Subscription {
+  return {
+    id: subscriptionId,
+    object: "subscription",
+    created: 1_800_000_000,
+    status: input.status,
+    customer: customerId,
+    cancel_at: null,
+    cancel_at_period_end: input.cancelAtPeriodEnd ?? false,
+    canceled_at: input.endedAt ?? null,
+    ended_at: input.endedAt ?? null,
+    metadata: { doodlenoteUserId: userId },
+    items: {
+      object: "list",
+      data: [
+        {
+          id: "si_lifecycle",
+          object: "subscription_item",
+          price: { id: "price_sync" },
+          quantity: 1,
+          current_period_end: Math.floor(scheduledFor.getTime() / 1000),
+        } as Stripe.SubscriptionItem,
+      ],
+      has_more: false,
+      url: "/v1/subscription_items",
+    },
+  } as unknown as Stripe.Subscription;
+}
+
+function stripeEvent(
+  id: string,
+  type:
+    | "customer.subscription.updated"
+    | "customer.subscription.deleted",
+  subscription: Stripe.Subscription,
+  previousAttributes: Record<string, unknown> = {},
+): Stripe.Event {
+  return {
+    id,
+    object: "event",
+    api_version: "2026-02-25.clover",
+    created: Math.floor(now.getTime() / 1000),
+    data: {
+      object: subscription,
+      previous_attributes: previousAttributes,
+    },
+    livemode: false,
+    pending_webhooks: 1,
+    request: null,
+    type,
+  } as unknown as Stripe.Event;
+}
+
+before(async () => {
+  mem = await createInMemoryDb();
+  await mem.db.insert(user).values({
+    id: userId,
+    name: "Lifecycle User",
+    email: "lifecycle@example.com",
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  await mem.db.insert(organization).values({
+    id: "lifecycle-personal",
+    name: "Personal",
+    slug: "personal-lifecycle",
+    createdAt: now,
+  });
+  await mem.db.insert(member).values({
+    id: "lifecycle-member",
+    organizationId: "lifecycle-personal",
+    userId,
+    role: "owner",
+    createdAt: now,
+  });
+  await mem.db.insert(subscriptions).values({
+    userId,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscriptionId,
+    status: "active",
+    currentPeriodEnd: scheduledFor,
+  });
+});
+
+after(async () => {
+  await mem.close();
+});
+
+describe("durable cancellation processing", () => {
+  it("sends the scheduled email once and persists the deletion date", async () => {
+    const sent: BillingEmailMessage[] = [];
+    const idempotencyKeys: string[] = [];
+    const subscription = stripeSubscription({
+      status: "active",
+      cancelAtPeriodEnd: true,
+    });
+    const event = stripeEvent("evt_scheduled", "customer.subscription.updated", subscription, {
+      cancel_at_period_end: false,
+    });
+    const dependencies = {
+      db: mem.db,
+      now,
+      sendEmail: async (
+        message: BillingEmailMessage,
+        idempotencyKey: string,
+      ) => {
+        sent.push(message);
+        idempotencyKeys.push(idempotencyKey);
+      },
+    };
+
+    await handleSubscriptionLifecycleEvent(
+      event,
+      { userId, subscription },
+      dependencies,
+    );
+    await handleSubscriptionLifecycleEvent(
+      event,
+      { userId, subscription },
+      dependencies,
+    );
+
+    const [job] = await mem.db
+      .select()
+      .from(billingDataDeletions)
+      .where(eq(billingDataDeletions.userId, userId));
+    const notifications = await mem.db
+      .select()
+      .from(billingNotifications)
+      .where(eq(billingNotifications.userId, userId));
+    assert.equal(job?.status, "pending");
+    assert.equal(job?.scheduledFor.toISOString(), scheduledFor.toISOString());
+    assert.equal(sent.length, 1);
+    assert.deepEqual(idempotencyKeys, [
+      "stripe:evt_scheduled:cancellation-scheduled",
+    ]);
+    assert.equal(notifications.length, 1);
+    assert.ok(notifications[0]?.sentAt);
+  });
+
+  it("does not purge while Stripe still reports a serving subscription", async () => {
+    let purgeCount = 0;
+    const result = await processDueDataDeletions({
+      db: mem.db,
+      now: new Date("2026-09-15T01:00:00.000Z"),
+      verifyDeletion: async () => "wait",
+      purgeData: async () => {
+        purgeCount += 1;
+        return { personalWorkspaceCount: 1, meetingCount: 1 };
+      },
+    });
+
+    const [job] = await mem.db
+      .select()
+      .from(billingDataDeletions)
+      .where(eq(billingDataDeletions.userId, userId));
+    assert.deepEqual(result, {
+      completed: 0,
+      waiting: 1,
+      canceled: 0,
+      failed: 0,
+    });
+    assert.equal(purgeCount, 0);
+    assert.equal(job?.status, "pending");
+  });
+
+  it("cancels the deletion job when the subscriber resumes", async () => {
+    const subscription = stripeSubscription({ status: "active" });
+    await handleSubscriptionLifecycleEvent(
+      stripeEvent("evt_resumed", "customer.subscription.updated", subscription, {
+        cancel_at_period_end: true,
+      }),
+      { userId, subscription },
+      { db: mem.db, now, sendEmail: async () => {} },
+    );
+
+    const [job] = await mem.db
+      .select()
+      .from(billingDataDeletions)
+      .where(eq(billingDataDeletions.userId, userId));
+    assert.equal(job?.status, "canceled");
+  });
+
+  it("purges once after Stripe confirms expiration and sends the final email once", async () => {
+    const sent: BillingEmailMessage[] = [];
+    let purgeAttempts = 0;
+    let emailAttempts = 0;
+    const endedAt = Math.floor(scheduledFor.getTime() / 1000);
+    const subscription = stripeSubscription({ status: "canceled", endedAt });
+    const event = stripeEvent(
+      "evt_ended",
+      "customer.subscription.deleted",
+      subscription,
+    );
+    const dependencies = {
+      db: mem.db,
+      now: new Date("2026-09-15T01:00:00.000Z"),
+      sendEmail: async (message: BillingEmailMessage) => {
+        emailAttempts += 1;
+        if (emailAttempts === 1) {
+          throw new Error("temporary email provider failure");
+        }
+        sent.push(message);
+      },
+      verifyDeletion: async () => "ended" as const,
+      purgeData: async () => {
+        purgeAttempts += 1;
+        if (purgeAttempts === 1) {
+          throw new Error("temporary blob provider failure");
+        }
+        return { personalWorkspaceCount: 1, meetingCount: 1 };
+      },
+    };
+
+    await assert.rejects(
+      handleSubscriptionLifecycleEvent(
+        event,
+        { userId, subscription },
+        dependencies,
+      ),
+      /remains queued for retry/,
+    );
+    await handleSubscriptionLifecycleEvent(
+      event,
+      { userId, subscription },
+      dependencies,
+    );
+
+    const [job] = await mem.db
+      .select()
+      .from(billingDataDeletions)
+      .where(eq(billingDataDeletions.userId, userId));
+    const notifications = await mem.db
+      .select()
+      .from(billingNotifications)
+      .where(eq(billingNotifications.userId, userId));
+    assert.equal(job?.status, "completed");
+    assert.ok(job?.completedAt);
+    assert.equal(purgeAttempts, 2);
+    assert.equal(emailAttempts, 2);
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0]?.subject, "Your DoodleNote Cloud Sync has ended");
+    assert.equal(notifications.length, 2);
+  });
+});

--- a/apps/web/tests/billing-persistence.test.ts
+++ b/apps/web/tests/billing-persistence.test.ts
@@ -5,7 +5,9 @@ import { eq, subscriptions, user } from "@repo/db";
 import { createInMemoryDb, type InMemoryDb } from "@repo/db/testing";
 
 let mem: InMemoryDb;
-let recordSubscription: (subscription: Stripe.Subscription) => Promise<void>;
+let recordSubscription: (
+  subscription: Stripe.Subscription,
+) => Promise<string | null>;
 
 function subscription(priceId = "price_sync"): Stripe.Subscription {
   return {

--- a/apps/web/tests/billing-settings.test.ts
+++ b/apps/web/tests/billing-settings.test.ts
@@ -81,7 +81,8 @@ describe("billing settings state", () => {
       {
         kind: "canceling",
         title: "Cancellation scheduled",
-        description: "Cloud Sync remains available until the cancellation date.",
+        description:
+          "Cloud Sync remains available until the cancellation date. That day, DoodleNote permanently deletes the active cloud copy in your Personal workspace and disconnects your linked Cloud Sync devices.",
         canManage: true,
         canStart: false,
       },
@@ -132,6 +133,13 @@ test("verification and subscription management surfaces stay discoverable and th
   assert.match(settingsNav, /\/app\/settings\/billing/);
   assert.match(portal, /configuration: portalConfigurationId/);
   assert.match(portal, /return_url: `\$\{origin\}\/app\/settings\/billing`/);
+
+  const billingPage = readFileSync(
+    join(root, "app/app/settings/billing/page.tsx"),
+    "utf8",
+  );
+  assert.match(billingPage, /permanently deletes the active cloud copy/);
+  assert.match(billingPage, /local\s+notes and recordings remain/);
 });
 
 test("dark verification card colors meet normal-text contrast", () => {

--- a/apps/web/tests/cloud-data-purge.test.ts
+++ b/apps/web/tests/cloud-data-purge.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import {
+  agentTokens,
+  eq,
+  folders,
+  member,
+  meetingStars,
+  meetings,
+  meetingTagLinks,
+  meetingTags,
+  notes,
+  organization,
+  subscriptions,
+  syncDevices,
+  transcriptSegments,
+  user,
+} from "@repo/db";
+import { createInMemoryDb, type InMemoryDb } from "@repo/db/testing";
+
+import { purgePersonalCloudData } from "../lib/cloud-data-purge";
+
+let mem: InMemoryDb;
+
+const userId = "canceling-user";
+const collaboratorId = "collaborator";
+const personalId = "personal-workspace";
+const sharedId = "shared-workspace";
+const personalMeetingId = "00000000-0000-4000-8000-000000000001";
+const sharedMeetingId = "00000000-0000-4000-8000-000000000002";
+const personalFolderId = "00000000-0000-4000-8000-000000000011";
+const sharedFolderId = "00000000-0000-4000-8000-000000000012";
+const personalTagId = "00000000-0000-4000-8000-000000000021";
+const sharedTagId = "00000000-0000-4000-8000-000000000022";
+
+before(async () => {
+  mem = await createInMemoryDb();
+  const now = new Date();
+  await mem.db.insert(user).values([
+    {
+      id: userId,
+      name: "Canceling User",
+      email: "canceling@example.com",
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: collaboratorId,
+      name: "Collaborator",
+      email: "collaborator@example.com",
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    },
+  ]);
+  await mem.db.insert(organization).values([
+    { id: personalId, name: "Personal", slug: "personal-fixture", createdAt: now },
+    { id: sharedId, name: "Shared", slug: "shared-fixture", createdAt: now },
+  ]);
+  await mem.db.insert(member).values([
+    { id: "member-personal", organizationId: personalId, userId, role: "owner", createdAt: now },
+    { id: "member-shared", organizationId: sharedId, userId, role: "member", createdAt: now },
+    { id: "member-collaborator", organizationId: sharedId, userId: collaboratorId, role: "owner", createdAt: now },
+  ]);
+  await mem.db.insert(folders).values([
+    { id: personalFolderId, organizationId: personalId, name: "Private" },
+    { id: sharedFolderId, organizationId: sharedId, name: "Team" },
+  ]);
+  await mem.db.insert(meetings).values([
+    { id: personalMeetingId, organizationId: personalId, title: "Private meeting", folderId: personalFolderId },
+    { id: sharedMeetingId, organizationId: sharedId, title: "Shared meeting", folderId: sharedFolderId },
+  ]);
+  await mem.db.insert(transcriptSegments).values([
+    { meetingId: personalMeetingId, channel: "mic", speaker: "You", text: "private", startMs: 0, endMs: 10 },
+    { meetingId: sharedMeetingId, channel: "mic", speaker: "You", text: "shared", startMs: 0, endMs: 10 },
+  ]);
+  await mem.db.insert(notes).values([
+    { meetingId: personalMeetingId, rawContent: { format: "markdown", markdown: "private" } },
+    { meetingId: sharedMeetingId, rawContent: { format: "markdown", markdown: "shared" } },
+  ]);
+  await mem.db.insert(meetingTags).values([
+    { id: personalTagId, organizationId: personalId, name: "private" },
+    { id: sharedTagId, organizationId: sharedId, name: "shared" },
+  ]);
+  await mem.db.insert(meetingTagLinks).values([
+    { meetingId: personalMeetingId, tagId: personalTagId },
+    { meetingId: sharedMeetingId, tagId: sharedTagId },
+  ]);
+  await mem.db.insert(meetingStars).values([
+    { meetingId: personalMeetingId, userId },
+    { meetingId: sharedMeetingId, userId },
+    { meetingId: sharedMeetingId, userId: collaboratorId },
+  ]);
+  await mem.db.insert(syncDevices).values([
+    { tokenHash: "user-personal-token", userId, organizationId: personalId, deviceName: "Mac" },
+    { tokenHash: "user-shared-token", userId, organizationId: sharedId, deviceName: "Mac" },
+    { tokenHash: "collaborator-token", userId: collaboratorId, organizationId: sharedId, deviceName: "Mac" },
+  ]);
+  await mem.db.insert(agentTokens).values([
+    { tokenHash: "user-agent-token", userId, organizationId: personalId, name: "Agent" },
+    { tokenHash: "collaborator-agent-token", userId: collaboratorId, organizationId: sharedId, name: "Agent" },
+  ]);
+  await mem.db.insert(subscriptions).values({
+    userId,
+    stripeCustomerId: "cus_fixture",
+    stripeSubscriptionId: "sub_fixture",
+    status: "canceled",
+  });
+});
+
+after(async () => {
+  await mem.close();
+});
+
+describe("personal Cloud Sync data purge", () => {
+  it("deletes personal cloud copies and user credentials while retaining the account and shared data", async () => {
+    const deletedPrefixes: string[] = [];
+    const result = await purgePersonalCloudData({
+      db: mem.db,
+      userId,
+      deleteAttachmentPrefix: async (prefix) => {
+        deletedPrefixes.push(prefix);
+      },
+    });
+
+    assert.deepEqual(deletedPrefixes, [`attachments/${personalId}/`]);
+    assert.equal(result.personalWorkspaceCount, 1);
+    assert.equal(result.meetingCount, 1);
+
+    assert.equal((await mem.db.select().from(meetings).where(eq(meetings.id, personalMeetingId))).length, 0);
+    assert.equal((await mem.db.select().from(folders).where(eq(folders.id, personalFolderId))).length, 0);
+    assert.equal((await mem.db.select().from(meetingTags).where(eq(meetingTags.id, personalTagId))).length, 0);
+    assert.equal((await mem.db.select().from(meetings).where(eq(meetings.id, sharedMeetingId))).length, 1);
+    assert.equal((await mem.db.select().from(folders).where(eq(folders.id, sharedFolderId))).length, 1);
+    assert.equal((await mem.db.select().from(meetingTags).where(eq(meetingTags.id, sharedTagId))).length, 1);
+
+    assert.equal((await mem.db.select().from(syncDevices).where(eq(syncDevices.userId, userId))).length, 0);
+    assert.equal((await mem.db.select().from(agentTokens).where(eq(agentTokens.userId, userId))).length, 0);
+    assert.equal((await mem.db.select().from(meetingStars).where(eq(meetingStars.userId, userId))).length, 0);
+    assert.equal((await mem.db.select().from(syncDevices).where(eq(syncDevices.userId, collaboratorId))).length, 1);
+    assert.equal((await mem.db.select().from(agentTokens).where(eq(agentTokens.userId, collaboratorId))).length, 1);
+    assert.equal((await mem.db.select().from(meetingStars).where(eq(meetingStars.userId, collaboratorId))).length, 1);
+
+    assert.equal((await mem.db.select().from(user).where(eq(user.id, userId))).length, 1);
+    assert.equal((await mem.db.select().from(organization).where(eq(organization.id, personalId))).length, 1);
+    assert.equal((await mem.db.select().from(member).where(eq(member.userId, userId))).length, 2);
+    assert.equal((await mem.db.select().from(subscriptions).where(eq(subscriptions.userId, userId))).length, 1);
+  });
+});

--- a/apps/web/tests/legal-pages.test.ts
+++ b/apps/web/tests/legal-pages.test.ts
@@ -23,7 +23,11 @@ test("privacy policy documents local, synced, shared, and deletion behavior", ()
   assert.match(privacy, /does\s+not\s+upload meeting audio as part of Sync/);
   assert.match(privacy, /meeting titles, notes, transcripts/);
   assert.match(privacy, /public\s+share\s+link/);
-  assert.match(privacy, /request\s+account or hosted-data deletion/);
+  assert.match(privacy, /request\s+account or other hosted-data/);
+  assert.match(privacy, /permanently deletes the active cloud copy/);
+  assert.match(privacy, /provider&apos;s normal backup rotation/);
+  assert.match(privacy, /Local notes and recordings remain/);
+  assert.match(privacy, /shared workspaces is retained/);
   assert.match(privacy, /team@onyxdev\.io/);
 });
 
@@ -32,4 +36,6 @@ test("terms separate the MIT software license from the hosted service", () => {
   assert.match(terms, /MIT\s+License governs/);
   assert.match(terms, /service terms separately govern/);
   assert.match(terms, /recording-consent requirements/);
+  assert.match(terms, /permanently deletes the\s+active cloud copy/);
+  assert.match(terms, /stored\s+locally on your devices are not deleted/);
 });

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/billing-lifecycle",
+      "schedule": "0 6 * * *"
+    }
+  ]
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,7 +3,7 @@
   "crons": [
     {
       "path": "/api/cron/billing-lifecycle",
-      "schedule": "0 6 * * *"
+      "schedule": "0 * * * *"
     }
   ]
 }

--- a/packages/db/drizzle/0012_perfect_pretty_boy.sql
+++ b/packages/db/drizzle/0012_perfect_pretty_boy.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "billing_data_deletions" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"stripe_customer_id" text NOT NULL,
+	"stripe_subscription_id" text NOT NULL,
+	"scheduled_for" timestamp with time zone NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"claimed_at" timestamp with time zone,
+	"completed_at" timestamp with time zone,
+	"last_error" text,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "billing_notifications" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"dedupe_key" text NOT NULL,
+	"user_id" text NOT NULL,
+	"kind" text NOT NULL,
+	"effective_at" timestamp with time zone NOT NULL,
+	"claimed_at" timestamp with time zone,
+	"sent_at" timestamp with time zone,
+	"last_error" text,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "billing_data_deletions" ADD CONSTRAINT "billing_data_deletions_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "billing_notifications" ADD CONSTRAINT "billing_notifications_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "billing_data_deletions_due_idx" ON "billing_data_deletions" USING btree ("status","scheduled_for");--> statement-breakpoint
+CREATE UNIQUE INDEX "billing_notifications_dedupe_key_uidx" ON "billing_notifications" USING btree ("dedupe_key");--> statement-breakpoint
+CREATE INDEX "billing_notifications_pending_idx" ON "billing_notifications" USING btree ("sent_at","created_at");

--- a/packages/db/drizzle/meta/0012_snapshot.json
+++ b/packages/db/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,2024 @@
+{
+  "id": "25069405-5ba9-4ae8-9f7d-ee14f4bf4fb0",
+  "prevId": "5f53dec3-f20f-4716-8cac-1bc543aac956",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_tokens": {
+      "name": "agent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Agent'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tokens_user_id_idx": {
+          "name": "agent_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tokens_user_id_user_id_fk": {
+          "name": "agent_tokens_user_id_user_id_fk",
+          "tableFrom": "agent_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tokens_organization_id_organization_id_fk": {
+          "name": "agent_tokens_organization_id_organization_id_fk",
+          "tableFrom": "agent_tokens",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tokens_token_hash_unique": {
+          "name": "agent_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_data_deletions": {
+      "name": "billing_data_deletions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_data_deletions_due_idx": {
+          "name": "billing_data_deletions_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_data_deletions_user_id_user_id_fk": {
+          "name": "billing_data_deletions_user_id_user_id_fk",
+          "tableFrom": "billing_data_deletions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_notifications": {
+      "name": "billing_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_notifications_dedupe_key_uidx": {
+          "name": "billing_notifications_dedupe_key_uidx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_notifications_pending_idx": {
+          "name": "billing_notifications_pending_idx",
+          "columns": [
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_notifications_user_id_user_id_fk": {
+          "name": "billing_notifications_user_id_user_id_fk",
+          "tableFrom": "billing_notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.folders": {
+      "name": "folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "folders_organization_id_idx": {
+          "name": "folders_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "folders_organization_id_organization_id_fk": {
+          "name": "folders_organization_id_organization_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_stars": {
+      "name": "meeting_stars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meeting_stars_meeting_user_uidx": {
+          "name": "meeting_stars_meeting_user_uidx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meeting_stars_user_id_idx": {
+          "name": "meeting_stars_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meeting_stars_meeting_id_meetings_id_fk": {
+          "name": "meeting_stars_meeting_id_meetings_id_fk",
+          "tableFrom": "meeting_stars",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meeting_stars_user_id_user_id_fk": {
+          "name": "meeting_stars_user_id_user_id_fk",
+          "tableFrom": "meeting_stars",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_tag_links": {
+      "name": "meeting_tag_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meeting_tag_links_meeting_tag_uidx": {
+          "name": "meeting_tag_links_meeting_tag_uidx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meeting_tag_links_meeting_id_idx": {
+          "name": "meeting_tag_links_meeting_id_idx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meeting_tag_links_meeting_id_meetings_id_fk": {
+          "name": "meeting_tag_links_meeting_id_meetings_id_fk",
+          "tableFrom": "meeting_tag_links",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meeting_tag_links_tag_id_meeting_tags_id_fk": {
+          "name": "meeting_tag_links_tag_id_meeting_tags_id_fk",
+          "tableFrom": "meeting_tag_links",
+          "tableTo": "meeting_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_tags": {
+      "name": "meeting_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meeting_tags_organization_name_uidx": {
+          "name": "meeting_tags_organization_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meeting_tags_organization_id_idx": {
+          "name": "meeting_tags_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meeting_tags_organization_id_organization_id_fk": {
+          "name": "meeting_tags_organization_id_organization_id_fk",
+          "tableFrom": "meeting_tags",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetings": {
+      "name": "meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled meeting'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'meeting'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_expires_at": {
+          "name": "share_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_include_transcript": {
+          "name": "share_include_transcript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetings_organization_id_idx": {
+          "name": "meetings_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetings_organization_id_organization_id_fk": {
+          "name": "meetings_organization_id_organization_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_folder_id_folders_id_fk": {
+          "name": "meetings_folder_id_folders_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meetings_share_token_unique": {
+          "name": "meetings_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notes": {
+      "name": "notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_content": {
+          "name": "raw_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enhanced_content": {
+          "name": "enhanced_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notes_meeting_id_meetings_id_fk": {
+          "name": "notes_meeting_id_meetings_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notes_meeting_id_unique": {
+          "name": "notes_meeting_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meeting_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grandfathered": {
+          "name": "grandfathered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_user_id_user_id_fk": {
+          "name": "subscriptions_user_id_user_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_customer_id_unique": {
+          "name": "subscriptions_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_devices": {
+      "name": "sync_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Desktop'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_devices_user_id_idx": {
+          "name": "sync_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_devices_user_id_user_id_fk": {
+          "name": "sync_devices_user_id_user_id_fk",
+          "tableFrom": "sync_devices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_devices_organization_id_organization_id_fk": {
+          "name": "sync_devices_organization_id_organization_id_fk",
+          "tableFrom": "sync_devices",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sync_devices_token_hash_unique": {
+          "name": "sync_devices_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcript_segments": {
+      "name": "transcript_segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker": {
+          "name": "speaker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "absolute_start_ms": {
+          "name": "absolute_start_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcript_segments_meeting_id_idx": {
+          "name": "transcript_segments_meeting_id_idx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transcript_segments_meeting_id_meetings_id_fk": {
+          "name": "transcript_segments_meeting_id_meetings_id_fk",
+          "tableFrom": "transcript_segments",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verified_caller_ids": {
+      "name": "verified_caller_ids",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "outgoing_caller_id_sid": {
+          "name": "outgoing_caller_id_sid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "verified_caller_ids_user_id_user_id_fk": {
+          "name": "verified_caller_ids_user_id_user_id_fk",
+          "tableFrom": "verified_caller_ids",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_issuer_accountId_uidx": {
+          "name": "account_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1787847414555,
       "tag": "0011_long_dormammu",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1788184190594,
+      "tag": "0012_perfect_pretty_boy",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,4 +3,17 @@ export * from "./auth-schema";
 export { getDb, schema, authSchema, fullSchema, type Db, type FullSchema } from "./client";
 // Query-builder helpers re-exported so consumers don't need their own
 // drizzle-orm dependency (keeps the version single-sourced here).
-export { and, asc, desc, eq, gt, ilike, inArray, or, sql } from "drizzle-orm";
+export {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  ilike,
+  inArray,
+  isNull,
+  lt,
+  lte,
+  or,
+  sql,
+} from "drizzle-orm";

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -224,6 +224,68 @@ export const subscriptions = pgTable("subscriptions", {
 });
 
 /**
+ * Durable, retryable deletion schedule for a subscriber's Personal workspace
+ * cloud copy. Stripe remains authoritative at execution time so a resumed or
+ * replacement subscription prevents an obsolete job from deleting data.
+ */
+export const billingDataDeletions = pgTable(
+  "billing_data_deletions",
+  {
+    userId: text("user_id")
+      .primaryKey()
+      .references(() => user.id, { onDelete: "cascade" }),
+    stripeCustomerId: text("stripe_customer_id").notNull(),
+    stripeSubscriptionId: text("stripe_subscription_id").notNull(),
+    scheduledFor: timestamp("scheduled_for", { withTimezone: true }).notNull(),
+    status: text("status", {
+      enum: ["pending", "completed", "canceled"],
+    })
+      .notNull()
+      .default("pending"),
+    claimedAt: timestamp("claimed_at", { withTimezone: true }),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    lastError: text("last_error"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => [
+    index("billing_data_deletions_due_idx").on(
+      table.status,
+      table.scheduledFor,
+    ),
+  ],
+);
+
+/**
+ * Small transactional outbox for customer billing messages. Dedupe keys make
+ * Stripe webhook retries safe, while claimed_at prevents concurrent workers
+ * from sending the same message.
+ */
+export const billingNotifications = pgTable(
+  "billing_notifications",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    dedupeKey: text("dedupe_key").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    kind: text("kind", {
+      enum: ["cancellation_scheduled", "cloud_sync_ended"],
+    }).notNull(),
+    effectiveAt: timestamp("effective_at", { withTimezone: true }).notNull(),
+    claimedAt: timestamp("claimed_at", { withTimezone: true }),
+    sentAt: timestamp("sent_at", { withTimezone: true }),
+    lastError: text("last_error"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("billing_notifications_dedupe_key_uidx").on(table.dedupeKey),
+    index("billing_notifications_pending_idx").on(table.sentAt, table.createdAt),
+  ],
+);
+
+/**
  * Verified Caller ID for phone calls: a user proves ownership of their real
  * number via Twilio's validation flow, and outbound DoodleNote calls then
  * display it instead of the shared workspace number.


### PR DESCRIPTION
## Summary\n\n- send a branded email when Cloud Sync cancellation is scheduled, including the exact service and active-cloud-data deletion date\n- permanently purge Personal-workspace meetings, transcripts, notes, folders, tags, share links, attachments, device tokens, and hosted-agent tokens after Stripe confirms the subscription ended\n- retain shared-workspace content for the remaining members and preserve local device data\n- use durable deletion jobs and an idempotent email outbox so webhook retries cannot duplicate completed work\n- add an authenticated daily Vercel safety worker for transient Stripe, Resend, Blob, or database failures\n- update Billing, Privacy, and Terms copy to disclose the deletion behavior and provider-backup limitation\n\n## Safety properties\n\n- Stripe is rechecked before every destructive purge\n- a resumed or replacement serving subscription cancels the pending deletion\n- only Personal workspaces owned by the subscriber are purged\n- shared-workspace content and the DoodleNote login account are retained\n- Vercel Blob attachments are deleted before the database records are finalized\n- completed deletion jobs are not reopened by duplicate webhook delivery\n- Resend receives an idempotency key and the database records sent state\n\n## Verification\n\n- web tests: 85 passed\n- database tests: 7 passed\n- full workspace lint: passed\n- full workspace typecheck: passed\n- production Next.js build: passed\n- production dependency audit: no known vulnerabilities\n- migration 0012 applied successfully to fresh in-memory PostgreSQL test databases\n- Vercel project root verified as apps/web\n- Vercel cron authentication and Blob deletion APIs checked against current official documentation\n\n## Production rollout requirements\n\nDo not merge or deploy until these are complete:\n\n1. Apply packages/db/drizzle/0012_perfect_pretty_boy.sql to the Production Neon database.\n2. Add a new random CRON_SECRET only to Vercel Production. AUTH_FROM_EMAIL is already a valid fallback for billing mail, and the Production Blob token is already present.\n3. Run the full cancellation flow in an isolated Preview database and Stripe test mode.\n4. After merge, verify the Production webhook, scheduled email, cancellation reversal, terminal deletion, final email, and daily worker.\n\n## Risk and rollback\n\nThe migration only adds two lifecycle tables. The destructive worker is unreachable without a verified Stripe terminal state or the authenticated cron, and it limits deletion to subscriber-owned Personal workspaces. Before a Production cancellation reaches its end date, rollback is to redeploy the prior commit and disable the cron. A completed data purge is intentionally irreversible.