### PR TITLE
chore: release DoodleNote v0.4.18

### DIFF
--- a/RELEASE-v0.4.18.md
+++ b/RELEASE-v0.4.18.md
@@ -1,0 +1,50 @@
+# DoodleNote v0.4.18 release candidate
+
+## Included
+
+- [x] Import MP4 video recordings through the existing Import audio flow
+- [x] Transcribe decodable MP4 audio locally on macOS and Windows
+- [x] Preserve local MP4 playback and seeking after restart
+- [x] Keep the existing Generate notes workflow for imported transcripts
+- [x] Fail clearly when an MP4 has no supported audio track
+- [x] Preserve WAV, MP3, M4A, and existing size-limit behavior
+- [x] Bump the desktop version from 0.4.17 to 0.4.18
+- [x] Add the v0.4.18 changelog entry
+
+## Verification
+
+- [x] Frozen-lockfile dependency install
+- [x] Swift transcription engine release build
+- [x] Workspace typecheck
+- [x] Full workspace test suite: 266 tests passed
+- [x] Workspace lint
+- [x] Production Electron, web, and MCP builds
+- [x] Production dependency audit: no known vulnerabilities
+- [ ] Packaged application reports version 0.4.18
+- [ ] Developer ID signature and hardened runtime validation
+- [ ] App notarization and stapled-ticket validation
+- [ ] Final DMG signature, notarization, stapling, and Gatekeeper validation
+- [ ] Updater ZIP and website DMG checksums recorded
+- [ ] Updater manifest references only version-matched v0.4.18 artifacts
+
+## Release gates
+
+- [x] User authorized Alec review bypass, source merge, packaging, and publication
+- [x] Feature PR #113 checks passed and the PR merged into main
+- [ ] Post-merge CI and CodeQL passed on the feature merge commit
+- [ ] Release PR has green required CI
+- [ ] Release PR merged into main using the authorized review bypass
+- [ ] Public update feed reports 0.4.18
+- [ ] Public ZIP checksum matches the release artifact
+- [ ] Public DMG checksum matches the release artifact
+- [ ] Installed 0.4.17 client detects the 0.4.18 update
+- [ ] Installed 0.4.18 app imports, transcribes, plays, and generates notes from an MP4
+
+## Package
+
+- Updater artifact: `DoodleNote-0.4.18-arm64-mac.zip`
+- Website installer: `DoodleNote-0.4.18-arm64.dmg`
+- Updater ZIP SHA-256: pending
+- Website DMG SHA-256: pending
+- App notarization submission: pending
+- DMG notarization submission: pending

--- a/RELEASE-v0.4.18.md
+++ b/RELEASE-v0.4.18.md
@@ -20,18 +20,20 @@
 - [x] Workspace lint
 - [x] Production Electron, web, and MCP builds
 - [x] Production dependency audit: no known vulnerabilities
-- [ ] Packaged application reports version 0.4.18
-- [ ] Developer ID signature and hardened runtime validation
-- [ ] App notarization and stapled-ticket validation
-- [ ] Final DMG signature, notarization, stapling, and Gatekeeper validation
-- [ ] Updater ZIP and website DMG checksums recorded
-- [ ] Updater manifest references only version-matched v0.4.18 artifacts
+- [x] Packaged application reports version 0.4.18
+- [x] Developer ID signature and hardened runtime validation
+- [x] App notarization and stapled-ticket validation
+- [x] Final DMG signature, notarization, stapling, and Gatekeeper validation
+- [x] Mounted DMG contains the executable Swift engine and MP4 import code
+- [x] Updater ZIP and website DMG checksums recorded
+- [x] Updater manifest references only version-matched v0.4.18 artifacts
+- [x] Downloaded public Blob artifacts match the local SHA-256 checksums
 
 ## Release gates
 
 - [x] User authorized Alec review bypass, source merge, packaging, and publication
 - [x] Feature PR #113 checks passed and the PR merged into main
-- [ ] Post-merge CI and CodeQL passed on the feature merge commit
+- [x] Post-merge CI, CodeQL, and Windows packaging passed on the feature merge commit
 - [ ] Release PR has green required CI
 - [ ] Release PR merged into main using the authorized review bypass
 - [ ] Public update feed reports 0.4.18
@@ -44,7 +46,7 @@
 
 - Updater artifact: `DoodleNote-0.4.18-arm64-mac.zip`
 - Website installer: `DoodleNote-0.4.18-arm64.dmg`
