### PR TITLE
Defer automatic npm major dependency upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
         update-types:
           - patch
           - minor
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

- stop routine Dependabot version-update PRs for npm major releases
- continue weekly grouped npm patch and minor updates
- preserve Dependabot security updates, including security updates that require a major version

## Verification

- parsed `.github/dependabot.yml` successfully with Ruby YAML
- asserted the npm configuration contains the wildcard `version-update:semver-major` ignore rule
- `git diff --check`

## Context

Dependabot opened five major-upgrade PRs that either mismatched the current runtime or failed CI, Windows packaging, or Vercel. Those PRs were closed separately. Planned major upgrades can still be implemented in focused engineering PRs.

This PR does not merge or deploy anything.
