### PR TITLE
Add DoodleNote contact form and fix footer wrapping

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -27,6 +27,7 @@
 # AUTH_FROM_EMAIL=DoodleNote <no-reply@doodlenote.ai>
 # INVITATION_FROM_EMAIL=
 # BILLING_FROM_EMAIL=DoodleNote <no-reply@doodlenote.ai>
+# CONTACT_FROM_EMAIL=DoodleNote <no-reply@doodlenote.ai>
 
 # Official hosted Sync billing ($10 / user / month at doodlenote.ai)
 # STRIPE_SECRET_KEY=

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -31,6 +31,7 @@ No external service is required for the basic local development path:
 | Google sign-in                    | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`                                                                                           |
 | Account verification              | `RESEND_API_KEY`, `AUTH_FROM_EMAIL`                                                                                                  |
 | Workspace invitations             | `RESEND_API_KEY`, `INVITATION_FROM_EMAIL`                                                                                            |
+| Public contact form               | `RESEND_API_KEY`, optional `CONTACT_FROM_EMAIL` (falls back to `AUTH_FROM_EMAIL`)                                                     |
 | Billing                           | `STRIPE_SECRET_KEY`, `STRIPE_ACCOUNT_ID`, `STRIPE_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PORTAL_CONFIGURATION_ID`                |
 | Voice features                    | `TWILIO_ACCOUNT_SID`, `TWILIO_API_KEY_SID`, `TWILIO_API_KEY_SECRET`, `TWILIO_TWIML_APP_SID`, `TWILIO_CALLER_ID`, `TWILIO_AUTH_TOKEN` |
 

--- a/apps/web/app/api/contact/route.ts
+++ b/apps/web/app/api/contact/route.ts
@@ -1,0 +1,287 @@
+import { createHash } from "node:crypto";
+
+import { NextResponse } from "next/server";
+
+const CONTACT_RECIPIENT = "team@onyxdev.io";
+const MAX_BODY_BYTES = 16_384;
+const MIN_COMPLETION_MS = 2_000;
+const MAX_COMPLETION_MS = 2 * 60 * 60 * 1_000;
+const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1_000;
+const RATE_LIMIT_MAX = 5;
+
+export interface ContactSubmission {
+  name: string;
+  email: string;
+  company: string;
+  phone: string;
+  message: string;
+}
+
+interface ContactEmail {
+  from: string;
+  to: string[];
+  reply_to: string;
+  subject: string;
+  text: string;
+  html: string;
+}
+
+interface ContactHandlerDependencies {
+  now?: () => number;
+  allowRequest?: (request: Request, now: number) => boolean;
+  sendEmail?: (
+    submission: ContactSubmission,
+    idempotencyKey: string,
+  ) => Promise<void>;
+}
+
+type RateLimitEntry = { count: number; windowStartedAt: number };
+
+const rateLimitState = globalThis as typeof globalThis & {
+  __doodleNoteContactRateLimits?: Map<string, RateLimitEntry>;
+};
+const rateLimits =
+  rateLimitState.__doodleNoteContactRateLimits ??
+  (rateLimitState.__doodleNoteContactRateLimits = new Map());
+
+function html(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function oneLine(value: unknown): string | null {
+  return typeof value === "string" ? value.trim().replace(/\s+/g, " ") : null;
+}
+
+function parseSubmission(
+  value: unknown,
+  now: number,
+):
+  | { kind: "valid"; submission: ContactSubmission; startedAt: number }
+  | { kind: "honeypot" }
+  | { kind: "invalid" } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { kind: "invalid" };
+  }
+
+  const input = value as Record<string, unknown>;
+  const website = oneLine(input.website);
+  if (website) return { kind: "honeypot" };
+
+  const name = oneLine(input.name);
+  const email = oneLine(input.email)?.toLowerCase() ?? null;
+  const company = oneLine(input.company);
+  const phone = oneLine(input.phone);
+  const message = typeof input.message === "string" ? input.message.trim() : null;
+  const startedAt = input.startedAt;
+  const elapsed = typeof startedAt === "number" ? now - startedAt : NaN;
+
+  if (
+    !name ||
+    name.length < 2 ||
+    name.length > 100 ||
+    !email ||
+    email.length > 254 ||
+    !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ||
+    company === null ||
+    company.length > 120 ||
+    phone === null ||
+    phone.length > 40 ||
+    !message ||
+    message.length < 10 ||
+    message.length > 5_000 ||
+    !Number.isFinite(elapsed) ||
+    elapsed < MIN_COMPLETION_MS ||
+    elapsed > MAX_COMPLETION_MS
+  ) {
+    return { kind: "invalid" };
+  }
+
+  return {
+    kind: "valid",
+    startedAt: startedAt as number,
+    submission: { name, email, company, phone, message },
+  };
+}
+
+function sameOrigin(request: Request): boolean {
+  const origin = request.headers.get("origin");
+  const fetchSite = request.headers.get("sec-fetch-site");
+  return (
+    origin === new URL(request.url).origin &&
+    (!fetchSite || fetchSite === "same-origin")
+  );
+}
+
+function rateLimitKey(request: Request): string | null {
+  const address =
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip")?.trim();
+  return address
+    ? createHash("sha256").update(address).digest("hex")
+    : null;
+}
+
+function allowRequest(request: Request, now: number): boolean {
+  const key = rateLimitKey(request);
+  if (!key) return true;
+
+  if (rateLimits.size > 1_000) {
+    for (const [candidate, entry] of rateLimits) {
+      if (now - entry.windowStartedAt >= RATE_LIMIT_WINDOW_MS) {
+        rateLimits.delete(candidate);
+      }
+    }
+  }
+
+  const existing = rateLimits.get(key);
+  if (!existing || now - existing.windowStartedAt >= RATE_LIMIT_WINDOW_MS) {
+    rateLimits.set(key, { count: 1, windowStartedAt: now });
+    return true;
+  }
+  if (existing.count >= RATE_LIMIT_MAX) return false;
+  existing.count += 1;
+  return true;
+}
+
+export function buildContactEmail(
+  submission: ContactSubmission,
+  from: string,
+): ContactEmail {
+  const company = submission.company || "Not provided";
+  const phone = submission.phone || "Not provided";
+  return {
+    from,
+    to: [CONTACT_RECIPIENT],
+    reply_to: submission.email,
+    subject: `DoodleNote contact from ${submission.name}`,
+    text: [
+      "New DoodleNote contact form submission",
+      "",
+      `Name: ${submission.name}`,
+      `Email: ${submission.email}`,
+      `Company: ${company}`,
+      `Phone: ${phone}`,
+      "",
+      "Message:",
+      submission.message,
+    ].join("\n"),
+    html: `<!doctype html>
+<html lang="en">
+  <body style="margin:0;padding:24px;background:#f7f5ee;color:#26281f;font-family:Arial,Helvetica,sans-serif;">
+    <div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e7e3d8;border-radius:12px;overflow:hidden;">
+      <div style="padding:20px 24px;background:#e9efe0;border-bottom:1px solid #e7e3d8;">
+        <strong style="font-size:20px;">New DoodleNote message</strong>
+      </div>
+      <div style="padding:24px;line-height:1.6;">
+        <p style="margin:0 0 6px;"><strong>Name:</strong> ${html(submission.name)}</p>
+        <p style="margin:0 0 6px;"><strong>Email:</strong> ${html(submission.email)}</p>
+        <p style="margin:0 0 6px;"><strong>Company:</strong> ${html(company)}</p>
+        <p style="margin:0 0 20px;"><strong>Phone:</strong> ${html(phone)}</p>
+        <p style="margin:0 0 8px;"><strong>Message</strong></p>
+        <div style="white-space:pre-wrap;padding:16px;background:#fdfcf8;border:1px solid #e7e3d8;border-radius:8px;">${html(submission.message)}</div>
+      </div>
+    </div>
+  </body>
+</html>`,
+  };
+}
+
+async function sendContactEmail(
+  submission: ContactSubmission,
+  idempotencyKey: string,
+): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.CONTACT_FROM_EMAIL || process.env.AUTH_FROM_EMAIL;
+  if (!apiKey || !from) {
+    throw new Error("Contact email delivery is not configured.");
+  }
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+      "idempotency-key": idempotencyKey,
+    },
+    body: JSON.stringify(buildContactEmail(submission, from)),
+  });
+  if (!response.ok) {
+    console.error("[contact] Resend rejected a contact email.", {
+      status: response.status,
+    });
+    throw new Error("Contact email delivery failed.");
+  }
+}
+
+function json(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: { "cache-control": "no-store" },
+  });
+}
+
+export function createContactPostHandler(
+  dependencies: ContactHandlerDependencies = {},
+) {
+  const now = dependencies.now ?? Date.now;
+  const isAllowed = dependencies.allowRequest ?? allowRequest;
+  const deliver = dependencies.sendEmail ?? sendContactEmail;
+
+  return async function POST(request: Request): Promise<Response> {
+    if (!sameOrigin(request)) {
+      return json({ error: "This request could not be accepted." }, 403);
+    }
+    if (!request.headers.get("content-type")?.startsWith("application/json")) {
+      return json({ error: "This request could not be accepted." }, 415);
+    }
+    const declaredLength = Number(request.headers.get("content-length"));
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_BODY_BYTES) {
+      return json({ error: "Your message is too large." }, 413);
+    }
+
+    const rawBody = await request.text();
+    if (new TextEncoder().encode(rawBody).byteLength > MAX_BODY_BYTES) {
+      return json({ error: "Your message is too large." }, 413);
+    }
+
+    let input: unknown;
+    try {
+      input = JSON.parse(rawBody);
+    } catch {
+      return json({ error: "Please check the form and try again." }, 400);
+    }
+
+    const currentTime = now();
+    const parsed = parseSubmission(input, currentTime);
+    if (parsed.kind === "honeypot") return json({ ok: true });
+    if (parsed.kind === "invalid") {
+      return json({ error: "Please check the form and try again." }, 400);
+    }
+    if (!isAllowed(request, currentTime)) {
+      return json(
+        { error: "Too many messages were sent. Please try again later." },
+        429,
+      );
+    }
+
+    const idempotencyKey = `doodlenote-contact-${createHash("sha256")
+      .update(JSON.stringify([parsed.submission, parsed.startedAt]))
+      .digest("hex")}`;
+    try {
+      await deliver(parsed.submission, idempotencyKey);
+    } catch {
+      return json(
+        { error: "Your message could not be sent right now. Please try again." },
+        502,
+      );
+    }
+    return json({ ok: true });
+  };
+}
+
+export const POST = createContactPostHandler();

--- a/apps/web/app/contact/contact-form.tsx
+++ b/apps/web/app/contact/contact-form.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import { buttonPrimary, inputClass } from "../ui";
+
+type FormState =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "success" }
+  | { kind: "error"; message: string };
+
+export function ContactForm() {
+  const formRef = useRef<HTMLFormElement>(null);
+  const startedAt = useRef<number | null>(null);
+  const [state, setState] = useState<FormState>({ kind: "idle" });
+
+  function recordInteraction() {
+    startedAt.current ??= Date.now();
+  }
+
+  async function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (state.kind === "submitting") return;
+
+    setState({ kind: "submitting" });
+    const fields = Object.fromEntries(new FormData(event.currentTarget));
+    try {
+      const response = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ...fields, startedAt: startedAt.current ?? 0 }),
+      });
+      const result = (await response.json().catch(() => null)) as {
+        error?: unknown;
+      } | null;
+      if (!response.ok) {
+        throw new Error(
+          typeof result?.error === "string"
+            ? result.error
+            : "Your message could not be sent right now. Please try again.",
+        );
+      }
+
+      formRef.current?.reset();
+      startedAt.current = null;
+      setState({ kind: "success" });
+    } catch (error) {
+      setState({
+        kind: "error",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Your message could not be sent right now. Please try again.",
+      });
+    }
+  }
+
+  const pending = state.kind === "submitting";
+
+  return (
+    <form
+      ref={formRef}
+      onSubmit={submit}
+      onFocusCapture={recordInteraction}
+      onPointerDownCapture={recordInteraction}
+      className="rounded-xl border border-sand bg-card p-5 shadow-[0_12px_32px_-24px_rgba(38,40,31,0.35)] sm:p-7"
+    >
+      <div className="grid gap-5 sm:grid-cols-2">
+        <label className="block text-sm font-medium text-ink" htmlFor="name">
+          Name
+          <input
+            className={`mt-1.5 ${inputClass}`}
+            id="name"
+            name="name"
+            type="text"
+            autoComplete="name"
+            minLength={2}
+            maxLength={100}
+            required
+          />
+        </label>
+        <label className="block text-sm font-medium text-ink" htmlFor="email">
+          Email
+          <input
+            className={`mt-1.5 ${inputClass}`}
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            maxLength={254}
+            required
+          />
+        </label>
+        <label className="block text-sm font-medium text-ink" htmlFor="company">
+          Company <span className="font-normal text-stone">(optional)</span>
+          <input
+            className={`mt-1.5 ${inputClass}`}
+            id="company"
+            name="company"
+            type="text"
+            autoComplete="organization"
+            maxLength={120}
+          />
+        </label>
+        <label className="block text-sm font-medium text-ink" htmlFor="phone">
+          Phone <span className="font-normal text-stone">(optional)</span>
+          <input
+            className={`mt-1.5 ${inputClass}`}
+            id="phone"
+            name="phone"
+            type="tel"
+            autoComplete="tel"
+            maxLength={40}
+          />
+        </label>
+      </div>
+
+      <label className="mt-5 block text-sm font-medium text-ink" htmlFor="message">
+        How can we help?
+        <textarea
+          className={`mt-1.5 min-h-40 resize-y ${inputClass}`}
+          id="message"
+          name="message"
+          minLength={10}
+          maxLength={5_000}
+          required
+        />
+      </label>
+
+      <div className="absolute left-[-10000px] top-auto h-px w-px overflow-hidden" aria-hidden="true">
+        <label htmlFor="website">Website</label>
+        <input id="website" name="website" type="text" tabIndex={-1} autoComplete="off" />
+      </div>
+
+      <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <button
+          type="submit"
+          className={buttonPrimary}
+          disabled={pending}
+        >
+          {pending ? "Sending…" : "Send message"}
+        </button>
+        <p
+          className={`text-sm ${state.kind === "error" ? "text-red-700 dark:text-red-300" : "text-sage-deep"}`}
+          role={state.kind === "error" ? "alert" : "status"}
+          aria-live="polite"
+        >
+          {state.kind === "success"
+            ? "Thanks. Your message has been sent to the DoodleNote team."
+            : state.kind === "error"
+              ? state.message
+              : "We normally reply by email."}
+        </p>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/app/contact/page.tsx
+++ b/apps/web/app/contact/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+
+import { SiteFooter, SiteHeader } from "../ui";
+import { ContactForm } from "./contact-form";
+
+export const metadata: Metadata = {
+  title: "Contact DoodleNote",
+  description: "Contact the DoodleNote team with a question or message.",
+};
+
+export default function ContactPage() {
+  return (
+    <div className="flex flex-1 flex-col bg-cream text-bark">
+      <SiteHeader />
+      <main className="flex flex-1 items-start px-6 pb-20 pt-12 sm:pt-20">
+        <section className="mx-auto grid w-full max-w-5xl gap-10 lg:grid-cols-[0.8fr_1.2fr] lg:gap-16">
+          <div className="max-w-md">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-sage-deep">
+              Contact us
+            </p>
+            <h1 className="mt-3 font-display text-4xl font-semibold tracking-tight text-ink sm:text-5xl">
+              Tell us what you need.
+            </h1>
+            <p className="mt-5 text-base leading-relaxed text-bark">
+              Questions about DoodleNote, Cloud Sync, privacy, or getting
+              started are welcome. Send us the details and we will reply by
+              email.
+            </p>
+            <div className="mt-8 border-l-2 border-sage pl-4 text-sm leading-relaxed text-stone">
+              Prefer email? Write directly to{" "}
+              <a
+                href="mailto:team@onyxdev.io"
+                className="font-medium text-sage-deep underline decoration-sage/50 underline-offset-2 hover:decoration-sage-deep"
+              >
+                team@onyxdev.io
+              </a>
+              .
+            </div>
+          </div>
+          <ContactForm />
+        </section>
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -30,6 +30,10 @@ export default function PrivacyPage() {
             provider.
           </li>
           <li>
+            Contact-form details such as your name, email address, optional
+            company and phone number, and the message you send us.
+          </li>
+          <li>
             Workspace membership, invitations, linked devices, and security
             tokens.
           </li>
@@ -64,11 +68,12 @@ export default function PrivacyPage() {
       <LegalSection title="Optional providers">
         <p>
           Hosted features may use Vercel for application and object hosting,
-          Neon for PostgreSQL, Stripe for billing, Resend for invitation email,
-          Twilio for optional voice features, and Microsoft or Google for
-          sign-in and calendar access. If you choose an external AI provider,
-          the content you submit is sent to that provider under its terms. Local
-          AI and Ollama do not require DoodleNote to receive that content.
+          Neon for PostgreSQL, Stripe for billing, Resend for account,
+          invitation, billing, and contact-form email, Twilio for optional voice
+          features, and Microsoft or Google for sign-in and calendar access. If
+          you choose an external AI provider, the content you submit is sent to
+          that provider under its terms. Local AI and Ollama do not require
+          DoodleNote to receive that content.
         </p>
       </LegalSection>
 

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const origin = "https://www.doodlenote.ai";
-  return ["", "/pricing", "/changelog", "/privacy", "/terms"].map((path) => ({
+  return ["", "/pricing", "/changelog", "/contact", "/privacy", "/terms"].map((path) => ({
     url: `${origin}${path}`,
     changeFrequency: path === "" ? "weekly" : "monthly",
     priority: path === "" ? 1 : 0.6,

--- a/apps/web/app/ui.tsx
+++ b/apps/web/app/ui.tsx
@@ -165,27 +165,30 @@ export function SiteHeader({ nav }: { nav?: React.ReactNode }) {
 export function SiteFooter() {
   return (
     <footer className="border-t border-sand">
-      <div className="mx-auto flex w-full max-w-3xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-stone sm:flex-row">
+      <div className="mx-auto flex w-full max-w-7xl flex-col items-center justify-between gap-5 px-6 py-6 text-sm text-stone lg:grid lg:grid-cols-[auto_minmax(0,1fr)_auto] lg:gap-8">
         <BrandLockup compact />
-        <nav className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
-          <Link href="/pricing" className="hover:text-ink">
+        <nav className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 lg:flex-nowrap">
+          <Link href="/pricing" className="whitespace-nowrap hover:text-ink">
             Pricing
           </Link>
-          <Link href="/changelog" className="hover:text-ink">
+          <Link href="/changelog" className="whitespace-nowrap hover:text-ink">
             What&rsquo;s new
           </Link>
-          <Link href="/privacy" className="hover:text-ink">
+          <Link href="/contact" className="whitespace-nowrap hover:text-ink">
+            Contact
+          </Link>
+          <Link href="/privacy" className="whitespace-nowrap hover:text-ink">
             Privacy
           </Link>
-          <Link href="/terms" className="hover:text-ink">
+          <Link href="/terms" className="whitespace-nowrap hover:text-ink">
             Terms
           </Link>
           <GitHubNavLink className="rounded-md px-1.5 py-1.5 text-bark transition-colors hover:bg-sage-fill hover:text-ink" />
-          <Link href="/login" className="hover:text-ink">
+          <Link href="/login" className="whitespace-nowrap hover:text-ink">
             Sign in
           </Link>
         </nav>
-        <span>Local-first. Cloud only when you opt in.</span>
+        <span className="whitespace-nowrap text-center lg:text-right">Local-first. Cloud only when you opt in.</span>
       </div>
     </footer>
   );

--- a/apps/web/tests/contact-form.test.ts
+++ b/apps/web/tests/contact-form.test.ts
@@ -153,6 +153,7 @@ describe("DoodleNote contact form", () => {
     assert.match(email.text, /Question <b>with markup<\/b>/);
     assert.match(email.html, /Ada &lt;script&gt;alert\(1\)&lt;\/script&gt;/);
     assert.match(email.html, /Question &lt;b&gt;with markup&lt;\/b&gt;/);
-    assert.doesNotMatch(email.html, /<script>|<b>with markup<\/b>/);
+    assert.ok(!email.html.toLowerCase().includes("<script"));
+    assert.ok(!email.html.includes("<b>with markup</b>"));
   });
 });

--- a/apps/web/tests/contact-form.test.ts
+++ b/apps/web/tests/contact-form.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildContactEmail,
+  createContactPostHandler,
+  type ContactSubmission,
+} from "../app/api/contact/route";
+
+const NOW = Date.parse("2026-08-31T18:00:00.000Z");
+
+function validSubmission(
+  overrides: Partial<Record<keyof ContactSubmission | "website" | "startedAt", unknown>> = {},
+) {
+  return {
+    name: "  Ada Lovelace  ",
+    email: " ADA@example.com ",
+    company: " Analytical Engines ",
+    phone: " +1 817 555 0100 ",
+    message: "  I have a question about DoodleNote Cloud Sync.  ",
+    website: "",
+    startedAt: NOW - 5_000,
+    ...overrides,
+  };
+}
+
+function request(
+  body: unknown,
+  headers: Record<string, string> = {},
+): Request {
+  return new Request("https://www.doodlenote.ai/api/contact", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin: "https://www.doodlenote.ai",
+      "x-forwarded-for": "203.0.113.42",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("DoodleNote contact form", () => {
+  it("normalizes and sends a valid same-origin submission", async () => {
+    const sent: ContactSubmission[] = [];
+    const post = createContactPostHandler({
+      now: () => NOW,
+      allowRequest: () => true,
+      sendEmail: async (submission) => {
+        sent.push(submission);
+      },
+    });
+
+    const response = await post(request(validSubmission()));
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true });
+    assert.deepEqual(sent, [
+      {
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        company: "Analytical Engines",
+        phone: "+1 817 555 0100",
+        message: "I have a question about DoodleNote Cloud Sync.",
+      },
+    ]);
+  });
+
+  it("rejects cross-origin and invalid submissions without sending", async () => {
+    let sends = 0;
+    const post = createContactPostHandler({
+      now: () => NOW,
+      allowRequest: () => true,
+      sendEmail: async () => {
+        sends += 1;
+      },
+    });
+
+    const wrongOrigin = await post(
+      request(validSubmission(), { origin: "https://example.com" }),
+    );
+    const invalid = await post(
+      request(validSubmission({ email: "not-an-email", message: "short" })),
+    );
+
+    assert.equal(wrongOrigin.status, 403);
+    assert.equal(invalid.status, 400);
+    assert.equal(sends, 0);
+  });
+
+  it("quietly acknowledges the honeypot without sending", async () => {
+    let sends = 0;
+    const post = createContactPostHandler({
+      now: () => NOW,
+      allowRequest: () => true,
+      sendEmail: async () => {
+        sends += 1;
+      },
+    });
+
+    const response = await post(
+      request(validSubmission({ website: "https://spam.example" })),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true });
+    assert.equal(sends, 0);
+  });
+
+  it("rejects automated instant submissions and exhausted rate limits", async () => {
+    let sends = 0;
+    const tooFast = createContactPostHandler({
+      now: () => NOW,
+      allowRequest: () => true,
+      sendEmail: async () => {
+        sends += 1;
+      },
+    });
+    const rateLimited = createContactPostHandler({
+      now: () => NOW,
+      allowRequest: () => false,
+      sendEmail: async () => {
+        sends += 1;
+      },
+    });
+
+    const fastResponse = await tooFast(
+      request(validSubmission({ startedAt: NOW - 250 })),
+    );
+    const limitedResponse = await rateLimited(request(validSubmission()));
+
+    assert.equal(fastResponse.status, 400);
+    assert.equal(limitedResponse.status, 429);
+    assert.equal(sends, 0);
+  });
+
+  it("builds a replyable, escaped email only for the Onyx team inbox", () => {
+    const email = buildContactEmail(
+      {
+        name: "Ada <script>alert(1)</script>",
+        email: "ada@example.com",
+        company: "Example & Co.",
+        phone: "",
+        message: "Question <b>with markup</b>",
+      },
+      "DoodleNote <no-reply@doodlenote.ai>",
+    );
+
+    assert.deepEqual(email.to, ["team@onyxdev.io"]);
+    assert.equal(email.reply_to, "ada@example.com");
+    assert.equal(email.from, "DoodleNote <no-reply@doodlenote.ai>");
+    assert.match(email.subject, /^DoodleNote contact from Ada/);
+    assert.match(email.text, /Question <b>with markup<\/b>/);
+    assert.match(email.html, /Ada &lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+    assert.match(email.html, /Question &lt;b&gt;with markup&lt;\/b&gt;/);
+    assert.doesNotMatch(email.html, /<script>|<b>with markup<\/b>/);
+  });
+});

--- a/apps/web/tests/legal-pages.test.ts
+++ b/apps/web/tests/legal-pages.test.ts
@@ -12,8 +12,11 @@ function source(path: string): string {
 
 test("public footer links to privacy and terms without overstating local-only behavior", () => {
   const ui = source("ui.tsx");
+  assert.match(ui, /href="\/contact"/);
   assert.match(ui, /href="\/privacy"/);
   assert.match(ui, /href="\/terms"/);
+  assert.match(ui, /lg:flex-nowrap/);
+  assert.match(ui, /Local-first\. Cloud only when you opt in\.<\/span>/);
   assert.match(ui, /Cloud only when you opt in/);
   assert.doesNotMatch(ui, /Your meetings never leave your device/);
 });
@@ -22,6 +25,8 @@ test("privacy policy documents local, synced, shared, and deletion behavior", ()
   const privacy = source("privacy/page.tsx");
   assert.match(privacy, /does\s+not\s+upload meeting audio as part of Sync/);
   assert.match(privacy, /meeting titles, notes, transcripts/);
+  assert.match(privacy, /Contact-form details/);
+  assert.match(privacy, /contact-form email/);
   assert.match(privacy, /public\s+share\s+link/);
   assert.match(privacy, /request\s+account or other hosted-data/);
   assert.match(privacy, /permanently deletes the active cloud copy/);


### PR DESCRIPTION
## Summary

- add a branded public Contact page with name, email, optional company and phone, and message fields
- send submissions server-side through the existing Resend account to `team@onyxdev.io`, with the visitor address set as Reply-To
- add validation, same-origin enforcement, a honeypot, submission timing checks, request limits, best-effort rate limiting, safe HTML escaping, and idempotent Resend requests
- widen and restructure the desktop footer so navigation labels and Sign in stay on one line
- add Contact to the footer and sitemap
- update the privacy policy and environment documentation for contact-form data and Resend delivery

## Verification

- `pnpm --filter web test` (91 passing)
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`
- visual review at 1440 px, 1024 px, and 390 px
- confirmed no horizontal overflow at the desktop and mobile widths tested
- confirmed Vercel Production already has `RESEND_API_KEY` and `AUTH_FROM_EMAIL` configured, without reading their values

## Risk and follow-up

- No real contact email was sent during development. Delivery remains unverified end to end until an explicitly approved test submission is made from the Preview or Production deployment.
- Rate limiting is best effort per application instance. The fixed recipient, same-origin enforcement, honeypot, timing check, and input limits provide additional abuse controls.
- This PR does not merge or deploy anything.