-- Updater ZIP SHA-256: pending
-- Website DMG SHA-256: pending
-- App notarization submission: pending
-- DMG notarization submission: pending
+- Updater ZIP SHA-256: `45605766fe07cc9ba5b4d0c366897412db1dee35dccd57bef5ed8df046e30eaf`
+- Website DMG SHA-256: `debf8baf3dd82c835ecaae57f1148b663871a4c23615084cd2291358dd0754c4`
+- App notarization submission: `9cc5e972-dca8-47fc-81ca-ce175918b599` (Accepted)
+- DMG notarization submission: `563e3e92-7953-4014-9614-2460af58c713` (Accepted)

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "private": true,
   "description": "DoodleNote desktop app for privacy-first local capture, transcription, and AI meeting notes",
   "main": "./out/main/index.js",

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,15 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.18",
+    date: "September 1, 2026",
+    highlights: [
+      "Import MP4 video recordings and transcribe their audio into a meeting",
+      "Play and seek imported MP4 recordings after restarting DoodleNote",
+      "Show a clear error when an MP4 has no supported audio track",
+    ],
+  },
+  {
     version: "0.4.17",
     date: "August 30, 2026",
     highlights: [

--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,11 +1,11 @@
-version: 0.4.17
+version: 0.4.18
 files:
-  - url: DoodleNote-0.4.17-arm64-mac.zip
-    sha512: ztoix3BatTcS37mWntEnfN4JG+swy+aCNhlr5x7rV5xXyrRi6226k3wTSBAUpLNVmbN/GzXqojVHImWf+gHqHQ==
-    size: 185925884
-  - url: DoodleNote-0.4.17-arm64.dmg
-    sha512: 9WZhmt7CxwRrJqAjULk2yMaUmNgyp8p/4mLlnC9gUiDZH5fvCVYU2Q/D2FLsbn/pbMExDVPpUAoatHsHfiWDvQ==
-    size: 187873839
-path: DoodleNote-0.4.17-arm64-mac.zip
-sha512: ztoix3BatTcS37mWntEnfN4JG+swy+aCNhlr5x7rV5xXyrRi6226k3wTSBAUpLNVmbN/GzXqojVHImWf+gHqHQ==
-releaseDate: '2026-08-30T20:07:39.470Z'
+  - url: DoodleNote-0.4.18-arm64-mac.zip
+    sha512: HkOWwPnejqNQgLhxe20QhiB39aY98B+ri3IEj+pEIoKiH+RNTYx2GVtjwGpX18FXbJFoSGrTcmubLm7xDk2tJA==
+    size: 185935094
+  - url: DoodleNote-0.4.18-arm64.dmg
+    sha512: lZWibWgGBeSgxq2uozNk2w0fwS8WqFRSPR+hFZ6OQEeiPcmJXN6nf8bfk1drxQ2YflU2fQVSbXMCAOdh+vDKJg==
+    size: 187883550
+path: DoodleNote-0.4.18-arm64-mac.zip
+sha512: HkOWwPnejqNQgLhxe20QhiB39aY98B+ri3IEj+pEIoKiH+RNTYx2GVtjwGpX18FXbJFoSGrTcmubLm7xDk2tJA==
+releaseDate: '2026-09-01T16:08:55.093Z'


### PR DESCRIPTION
## Release Candidate v0.4.18

### Included

- [x] Feature: Import MP4 video recordings and transcribe their audio locally
- [x] Feature: Preserve local MP4 playback and seeking after restart
- [x] Feature: Keep the existing Generate notes action for imported transcripts
- [x] Safety: Fail clearly when an MP4 has no supported audio track
- [x] Compatibility: Preserve WAV, MP3, M4A, and existing size limits
- [x] Release: Add the v0.4.18 changelog and release checklist

Feature issue: https://linear.app/onyxdevlabs/issue/ONY-219/import-mp4-recordings-for-transcription-and-notes

Feature PR: https://github.com/Onyx-Dev-Labs/doodle-note/pull/113

### Version

- Bumped the desktop app from v0.4.17 to v0.4.18.

### Verification

- Frozen dependency install passed.
- Swift engine release build passed.
- 266 workspace tests passed, including real MP4 speech extraction and the no-audio failure case.
- Workspace typecheck and lint passed.
- Electron, web, and MCP production builds passed.
- Production dependency audit reported no known vulnerabilities.
- Feature PR CI, CodeQL, Vercel, and Windows x64 packaging passed before merge.

### Release plan

1. Confirm this PR's required checks pass.
2. Merge using Sean's explicit Alec review bypass authorization.
3. Build, sign, notarize, staple, and verify the macOS updater ZIP and DMG.
4. Publish the versioned artifacts and updater manifest.
5. Verify the public feed, downloaded hashes, production changelog, and installed-app update path.

### Risks and notes

- MP4 codec support is bounded by the packaged operating-system decoder.
- Video frames are not analyzed, uploaded, or synced.
- Windows publication is not included. The CI Windows x64 package remains the build gate for the Windows implementation.
- Publishing the updater is separate from merging this release metadata PR.
