### PR TITLE
Show a menu-bar indicator while recording

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -20,6 +20,7 @@ import { ExportService } from './export-service'
 import { CalendarService } from './calendar-service'
 import { registerContextMenu } from './context-menu'
 import { EngineProcess } from './engine-process'
+import { RecordingIndicator } from './recording-indicator'
 import { WinEngineHost } from './engine-host-win'
 import { WinBatchTranscriber } from './win-batch-transcriber'
 import { FoldersService } from './folders-service'
@@ -335,17 +336,25 @@ app.whenReady().then(() => {
     }
   }
 
+  // Menu-bar "recording" pill: visible whenever a live capture runs, gone
+  // the moment it stops — crashes included, via the engine's exit event.
+  const recordingIndicator = new RecordingIndicator(focusMainWindow)
+
   engine.onEvent((event) => {
     broadcastEngineEvent(event)
     session.handle(event)
     if (event.event === 'audio') audioService.onAudioSaved(event)
+    if (event.event === 'exit' || event.event === 'spawn-error') recordingIndicator.stop()
     logEngineEvent(event)
   })
 
   ipcMain.on(ENGINE_START_CHANNEL, (_event, request: EngineStartRequest) => {
     // Our own capture holds the mic — the ad-hoc meeting detector must not
     // mistake it for a Zoom call. Suppress BEFORE the engine opens the mic.
-    if (request.command === 'live') calendarService?.setRecordingActive(true)
+    if (request.command === 'live') {
+      calendarService?.setRecordingActive(true)
+      recordingIndicator.start()
+    }
     micWatcher.setSuppressed(true)
     const opts = { ...request.opts }
     // Audio persistence: give the session a directory keyed by meeting; the
@@ -363,6 +372,7 @@ app.whenReady().then(() => {
     engine.stop()
     micWatcher.setSuppressed(false)
     calendarService?.setRecordingActive(false)
+    recordingIndicator.stop()
   })
 
   // Mic input picker: device list + (mid-session) switching. macOS engine

--- a/apps/desktop/src/main/recording-indicator-logic.test.ts
+++ b/apps/desktop/src/main/recording-indicator-logic.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { recordingElapsed, recordingTrayTitle } from './recording-indicator-logic'
+
+test('recordingElapsed formats seconds, minutes and hours', () => {
+  assert.equal(recordingElapsed(0), '0:00')
+  assert.equal(recordingElapsed(7_000), '0:07')
+  assert.equal(recordingElapsed(754_000), '12:34')
+  assert.equal(recordingElapsed(3_725_000), '1:02:05')
+})
+
+test('recordingElapsed never goes negative on clock skew', () => {
+  assert.equal(recordingElapsed(-5_000), '0:00')
+})
+
+test('recordingTrayTitle carries the always-red dot', () => {
+  assert.equal(recordingTrayTitle(61_000), '🔴 1:01')
+})

--- a/apps/desktop/src/main/recording-indicator-logic.ts
+++ b/apps/desktop/src/main/recording-indicator-logic.ts
@@ -1,0 +1,21 @@
+/**
+ * Pure formatting for the menu-bar recording indicator — kept Electron-free
+ * so it unit-tests under node like calendar-events.ts.
+ */
+
+/** Elapsed recording time as the menu bar shows it: "0:07", "12:34", "1:02:05". */
+export function recordingElapsed(elapsedMs: number): string {
+  const total = Math.max(0, Math.floor(elapsedMs / 1000))
+  const hours = Math.floor(total / 3600)
+  const minutes = Math.floor((total % 3600) / 60)
+  const seconds = total % 60
+  const mmss = `${minutes}:${String(seconds).padStart(2, '0')}`
+  return hours > 0
+    ? `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+    : mmss
+}
+
+/** The full tray title: a red dot that stays red in any menu-bar theme. */
+export function recordingTrayTitle(elapsedMs: number): string {
+  return `🔴 ${recordingElapsed(elapsedMs)}`
+}

--- a/apps/desktop/src/main/recording-indicator.ts
+++ b/apps/desktop/src/main/recording-indicator.ts
@@ -1,0 +1,62 @@
+import { Menu, Tray, nativeImage } from 'electron'
+import { recordingTrayTitle } from './recording-indicator-logic'
+
+/**
+ * A menu-bar item that exists only while a live capture runs: a red dot and
+ * the elapsed time, so "am I being recorded?" is answerable from any window
+ * — including none. Separate from the calendar Tray on purpose: that one
+ * needs a signed-in calendar, this one must always work.
+ *
+ * macOS only, like the calendar Tray; other platforms get a no-op.
+ */
+export class RecordingIndicator {
+  private tray: Tray | null = null
+  private startedAtMs = 0
+  private timer: ReturnType<typeof setInterval> | null = null
+
+  constructor(private readonly focusWindow: () => void) {}
+
+  start(): void {
+    if (process.platform !== 'darwin' || this.tray !== null) return
+    this.startedAtMs = Date.now()
+    try {
+      this.tray = new Tray(nativeImage.createEmpty())
+      this.tray.setToolTip('DoodleNote — recording')
+      this.tray.setContextMenu(
+        Menu.buildFromTemplate([
+          { label: 'Recording…', enabled: false },
+          { type: 'separator' },
+          { label: 'Open DoodleNote', click: () => this.focusWindow() }
+        ])
+      )
+      this.tick()
+      this.timer = setInterval(() => this.tick(), 1000)
+    } catch (err) {
+      // Tray support can be flaky (headless CI) — never let the menu bar
+      // break a recording.
+      console.error('[recording] tray failed:', err)
+      this.stop()
+    }
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    if (this.tray !== null) {
+      try {
+        this.tray.destroy()
+      } catch {
+        // Already gone.
+      }
+      this.tray = null
+    }
+  }
+
+  private tick(): void {
+    this.tray?.setTitle(recordingTrayTitle(Date.now() - this.startedAtMs), {
+      fontType: 'monospacedDigit'
+    })
+  }
+}


### PR DESCRIPTION
# Show a menu-bar indicator while recording

## The user problem and the change

While a meeting is being captured there is no always-visible answer to *"is DoodleNote actually recording right now?"*. The recording bars next to the timer are a CSS animation driven by recording state, not by captured audio, and they live inside the meeting window — hide the window and every signal is gone. When live captions stall (silence, or non-English speech the streaming model can't follow), it genuinely looks like nothing is being captured, even though it is. For a privacy-first recorder that's the wrong place to be vague, in both directions: users should always be able to see that a capture is running — and be reassured that it is.

This PR adds a macOS **menu-bar item that exists only during live capture**: a red dot plus the elapsed time (🔴 12:34, monospaced digits, ticking every second), with "Open DoodleNote" in its context menu. It appears the moment a live session starts and disappears on stop — including engine exit and spawn errors, so a crashed capture never leaves a stale indicator.

It is deliberately separate from the calendar Tray: that one only exists when a calendar is signed in and the menu-bar pref is on. The recording indicator must always work, so it owns its own (equally text-only) Tray and is torn down the moment recording ends.

## Surfaces and data flows affected

- `apps/desktop/src/main/recording-indicator.ts` — new: the Tray lifecycle (darwin-only; no-op elsewhere), guarded like the calendar Tray so a flaky menu bar can never break a recording.
- `apps/desktop/src/main/recording-indicator-logic.ts` — new: pure elapsed-time/title formatting, Electron-free like `calendar-events.ts`.
- `apps/desktop/src/main/index.ts` — wiring: start on the live `ENGINE_START_CHANNEL` branch (next to `setRecordingActive`), stop on `ENGINE_STOP_CHANNEL` and on engine `exit` / `spawn-error` events.

No IPC surface changes, no settings, no data flows — the indicator reads nothing but the wall clock.

## Checks run

- `pnpm --filter desktop typecheck` — clean
- `pnpm --filter desktop test` — 150/150 pass (3 new unit tests for the formatting)
- `pnpm --filter desktop lint` — clean

## Screenshots

[Attach: menu bar during a recording showing the red dot + elapsed time.]

## Privacy, migration, compatibility, release risks

- **Privacy:** strictly positive — the point is to make capture state visible at all times.
- **Migration/compat:** none; no persisted state, macOS-only, and the calendar Tray is untouched.
- **Release risk:** low; Tray failures are caught and logged the same way the calendar Tray handles them.

## Intentionally out of scope

- Real audio-level metering (making the in-app bars reflect actual captured signal would need the engine to emit level events — a natural follow-up, and I'm happy to take it on).
- A stop-recording action in the tray menu (stopping is owned by the renderer's meeting view; wiring a remote stop deserves its own careful change).
- Windows: live capture runs through a different host there; the menu-bar concept doesn't map 1:1.
