### PR TITLE
Add a transcription-language setting (English / Multilingual)

### DIFF
--- a/apps/desktop/src/main/import-logic.test.ts
+++ b/apps/desktop/src/main/import-logic.test.ts
@@ -4,7 +4,33 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { test } from 'node:test'
-import { transcribeFileToSegments } from './import-logic'
+import { batchTranscribeArgs, transcribeFileToSegments } from './import-logic'
+
+test('batchTranscribeArgs: only multilingual (v3) overrides the engine default', () => {
+  assert.deepEqual(batchTranscribeArgs('/m.wav'), [
+    'transcribe',
+    '--file',
+    '/m.wav',
+    '--channels',
+    'split'
+  ])
+  assert.deepEqual(batchTranscribeArgs('/m.wav', 'v2'), [
+    'transcribe',
+    '--file',
+    '/m.wav',
+    '--channels',
+    'split'
+  ])
+  assert.deepEqual(batchTranscribeArgs('/m.wav', 'v3'), [
+    'transcribe',
+    '--file',
+    '/m.wav',
+    '--channels',
+    'split',
+    '--model',
+    'v3'
+  ])
+})
 
 /**
  * Integration test against the REAL engine binary and real speech (macOS

--- a/apps/desktop/src/main/import-logic.ts
+++ b/apps/desktop/src/main/import-logic.ts
@@ -30,15 +30,25 @@ export interface BatchProgress {
  *  on first use can take a while on slow connections. */
 const TIMEOUT_MS = 30 * 60_000
 
