### PR TITLE
Harden DoodleNote Stripe webhook product isolation

### DIFF
--- a/apps/web/lib/billing.ts
+++ b/apps/web/lib/billing.ts
@@ -177,12 +177,20 @@ export async function reconcileSubscription(
   userId: string | null;
   subscription: Stripe.Subscription;
 }> {
+  const priceId = process.env.STRIPE_PRICE_ID;
+  if (!priceId) throw new Error("STRIPE_PRICE_ID is not set");
+  const hasDoodleNoteUserMarker = Object.prototype.hasOwnProperty.call(
+    incoming.metadata ?? {},
+    "doodlenoteUserId",
+  );
+  if (!hasDoodleNoteUserMarker && !subscriptionUsesPrice(incoming, priceId)) {
+    return { userId: null, subscription: incoming };
+  }
+
   const customerId =
     typeof incoming.customer === "string"
       ? incoming.customer
       : incoming.customer.id;
-  const priceId = process.env.STRIPE_PRICE_ID;
-  if (!priceId) throw new Error("STRIPE_PRICE_ID is not set");
 
   const stripe = await getVerifiedStripe();
   const current = await stripe.subscriptions.list({

--- a/apps/web/tests/billing-persistence.test.ts
+++ b/apps/web/tests/billing-persistence.test.ts
@@ -8,15 +8,21 @@ let mem: InMemoryDb;
 let recordSubscription: (
   subscription: Stripe.Subscription,
 ) => Promise<string | null>;
+let reconcileSubscription: (
+  subscription: Stripe.Subscription,
+) => Promise<{ userId: string | null; subscription: Stripe.Subscription }>;
 
-function subscription(priceId = "price_sync"): Stripe.Subscription {
+function subscription(
+  priceId = "price_sync",
+  metadata: Stripe.Metadata = { doodlenoteUserId: "billing-user" },
+): Stripe.Subscription {
   return {
     id: "sub_fixture",
     object: "subscription",
     created: 1_800_000_000,
     status: "active",
     customer: "cus_fixture",
-    metadata: { doodlenoteUserId: "billing-user" },
+    metadata,
     items: {
       object: "list",
       data: [
@@ -44,7 +50,7 @@ before(async () => {
   process.env.STRIPE_PRICE_ID = "price_sync";
   mem = await createInMemoryDb();
   (globalThis as { __repoDbClient?: unknown }).__repoDbClient = mem.db;
-  ({ recordSubscription } = await import("../lib/billing"));
+  ({ recordSubscription, reconcileSubscription } = await import("../lib/billing"));
   await mem.db.insert(user).values({
     id: "billing-user",
     name: "Billing User",
@@ -83,5 +89,16 @@ describe("subscription persistence", () => {
       .where(eq(subscriptions.userId, "billing-user"))
       .limit(1);
     assert.equal(row[0]?.status, "invalid_price");
+  });
+
+  it("ignores another product's subscription before Stripe or database work", async () => {
+    const foreign = subscription("price_techstatus", {
+      techstatus_tenant_id: "tenant-fixture",
+    });
+
+    const result = await reconcileSubscription(foreign);
+
+    assert.equal(result.userId, null);
+    assert.equal(result.subscription, foreign);
   });
 });


### PR DESCRIPTION
## Summary

- identify unrelated Stripe subscriptions before DoodleNote account or database reconciliation
- preserve fail-closed processing when a subscription carries either the DoodleNote user marker or configured DoodleNote Price
- add a regression for a TechStatus-style subscription in the shared Stripe account

## Why

The Onyx Stripe account is shared by DoodleNote and TechStatus. Stripe webhook destinations can filter event types but not Product or metadata, so both destinations receive some valid subscription events for the other product.

DoodleNote already acknowledged unknown subscriptions without retrying them, but it performed additional Stripe and database work first. This change makes the product boundary explicit and avoids that unnecessary work.

## Safety

The webhook signature is still verified by the route before reconciliation. Only subscriptions with neither a `doodlenoteUserId` metadata key nor the configured DoodleNote Price are ignored. A subscription carrying either marker still follows the existing reconciliation and invalid-Price behavior.

## Verification

- `pnpm --filter web exec tsx --test tests/billing-persistence.test.ts`
- `pnpm --filter web test` (86 passing)
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`
- `git diff --check`

## Deployment note

No Stripe configuration, secret, Product, Price, customer, payment, database schema, or production environment is changed by this PR.
