### PR TITLE
[ONY-225] Restore meeting prompts when apps use a non-default microphone

### DIFF
--- a/apps/desktop/src/main/mic-watcher-logic.test.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.test.ts
@@ -155,6 +155,39 @@ describe('meeting-end watch', () => {
 })
 
 describe('meetingPromptLabel', () => {
+  for (const [bundle, label] of [
+    ['com.tinyspeck.slackmacgap.helper', 'Slack'],
+    ['us.zoom.xos', 'Zoom'],
+    ['com.microsoft.teams2', 'Teams']
+  ]) {
+    it(`recognizes ${label} input while the default microphone is idle`, () => {
+      assert.equal(
+        meetingPromptLabel({ inputRunning: false, inputBundles: [bundle], outputBundles: [] }),
+        label
+      )
+    })
+  }
+
+  it('requires recognized input attribution regardless of default-device activity', () => {
+    for (const inputRunning of [false, true]) {
+      for (const inputBundles of [[], ['com.electron.wispr-flow.helper'], ['unknown.app']]) {
+        assert.equal(
+          meetingPromptLabel({
+            inputRunning,
+            inputBundles,
+            outputBundles: [
+              'us.zoom.ZoomPhone',
+              'com.tinyspeck.slackmacgap.helper',
+              'com.hnc.Discord.helper',
+              'com.google.Chrome.helper'
+            ]
+          }),
+          null
+        )
+      }
+    }
+  })
+
   it('never promotes output-only audio into a recording prompt', () => {
     assert.equal(
       meetingPromptLabel({

--- a/apps/desktop/src/main/mic-watcher-logic.ts
+++ b/apps/desktop/src/main/mic-watcher-logic.ts
@@ -63,7 +63,9 @@ export function meetingAppLabel(bundles: readonly string[]): string | null {
 }
 
 export interface MeetingPromptSignals {
+  /** macOS default-device activity; may be false while another input is in use. */
   inputRunning: boolean
+  /** Processes actively capturing input, across all devices. */
   inputBundles: readonly string[]
   outputBundles: readonly string[]
 }
@@ -75,7 +77,8 @@ export interface MeetingPromptSignals {
  * clips, Discord streams, and ordinary playback must never prompt alone.
  */
 export function meetingPromptLabel(signals: MeetingPromptSignals): string | null {
-  if (!signals.inputRunning) return null
+  // Attribution already proves active input. The macOS running flag only
+  // describes the default device, which the meeting app may not be using.
   return meetingAppLabel(signals.inputBundles)
 }
 

--- a/apps/desktop/src/main/mic-watcher.test.ts
+++ b/apps/desktop/src/main/mic-watcher.test.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict'
+import childProcess, { type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
+import { test, type Mock, type TestContext } from 'node:test'
+import { MicWatcher } from './mic-watcher'
+import { MEETING_END_DEBOUNCE_MS, MIC_COOLDOWN_MS, MIC_DEBOUNCE_MS } from './mic-watcher-logic'
+
+// Keep the real NDJSON parsing, state transitions, timers, and callbacks.
+// Only the native process and clock are replaced; no microphone is opened.
+function harness(t: TestContext): {
+  watcher: MicWatcher
+  prompts: Array<string | null>
+  ended: Mock<() => void>
+  emit: (bundles: string[], running?: boolean, outputBundles?: string[]) => void
+  tick: (ms: number) => void
+} {
+  const dir = mkdtempSync(join(tmpdir(), 'doodlenote-micwatch-'))
+  const child = Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    killed: false,
+    kill: () => true
+  })
+  t.mock.method(childProcess, 'spawn', () => child as unknown as ChildProcessWithoutNullStreams)
+  t.mock.timers.enable({ apis: ['Date', 'setTimeout'], now: 1_000_000 })
+  const prompts: Array<string | null> = []
+  const ended = t.mock.fn()
+  const watcher = new MicWatcher('unused-engine', dir, (label) => prompts.push(label), ended)
+  t.after(() => {
+    watcher.stop()
+    t.mock.timers.reset()
+    child.stdin.destroy()
+    child.stdout.destroy()
+    child.stderr.destroy()
+    rmSync(dir, { recursive: true, force: true })
+  })
+  watcher.start()
+  return {
+    watcher,
+    prompts,
+    ended,
+    emit(bundles: string[], running = false, outputBundles: string[] = []) {
+      child.stdout.emit(
+        'data',
+        JSON.stringify({ event: 'micmon', running, bundles, outputBundles }) + '\n'
+      )
+    },
+    tick: (ms: number) => t.mock.timers.tick(ms)
+  }
+}
+
+for (const [bundle, label] of [
+  ['com.tinyspeck.slackmacgap.helper', 'Slack'],
+  ['us.zoom.xos', 'Zoom'],
+  ['com.microsoft.teams2', 'Teams']
+]) {
+  test(`${label} on a non-default input delivers one debounced prompt`, (t) => {
+    const h = harness(t)
+    h.emit([bundle])
+    h.tick(MIC_DEBOUNCE_MS - 1)
+    assert.deepEqual(h.prompts, [])
+    h.tick(1)
+    assert.deepEqual(h.prompts, [label])
+    h.tick(MIC_COOLDOWN_MS)
+    h.emit([bundle], true) // Default-device activity changes, same meeting input.
+    h.tick(MIC_DEBOUNCE_MS)
+    assert.deepEqual(h.prompts, [label])
+    h.emit([])
+    h.tick(1_000)
+    h.emit([bundle]) // A brief reconnect still belongs to the same meeting.
+    h.tick(MIC_DEBOUNCE_MS)
+    assert.deepEqual(h.prompts, [label])
+  })
+}
+
+test('non-default input obeys disabled detection, recording suppression, and cooldown', (t) => {
+  const h = harness(t)
+  const bundles = ['us.zoom.xos']
+  h.watcher.setEnabled(false)
+  h.emit(bundles)
+  h.tick(MIC_DEBOUNCE_MS)
+  assert.deepEqual(h.prompts, [])
+  h.emit([])
+  h.watcher.setEnabled(true)
+  h.watcher.setSuppressed(true)
+  h.emit(bundles)
+  h.tick(MIC_DEBOUNCE_MS)
+  assert.deepEqual(h.prompts, [])
+  h.emit([])
+  h.watcher.setSuppressed(false)
+  h.emit(bundles)
+  h.tick(MIC_DEBOUNCE_MS)
+  assert.deepEqual(h.prompts, ['Zoom'])
+  h.emit([])
+  h.tick(121_000) // A separate meeting, but still within the five-minute cooldown.
+  h.emit(bundles)
+  h.tick(MIC_DEBOUNCE_MS)
+  assert.deepEqual(h.prompts, ['Zoom'])
+})
+
+test('active non-default input keeps recording alive and releasing it auto-stops once', (t) => {
+  const h = harness(t)
+  const bundles = ['us.zoom.xos']
+  h.emit(bundles, true)
+  h.watcher.setSuppressed(true)
+  h.emit(bundles, false) // Default input becomes idle, meeting input stays active.
+  h.tick(MEETING_END_DEBOUNCE_MS)
+  assert.equal(h.ended.mock.callCount(), 0)
+  h.emit([], false, bundles) // Meeting output can linger after input is released.
+  h.tick(MEETING_END_DEBOUNCE_MS - 1)
+  assert.equal(h.ended.mock.callCount(), 0)
+  h.tick(1)
+  assert.equal(h.ended.mock.callCount(), 1)
+  h.emit([])
+  h.tick(MEETING_END_DEBOUNCE_MS)
+  assert.equal(h.ended.mock.callCount(), 1)
+  assert.deepEqual(h.prompts, [])
+})
+
+test('non-default input seeds auto-stop when capture starts after the meeting', (t) => {
+  const h = harness(t)
+  const bundles = ['com.tinyspeck.slackmacgap.helper']
+  h.emit(bundles)
+  h.watcher.setSuppressed(true)
+  h.emit([])
+  h.tick(MEETING_END_DEBOUNCE_MS)
+  assert.equal(h.ended.mock.callCount(), 1)
+})
+
+test('output-only and dictation activity never reach the prompt callback', (t) => {
+  const h = harness(t)
+  const output = [
+    'us.zoom.ZoomPhone',
+    'com.tinyspeck.slackmacgap.helper',
+    'com.google.Chrome.helper'
+  ]
+  h.emit([], false, output)
+  h.tick(MIC_DEBOUNCE_MS)
+  h.emit(['com.electron.wispr-flow.helper'], true, output)
+  h.tick(MIC_DEBOUNCE_MS)
+  assert.deepEqual(h.prompts, [])
+})
+
+test('Windows-style active ConsentStore input still prompts and idle input does not', (t) => {
+  const h = harness(t)
+  h.emit([], false)
+  h.tick(MIC_DEBOUNCE_MS)
+  assert.deepEqual(h.prompts, [])
+  h.emit(['msteams_8wekyb3d8bbwe'], true)
+  h.tick(MIC_DEBOUNCE_MS)
+  assert.deepEqual(h.prompts, ['Teams'])
+})


### PR DESCRIPTION
## Linear Issue

Refs [ONY-225](https://linear.app/onyxdevlabs/issue/ONY-225/restore-meeting-prompts-when-apps-use-a-non-default-microphone). Keep the issue open through installed-client verification.

## Outcome

Slack, Zoom, and Teams microphone capture can now trigger a recording prompt when the macOS default microphone is idle. Meeting-app input on another device also keeps an active recording from being incorrectly auto-stopped.

## What Changed

Removed the default-device activity gate from `meetingPromptLabel`. Recognized active per-process input remains required; output-only activity stays ignored. Added unit cases and a watcher harness that feeds native-format NDJSON through the real parser, timers, state transitions, prompt callback, and auto-stop callback. Only the spawned process and clock are mocked.

## Bug Evidence / Root Cause

The native monitor's `running` flag describes the system default input, while its input bundle list covers actively capturing processes across devices. Combining those signals as an AND condition discarded valid meeting input. Nine new regression cases failed before the fix, including missed prompts and premature/missing auto-stop callbacks. All pass after the fix. No private recordings, logs, or meeting content are fixtures.

## Acceptance Criteria Evidence

- [x] Slack/Zoom/Teams with idle default input produce one callback after four seconds; repeat events and brief reconnects do not duplicate it.
- [x] Existing matching-default recognition, cooldown, disabled detection, and recording suppression pass.
- [x] Output-only, dictation, unknown input, and absent attribution remain ineligible.
- [x] Default-input idle transitions do not terminate an ongoing meeting capture; input release auto-stops once after 12 seconds, including when the meeting predates recording.
- [x] Windows-style ConsentStore payloads pass through the watcher; existing calendar/prompt-coordinator tests pass.
- [ ] Real Slack/Zoom/Teams calls with different default and app-selected microphones require human QA.
- [ ] Focused/background visible prompt delivery and real hardware reconnects require human QA.
- [x] Windows CI tests, typechecks, installer packaging, and packaged native-module smoke passed. Interactive Windows meeting QA remains a human check.
- [ ] Approved release, installed version, and visible prompt verification remain required before issue completion.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`: passed, no lockfile change.
- `pnpm --filter desktop exec tsx --test src/main/mic-watcher-logic.test.ts src/main/mic-watcher.test.ts`: 29 passed; before the fix, 9 failed and 20 passed.
- `pnpm --filter desktop test`: 154 passed, 5 existing engine/audio-import tests skipped, 0 failed.
- `pnpm --filter desktop typecheck`: passed.
- `pnpm --filter desktop lint`: passed.
- `pnpm --filter desktop exec prettier --check src/main/mic-watcher.test.ts src/main/mic-watcher-logic.test.ts src/main/mic-watcher-logic.ts`: passed.
- `pnpm --filter desktop build`: passed.
- `git diff --check`: passed.
- GitHub CI `checks`, Windows installer packaging/native-module smoke, CodeQL, and Vercel preview: passed on commit `11ec9a54173974f65af4d7bf3f4e1b82d0682ae8`.
- Native Swift source was unchanged; no new engine build or installed-app modification was performed.

## Local QA

Use an exclusive checkout of `codex/ONY-225-non-default-mic-prompts`, Node 22+, pnpm 10.33.2, and macOS with CoreAudio process attribution (14.4+). Install runtime dependencies and build the engine before the first launch:

```sh
pnpm install --frozen-lockfile
pnpm engine:build
DOODLE_USER_DATA=/tmp/doodlenote-ony225-qa pnpm --filter desktop dev
```

Use an isolated QA profile and avoid concurrently running the installed app during human QA so duplicate application instances do not confuse prompt results. Do not change or delete the normal profile.

Check this:

1. Set macOS default input to device A and the meeting app to device B, leaving A idle. Join a Slack huddle, Zoom, and Teams call in separate trials; expect one recording prompt after sustained capture for about four seconds. Allow the five-minute cooldown and more than two minutes of idle between trials, or restart the QA app.
2. Repeat once with DoodleNote focused and once in the background; expect the existing banner or floating/OS prompt, without stacked duplicates. Matching-default input should also prompt normally.
3. While recording a call, leave the default microphone idle and briefly reconnect the selected input; recording should continue and no duplicate prompt should appear. End the call; with auto-stop enabled, expect it to stop after about 12 seconds of absent meeting input.
4. Play meeting-app output without microphone capture, use dictation, and disable automatic detection; none should create a recording prompt.

## Risks and Release Notes

The same label drives prompts and auto-stop; both are regression-tested. The protection from PR #47 against output-only false prompts remains intact. No schema, permissions, network behavior, dependency, or version changes. Rollback is a source revert followed by an explicitly approved replacement release.

Merge and release are not authorized. Approval, real-device QA, signing/notarization, updater publication, and installed-client validation remain separate gates.

## Follow-ups

No additional issue or unrelated implementation work is proposed. The historical onset and exact earlier meeting-device selection remain unknown.