+/** v2 is the engine's default English model; v3 recognizes 25 European languages. */
+export type BatchAsrModel = 'v2' | 'v3'
+
+export function batchTranscribeArgs(filePath: string, model?: BatchAsrModel): string[] {
+  const args = ['transcribe', '--file', filePath, '--channels', 'split']
+  if (model === 'v3') args.push('--model', 'v3')
+  return args
+}
+
 export function transcribeFileToSegments(
   enginePath: string,
   filePath: string,
-  onProgress?: (progress: BatchProgress) => void
+  onProgress?: (progress: BatchProgress) => void,
+  model?: BatchAsrModel
 ): Promise<BatchTranscription> {
   return new Promise((resolve, reject) => {
     let child: ReturnType<typeof spawn>
     try {
-      child = spawn(enginePath, ['transcribe', '--file', filePath, '--channels', 'split'], {
+      child = spawn(enginePath, batchTranscribeArgs(filePath, model), {
         stdio: ['ignore', 'pipe', 'pipe']
       })
     } catch (err) {

--- a/apps/desktop/src/main/import-service.ts
+++ b/apps/desktop/src/main/import-service.ts
@@ -16,6 +16,7 @@ import { AudioService } from './audio-service'
 import { IMPORTABLE_EXTENSIONS } from './import-media'
 import {
   transcribeFileToSegments,
+  type BatchAsrModel,
   type BatchProgress,
   type BatchTranscription
 } from './import-logic'
@@ -42,7 +43,9 @@ export class ImportService {
     private readonly platformTranscriber?: (
       filePath: string,
       onProgress?: (progress: BatchProgress) => void
-    ) => Promise<BatchTranscription>
+    ) => Promise<BatchTranscription>,
+    /** Engine model to batch-transcribe with; absent = engine default (v2). */
+    private readonly asrModel?: () => BatchAsrModel
   ) {}
 
   registerIpc(): void {
@@ -188,6 +191,6 @@ export class ImportService {
   ): Promise<BatchTranscription> {
     return this.platformTranscriber
       ? this.platformTranscriber(filePath, onProgress)
-      : transcribeFileToSegments(this.enginePath, filePath, onProgress)
+      : transcribeFileToSegments(this.enginePath, filePath, onProgress, this.asrModel?.())
   }
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -405,7 +405,8 @@ app.whenReady().then(() => {
     broadcast,
     winBatchTranscriber
       ? (filePath, onProgress) => winBatchTranscriber!.transcribe(filePath, onProgress)
-      : undefined
+      : undefined,
+    () => notesService?.batchAsrModel() ?? 'v2'
   )
   importService.registerIpc()
 

--- a/apps/desktop/src/main/notes-service.ts
+++ b/apps/desktop/src/main/notes-service.ts
@@ -39,7 +39,8 @@ import {
   type GlobalChatEntry,
   type NotesModelsResponse,
   type NotesSettingsUpdate,
-  type NotesSettingsView
+  type NotesSettingsView,
+  type TranscriptionLanguage
 } from '../shared/notes-api'
 import type { MeetingRecord } from '../shared/meetings-api'
 import { isStoredCloudProvider } from '../shared/meeting-recovery'
@@ -73,6 +74,8 @@ interface StoredCloudSettings {
 interface StoredSettings {
   engineChoice: 'local' | 'cloud'
   activeLocalModelId?: string
+  /** Absent means 'english', the pre-existing behavior. */
+  transcriptionLanguage?: TranscriptionLanguage
   /** The user's own name, shown instead of "You" on their transcript lines. */
   profileName?: string
   cloud?: StoredCloudSettings
@@ -470,10 +473,16 @@ export class NotesService {
 
   /* ---- settings ---- */
 
+  /** Engine model for batch transcription (import + re-transcribe). */
+  batchAsrModel(): 'v2' | 'v3' {
+    return this.settings.transcriptionLanguage === 'multilingual' ? 'v3' : 'v2'
+  }
+
   private settingsView(): NotesSettingsView {
     const { engineChoice, activeLocalModelId, profileName, cloud } = this.settings
     return {
       engineChoice,
+      transcriptionLanguage: this.settings.transcriptionLanguage ?? 'english',
       ...(activeLocalModelId ? { activeLocalModelId } : {}),
       ...(profileName ? { profileName } : {}),
       ...(cloud
@@ -494,6 +503,13 @@ export class NotesService {
 
     if (update.engineChoice === 'local' || update.engineChoice === 'cloud') {
       this.settings.engineChoice = update.engineChoice
+    }
+
+    if (
+      update.transcriptionLanguage === 'english' ||
+      update.transcriptionLanguage === 'multilingual'
+    ) {
+      this.settings.transcriptionLanguage = update.transcriptionLanguage
     }
 
     if (typeof update.profileName === 'string') {
@@ -565,6 +581,9 @@ export class NotesService {
       if (typeof raw.profileName === 'string') {
         const name = sanitizeSpeakerName(raw.profileName)
         if (name) settings.profileName = name
+      }
+      if (raw.transcriptionLanguage === 'multilingual') {
+        settings.transcriptionLanguage = 'multilingual'
       }
       const cloud = raw.cloud
       if (

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -17,7 +17,8 @@ import {
   type EngineChoice,
   type NotesModelInfo,
   type NotesModelsResponse,
-  type NotesSettingsView
+  type NotesSettingsView,
+  type TranscriptionLanguage
 } from '../../shared/notes-api'
 import mascotUrl from './assets/mascot-square.png'
 
@@ -548,6 +549,11 @@ export default function ModelsView({
     setSettings(view)
   }
 
+  const chooseTranscriptionLanguage = async (language: TranscriptionLanguage): Promise<void> => {
+    const view = await window.notes.setSettings({ transcriptionLanguage: language })
+    setSettings(view)
+  }
+
   const saveCloudKey = async (): Promise<void> => {
     setError(null)
     const view = await window.notes.setSettings({
@@ -947,6 +953,38 @@ export default function ModelsView({
                   <button type="button" className="pill-btn" onClick={() => void saveProfileName()}>
                     {profileSaved ? 'Saved' : 'Save'}
                   </button>
+                </div>
+              </section>
+
+              <section className="keys-section">
+                <h3>Transcription language</h3>
+                <p className="models-sub">
+                  Applies to imported recordings and &ldquo;Re-transcribe&rdquo;. Multilingual
+                  recognizes 25 European languages (Danish, German, French, Spanish, …). Live
+                  captions during a meeting stay English either way — re-transcribe afterwards for
+                  the full-quality transcript.
+                </p>
+                <div className="theme-seg" role="radiogroup" aria-label="Transcription language">
+                  {(
+                    [
+                      ['english', 'English (fastest)'],
+                      ['multilingual', 'Multilingual']
+                    ] as const
+                  ).map(([value, label]) => {
+                    const active = (settings?.transcriptionLanguage ?? 'english') === value
+                    return (
+                      <button
+                        key={value}
+                        type="button"
+                        role="radio"
+                        aria-checked={active}
+                        className={active ? 'theme-seg-btn on' : 'theme-seg-btn'}
+                        onClick={() => void chooseTranscriptionLanguage(value)}
+                      >
+                        {label}
+                      </button>
+                    )
+                  })}
                 </div>
               </section>
 

--- a/apps/desktop/src/shared/notes-api.ts
+++ b/apps/desktop/src/shared/notes-api.ts
@@ -46,6 +46,14 @@ export const CLOUD_PROVIDERS: ReadonlyArray<{
 ]
 export type EngineChoice = 'local' | 'cloud'
 
+/**
+ * Batch-transcription language mode. 'english' runs the fastest English-only
+ * model; 'multilingual' recognizes 25 European languages (Danish, German,
+ * French, …). Applies to imported recordings and re-transcription; live
+ * captions always use the English streaming model.
+ */
+export type TranscriptionLanguage = 'english' | 'multilingual'
+
 /** One catalog model + its state on this machine. */
 export interface NotesModelInfo {
   id: string
@@ -76,6 +84,7 @@ export interface ActivateModelResult {
 export interface NotesSettingsView {
   engineChoice: EngineChoice
   activeLocalModelId?: string
+  transcriptionLanguage: TranscriptionLanguage
   /** The user's own name, used to label their transcript lines. */
   profileName?: string
   cloud?: {
@@ -90,6 +99,7 @@ export interface NotesSettingsView {
 /** Partial update; omitted fields are left untouched. */
 export interface NotesSettingsUpdate {
   engineChoice?: EngineChoice
+  transcriptionLanguage?: TranscriptionLanguage
   /** The user's own name; empty string clears it back to "You". */
   profileName?: string
   /**


### PR DESCRIPTION
# Add a transcription-language setting (English / Multilingual)

## The user problem and the change

DoodleNote currently batch-transcribes everything with the engine's default Parakeet v2 model, which is English-only. For anyone whose meetings aren't in English, imported recordings and "Re-transcribe" produce unusable text — a Danish test meeting came out as *"Mule, it de handler on voice new integration…"*.

The engine already ships multilingual support: `engine transcribe --model v3` runs Parakeet v3 (25 European languages). The desktop app just never passes the flag.

This PR adds **Settings → General → "Transcription language"** with two options:

- **English (fastest)** — the engine default (v2), unchanged behavior, still the default setting.
- **Multilingual** — passes `--model v3` to batch transcription (audio imports and Re-transcribe).

Live captions during a meeting are unaffected either way — the streaming model (`parakeet-unified-en`) is English-only — and the setting copy says so, pointing users to Re-transcribe for the full-quality pass.

Verified A/B on a Danish speech sample (macOS `say -v Sara`, ~15 s):

| Model | Output |
|---|---|
| v2 (default) | "Mule, it de handler on voice new integration, spurse motel air…" |
| v3 (this setting) | "Mødet i dag handler om vores nye integration. Spørgsmålet er, om vi skal integrere vores nuværende af…" (2 minor errors) |

## Surfaces and data flows affected

- `apps/desktop/src/shared/notes-api.ts` — new `TranscriptionLanguage` type; `NotesSettingsView`/`NotesSettingsUpdate` carry it.
- `apps/desktop/src/main/notes-service.ts` — persists the choice in `settings.json` (absent = `english`, so existing installs are unaffected); exposes `batchAsrModel()`.
- `apps/desktop/src/main/import-logic.ts` — new pure `batchTranscribeArgs()` builds the engine invocation; `transcribeFileToSegments` takes an optional model.
- `apps/desktop/src/main/import-service.ts` / `index.ts` — wiring: the setting flows into both import and re-transcribe.
- `apps/desktop/src/renderer/src/ModelsView.tsx` — the Settings → General control (same segmented-radio pattern as Appearance).

No new network behavior. The v3 model downloads exactly like v2 does today (FluidAudio's HuggingFace fetch, ~440 MB, same cache directory); nothing else leaves the machine.

## Checks run

- `pnpm --filter desktop typecheck` — clean
- `pnpm --filter desktop test` — 148/148 pass (engine built, integration tests included)
- `pnpm --filter desktop lint` — clean
- `pnpm engine:build` — clean
- New unit test: `batchTranscribeArgs` only adds `--model v3` for multilingual

## Screenshots

[Attach: Settings → General showing the "Transcription language" section.]
<img width="1242" height="404" alt="image" src="https://github.com/user-attachments/assets/87728fc5-beab-4b89-a335-a50f4a4e43ff" />

## Privacy, migration, compatibility, release risks

- **Privacy:** unchanged — transcription stays on-device; the only new download is the v3 model through the existing FluidAudio path.
- **Migration:** none — the settings key is optional and defaults to today's behavior.
- **Windows:** the packaged Windows transcriber ignores the setting (it has its own speech engine); the control currently only affects the macOS engine path. Follow-up material.
- **Honest quality note:** Parakeet v3's accuracy on spontaneous (as opposed to read) speech varies by language — in our Danish tests it was excellent on clear speech and weak on mumbled casual speech. The setting exposes what the engine already ships; it doesn't promise Whisper-level robustness.

## Intentionally out of scope

- Per-meeting language choice at recording start (the batch model has no per-language forcing — FluidAudio's `language:` hint filters by script only, so a per-meeting picker would be UI without effect beyond this toggle).
- Multilingual live captions (needs a multilingual streaming model in FluidAudio).
- A note-generation language setting (notes prompts are English-first today).
