### PR TITLE
[ONY-226] Preserve Windows microphone audio through startup, switching, and Stop

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -116,3 +116,5 @@ npmRebuild: false
 publish:
   provider: generic
   url: https://www.doodlenote.ai/updates
+  # Vercel Blob supports one byte range per request, not multipart ranges.
+  useMultipleRangeRequest: false

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "private": true,
   "description": "DoodleNote desktop app for privacy-first local capture, transcription, and AI meeting notes",
   "main": "./out/main/index.js",
@@ -12,7 +12,7 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "pnpm run typecheck:node && pnpm run typecheck:web",
-    "test": "tsx --test src/main/*.test.ts",
+    "test": "tsx --test src/main/*.test.ts src/renderer/src/lib/*.test.ts",
     "lint": "eslint --cache .",
     "format": "prettier --write .",
     "package": "pnpm --filter doodle-note-mcp build && electron-vite build && APPLE_KEYCHAIN_PROFILE=doodlenote-notary electron-builder --mac",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "private": true,
   "description": "DoodleNote desktop app for privacy-first local capture, transcription, and AI meeting notes",
   "main": "./out/main/index.js",

--- a/apps/desktop/scripts/publish-windows-beta.mjs
+++ b/apps/desktop/scripts/publish-windows-beta.mjs
@@ -5,6 +5,7 @@ import { put } from '@vercel/blob'
 import { createReadStream, readFileSync, statSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { buildWindowsBetaManifests } from './windows-beta-manifest.mjs'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const desktopDir = path.join(here, '..')
@@ -59,13 +60,14 @@ for (const { source, destination } of artifacts) {
   console.log(blob.url)
 }
 
-process.stdout.write('uploading beta manifest… ')
-const betaManifestBody = manifest.split(installerName).join(betaInstallerName)
-const betaManifest = await put('updates/latest-beta.yml', Buffer.from(betaManifestBody), {
-  access: 'public',
-  addRandomSuffix: false,
-  allowOverwrite: true,
-  cacheControlMaxAge: 60
-})
-console.log(betaManifest.url)
+for (const { pathname, body } of buildWindowsBetaManifests(manifest, installerName)) {
+  process.stdout.write(`uploading beta manifest ${pathname}… `)
+  const betaManifest = await put(pathname, Buffer.from(body), {
+    access: 'public',
+    addRandomSuffix: false,
+    allowOverwrite: true,
+    cacheControlMaxAge: 60
+  })
+  console.log(betaManifest.url)
+}
 console.log('production latest.yml remains unchanged')

--- a/apps/desktop/scripts/windows-beta-manifest.mjs
+++ b/apps/desktop/scripts/windows-beta-manifest.mjs
@@ -1,0 +1,9 @@
+export function buildWindowsBetaManifests(manifest, installerName) {
+  const betaInstallerName = installerName.replace(/-setup\.exe$/, '-beta-setup.exe')
+  const body = manifest.split(installerName).join(betaInstallerName)
+
+  return [
+    { pathname: 'updates/beta.yml', body },
+    { pathname: 'updates/latest-beta.yml', body }
+  ]
+}

--- a/apps/desktop/src/main/engine-host-win.ts
+++ b/apps/desktop/src/main/engine-host-win.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 import { app, utilityProcess, type UtilityProcess } from 'electron'
 import {
   ENGINE_CAPTURE_CONTROL_CHANNEL,
+  type EngineCaptureStatus,
   type EngineCommand,
   type EngineEvent,
   type EngineSidecarEvent,
@@ -13,6 +14,7 @@ import { join as joinPath } from 'node:path'
 import type { WizardPreflightEvent, WizardPreflightResult } from '../shared/wizard-api'
 
 const RESTART_DELAY_MS = 3_000
+const CAPTURE_DRAIN_TIMEOUT_MS = 2_000
 
 /**
  * Windows counterpart of EngineProcess: drives the sherpa-onnx engine
@@ -27,6 +29,11 @@ export class WinEngineHost {
   private child: UtilityProcess | null = null
   private ready = false
   private sessionActive = false
+  private captureState: 'idle' | 'starting' | 'capturing' | 'draining' | 'finishing' = 'idle'
+  private nextSessionId = 0
+  private activeSessionId: number | null = null
+  private workerStarted = false
+  private drainTimer: NodeJS.Timeout | null = null
   private restartTimer: NodeJS.Timeout | null = null
   private disposed = false
   private readonly listeners = new Set<EngineEventListener>()
@@ -72,8 +79,14 @@ export class WinEngineHost {
       this.child = null
       this.ready = false
       if (this.sessionActive) {
+        const sessionId = this.activeSessionId
         this.sessionActive = false
-        this.stopCaptureInRenderer()
+        this.captureState = 'idle'
+        this.activeSessionId = null
+        this.workerStarted = false
+        if (this.drainTimer) clearTimeout(this.drainTimer)
+        this.drainTimer = null
+        if (sessionId !== null) this.stopCaptureInRenderer(sessionId)
         // Engine crashed mid-session: keep the checkpoint chunks on disk —
         // next launch's orphan recovery merges them.
         this.recorder?.abort()
@@ -121,8 +134,14 @@ export class WinEngineHost {
     if (!this.sessionActive) return
     this.emit(event as unknown as EngineSidecarEvent)
     if (event.event === 'done') {
+      if (this.drainTimer) clearTimeout(this.drainTimer)
+      this.drainTimer = null
       this.sessionActive = false
-      this.stopCaptureInRenderer()
+      this.captureState = 'idle'
+      const sessionId = this.activeSessionId
+      this.activeSessionId = null
+      this.workerStarted = false
+      if (sessionId !== null) this.stopCaptureInRenderer(sessionId)
       // Merge the session's audio off the event path; the 'audio' event
       // follows 'exit' here (order is not part of the contract — listeners
       // react to each event independently).
@@ -164,11 +183,11 @@ export class WinEngineHost {
       return
     }
     if (this.sessionActive) {
-      // Supersede: end the old session; its tail events stop at 'done'.
-      // Its unmerged audio stays on disk for orphan recovery.
-      this.child.postMessage({ t: 'stop' })
-      this.recorder?.abort()
-      this.recorder = null
+      this.emit({
+        event: 'spawn-error',
+        message: 'The previous recording is still finishing. Try again in a moment.'
+      })
+      return
     }
     const source = opts.source ?? 'both'
     const channels = [
@@ -177,22 +196,48 @@ export class WinEngineHost {
     ].filter((c): c is string => c !== null)
 
     this.sessionActive = true
+    this.captureState = 'starting'
+    this.activeSessionId = ++this.nextSessionId
+    this.workerStarted = false
     this.activeChannels = channels
     this.inputDevice = opts.inputDevice
     this.recorder = opts.audioDir ? new WinSessionRecorder(opts.audioDir) : null
     this.emit({ event: 'started', command, filePath, binaryPath: 'sherpa-onnx (in-process)' })
-    this.child.postMessage({ t: 'start', channels })
     this.broadcast(ENGINE_CAPTURE_CONTROL_CHANNEL, {
       action: 'start',
+      sessionId: this.activeSessionId,
       channels,
       ...(this.inputDevice ? { inputDevice: this.inputDevice } : {})
     })
   }
 
   stop(): void {
-    if (!this.sessionActive || !this.child) return
-    this.stopCaptureInRenderer()
-    this.child.postMessage({ t: 'stop' })
+    if (!this.sessionActive || !this.child || this.activeSessionId === null) return
+    if (this.captureState === 'draining' || this.captureState === 'finishing') return
+    this.captureState = 'draining'
+    this.stopCaptureInRenderer(this.activeSessionId)
+    this.drainTimer = setTimeout(() => {
+      if (this.captureState !== 'draining') return
+      this.emit({
+        event: 'error',
+        message: 'Audio capture did not finish draining in time; finalizing available audio.'
+      })
+      this.finishAfterCaptureDrain()
+    }, CAPTURE_DRAIN_TIMEOUT_MS)
+    this.drainTimer.unref()
+  }
+
+  private finishAfterCaptureDrain(): void {
+    if (!this.sessionActive || this.captureState !== 'draining' || !this.child) return
+    if (this.drainTimer) clearTimeout(this.drainTimer)
+    this.drainTimer = null
+    this.captureState = 'finishing'
+    if (this.workerStarted) {
+      this.child.postMessage({ t: 'stop', sessionId: this.activeSessionId })
+    } else {
+      this.handleEngineEvent({ event: 'done' })
+      return
+    }
     const escalate = setTimeout(() => {
       if (this.sessionActive && this.child) {
         this.child.kill() // exit handler synthesizes the session end
@@ -202,17 +247,46 @@ export class WinEngineHost {
   }
 
   /** Renderer capture frames land here (via ENGINE_AUDIO_CHANNEL). */
-  pushAudio(channel: string, samples: Float32Array): void {
-    if (!this.sessionActive || !this.child) return
+  pushAudio(sessionId: number, channel: string, samples: Float32Array): void {
+    if (
+      !this.sessionActive ||
+      !this.child ||
+      !this.workerStarted ||
+      sessionId !== this.activeSessionId ||
+      (this.captureState !== 'capturing' && this.captureState !== 'draining')
+    ) {
+      return
+    }
     this.recorder?.write(channel, samples)
-    this.child.postMessage({ t: 'audio', channel, samples })
+    this.child.postMessage({ t: 'audio', sessionId, channel, samples })
   }
 
-  /** Renderer-side capture failed (permission etc.) — surface + end session. */
-  captureFailed(message: string): void {
-    if (!this.sessionActive) return
-    this.emit({ event: 'error', message })
-    this.stop()
+  /** Renderer capture lifecycle acknowledgements and actionable errors. */
+  captureStatus(status: EngineCaptureStatus): void {
+    if (!status || typeof status.sessionId !== 'number' || typeof status.type !== 'string') return
+    if (!this.sessionActive || status.sessionId !== this.activeSessionId) return
+    if (status.type === 'ready' && this.captureState === 'starting' && this.child) {
+      this.captureState = 'capturing'
+      this.workerStarted = true
+      this.child.postMessage({
+        t: 'start',
+        sessionId: status.sessionId,
+        channels: this.activeChannels
+      })
+      return
+    }
+    if (status.type === 'drained' && this.captureState === 'draining') {
+      this.finishAfterCaptureDrain()
+      return
+    }
+    if (status.type === 'switch-error') {
+      this.emit({ event: 'error', message: `Could not switch microphones: ${status.message}` })
+      return
+    }
+    if (status.type === 'error') {
+      this.emit({ event: 'error', message: status.message })
+      this.stop()
+    }
   }
 
   /** Windows renderer owns microphone capture, so device switches are sent there. */
@@ -221,6 +295,7 @@ export class WinEngineHost {
     if (!this.sessionActive || !this.activeChannels.includes('mic')) return
     this.broadcast(ENGINE_CAPTURE_CONTROL_CHANNEL, {
       action: 'switch-input',
+      sessionId: this.activeSessionId,
       ...(this.inputDevice ? { inputDevice: this.inputDevice } : {})
     })
   }
@@ -257,13 +332,14 @@ export class WinEngineHost {
     this.warmupWaiters.clear()
   }
 
-  private stopCaptureInRenderer(): void {
-    this.broadcast(ENGINE_CAPTURE_CONTROL_CHANNEL, { action: 'stop' })
+  private stopCaptureInRenderer(sessionId: number): void {
+    this.broadcast(ENGINE_CAPTURE_CONTROL_CHANNEL, { action: 'stop', sessionId })
   }
 
   dispose(): void {
     this.disposed = true
     if (this.restartTimer) clearTimeout(this.restartTimer)
+    if (this.drainTimer) clearTimeout(this.drainTimer)
     // Quit mid-recording: chunks stay for next-launch recovery.
     this.recorder?.abort()
     this.recorder = null

--- a/apps/desktop/src/main/engine-win-finalize.test.ts
+++ b/apps/desktop/src/main/engine-win-finalize.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  WINDOWS_ASR_SAMPLE_RATE,
+  WINDOWS_ASR_TAIL_SECONDS,
+  boundedTokenWindow,
+  finishOnlineStream
+} from './engine-win-finalize'
+
+test('finalization submits recognizer-only tail silence before inputFinished', () => {
+  const calls: string[] = []
+  const submitted: { value: Float32Array | null } = { value: null }
+  const stream = {
+    acceptWaveform({ samples, sampleRate }: { samples: Float32Array; sampleRate: number }) {
+      assert.equal(sampleRate, WINDOWS_ASR_SAMPLE_RATE)
+      submitted.value = samples
+      calls.push('tail')
+    },
+    inputFinished() {
+      calls.push('finished')
+    }
+  }
+  let readyChecks = 0
+  const recognizer = {
+    isReady() {
+      return readyChecks++ === 0
+    },
+    decode() {
+      calls.push('decode')
+    }
+  }
+
+  finishOnlineStream(stream, recognizer)
+
+  assert.deepEqual(calls, ['tail', 'finished', 'decode'])
+  assert.equal(submitted.value?.length, WINDOWS_ASR_SAMPLE_RATE * WINDOWS_ASR_TAIL_SECONDS)
+  assert.ok(submitted.value?.every((sample) => sample === 0))
+})
+
+test('tail padding cannot extend emitted timing beyond real audio', () => {
+  assert.deepEqual(boundedTokenWindow(1.8, 2.4, 2), { startSec: 1.8, endSec: 2 })
+  assert.equal(boundedTokenWindow(2.1, 2.4, 2), null)
+})

--- a/apps/desktop/src/main/engine-win-finalize.ts
+++ b/apps/desktop/src/main/engine-win-finalize.ts
@@ -1,0 +1,41 @@
+export const WINDOWS_ASR_SAMPLE_RATE = 16_000
+export const WINDOWS_ASR_TAIL_SECONDS = 0.5
+
+interface FinishableStream {
+  acceptWaveform(obj: { samples: Float32Array; sampleRate: number }): void
+  inputFinished(): void
+}
+
+interface StreamingRecognizer<TStream> {
+  isReady(stream: TStream): boolean
+  decode(stream: TStream): void
+}
+
+/**
+ * Flush a streaming recognizer using the tail silence recommended by Sherpa's
+ * online API examples. The silence is recognizer-only and is never persisted.
+ */
+export function finishOnlineStream<TStream extends FinishableStream>(
+  stream: TStream,
+  recognizer: StreamingRecognizer<TStream>
+): void {
+  stream.acceptWaveform({
+    samples: new Float32Array(WINDOWS_ASR_SAMPLE_RATE * WINDOWS_ASR_TAIL_SECONDS),
+    sampleRate: WINDOWS_ASR_SAMPLE_RATE
+  })
+  stream.inputFinished()
+  while (recognizer.isReady(stream)) recognizer.decode(stream)
+}
+
+export function boundedTokenWindow(
+  startSec: number,
+  endSec: number,
+  realAudioSeconds: number
+): { startSec: number; endSec: number } | null {
+  if (startSec > realAudioSeconds) return null
+  const start = Math.max(0, Math.min(startSec, realAudioSeconds))
+  return {
+    startSec: start,
+    endSec: Math.max(start, Math.min(endSec, realAudioSeconds))
+  }
+}

--- a/apps/desktop/src/main/engine-win.ts
+++ b/apps/desktop/src/main/engine-win.ts
@@ -18,6 +18,11 @@ import { spawn } from 'node:child_process'
 import { createWriteStream, existsSync, mkdirSync, rmSync } from 'node:fs'
 import { get as httpsGet } from 'node:https'
 import { join } from 'node:path'
+import {
+  WINDOWS_ASR_SAMPLE_RATE,
+  boundedTokenWindow,
+  finishOnlineStream
+} from './engine-win-finalize'
 
 const MODEL_NAME = 'sherpa-onnx-streaming-zipformer-en-2023-06-26'
 const MODEL_URL = `https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/${MODEL_NAME}.tar.bz2`
@@ -27,6 +32,7 @@ const TOKEN_TAIL_SEC = 0.25
 
 interface AudioMessage {
   t: 'audio'
+  sessionId?: number
   channel: string
   samples: Float32Array
   /** Batch imports use an acknowledgement for IPC backpressure. */
@@ -35,9 +41,9 @@ interface AudioMessage {
 
 type InMessage =
   | { t: 'init'; modelsDir: string }
-  | { t: 'start'; channels: string[] }
+  | { t: 'start'; channels: string[]; sessionId?: number }
   | AudioMessage
-  | { t: 'stop' }
+  | { t: 'stop'; sessionId?: number }
 
 const port = process.parentPort
 
@@ -136,6 +142,7 @@ class ChannelPipeline {
   private lastPartialAt = 0
   private lastPartialText = ''
   private started = false
+  private realSamples = 0
   private readonly startedAtMs = Date.now()
 
   constructor(
@@ -146,11 +153,12 @@ class ChannelPipeline {
   }
 
   ingest(samples: Float32Array): void {
+    this.realSamples += samples.length
     if (!this.started) {
       this.started = true
       emit({ event: 'channel_start', channel: this.channel, epochMs: Date.now() })
     }
-    this.stream.acceptWaveform({ samples, sampleRate: 16000 })
+    this.stream.acceptWaveform({ samples, sampleRate: WINDOWS_ASR_SAMPLE_RATE })
     while (this.recognizer.isReady(this.stream)) {
       this.recognizer.decode(this.stream)
     }
@@ -159,10 +167,7 @@ class ChannelPipeline {
 
   finish(): void {
     try {
-      this.stream.inputFinished()
-      while (this.recognizer.isReady(this.stream)) {
-        this.recognizer.decode(this.stream)
-      }
+      finishOnlineStream(this.stream, this.recognizer)
       this.publish(true)
       const result = this.recognizer.getResult(this.stream)
       emit({
@@ -183,20 +188,23 @@ class ChannelPipeline {
     const timestamps = result.timestamps ?? []
     if (tokens.length > this.emittedTokens) {
       const fresh: Array<Record<string, unknown>> = []
+      const realAudioSeconds = this.realSamples / WINDOWS_ASR_SAMPLE_RATE
       for (let i = this.emittedTokens; i < tokens.length; i++) {
         const start = timestamps[i] ?? 0
         const end = timestamps[i + 1] ?? start + TOKEN_TAIL_SEC
+        const bounded = boundedTokenWindow(start, Math.max(end, start), realAudioSeconds)
+        if (!bounded) continue
         fresh.push({
           // sherpa marks word starts with ▁ — the segmenter's contract is a
           // leading space (same as the Parakeet engine).
           token: tokens[i]!.replace(/▁/g, ' '),
-          startSec: Math.round(start * 1000) / 1000,
-          endSec: Math.round(Math.max(end, start) * 1000) / 1000,
+          startSec: Math.round(bounded.startSec * 1000) / 1000,
+          endSec: Math.round(bounded.endSec * 1000) / 1000,
           confidence: 0.9
         })
       }
       this.emittedTokens = tokens.length
-      emit({ event: 'timings', channel: this.channel, tokens: fresh })
+      if (fresh.length > 0) emit({ event: 'timings', channel: this.channel, tokens: fresh })
     }
     const now = Date.now()
     const text = joinedText(result)
@@ -220,6 +228,7 @@ function joinedText(result: { text: string }): string {
 let recognizer: SherpaRecognizer | null = null
 let pipelines = new Map<string, ChannelPipeline>()
 let sessionActive = false
+let activeSessionId: number | null = null
 
 async function init(modelsDir: string): Promise<void> {
   try {
@@ -250,7 +259,7 @@ async function init(modelsDir: string): Promise<void> {
   }
 }
 
-function startSession(channels: string[]): void {
+function startSession(channels: string[], sessionId = 0): void {
   if (!recognizer) {
     emit({ event: 'error', message: 'engine is not ready yet' })
     emit({ event: 'done' })
@@ -261,6 +270,7 @@ function startSession(channels: string[]): void {
     return
   }
   sessionActive = true
+  activeSessionId = sessionId
   pipelines = new Map(
     channels.map((channel) => [channel, new ChannelPipeline(channel, recognizer!)])
   )
@@ -268,14 +278,15 @@ function startSession(channels: string[]): void {
   emit({ event: 'status', stage: 'transcribing' })
 }
 
-function stopSession(): void {
-  if (!sessionActive) return
+function stopSession(sessionId = 0): void {
+  if (!sessionActive || activeSessionId !== sessionId) return
   sessionActive = false
   emit({ event: 'status', stage: 'finishing' })
   for (const pipeline of pipelines.values()) {
     pipeline.finish()
   }
   pipelines = new Map()
+  activeSessionId = null
   emit({ event: 'done' })
 }
 
@@ -286,13 +297,14 @@ port.on('message', (message: Electron.MessageEvent) => {
       void init(data.modelsDir)
       break
     case 'start':
-      startSession(data.channels)
+      startSession(data.channels, data.sessionId)
       break
     case 'audio': {
-      if (!sessionActive) break
-      const pipeline = pipelines.get(data.channel)
-      if (pipeline && data.samples instanceof Float32Array && data.samples.length > 0) {
-        pipeline.ingest(data.samples)
+      if (sessionActive && activeSessionId === (data.sessionId ?? 0)) {
+        const pipeline = pipelines.get(data.channel)
+        if (pipeline && data.samples instanceof Float32Array && data.samples.length > 0) {
+          pipeline.ingest(data.samples)
+        }
       }
       if (typeof data.sequence === 'number') {
         port.postMessage({ t: 'ack', sequence: data.sequence })
@@ -300,7 +312,7 @@ port.on('message', (message: Electron.MessageEvent) => {
       break
     }
     case 'stop':
-      stopSession()
+      stopSession(data.sessionId)
       break
   }
 })

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -44,7 +44,7 @@ import { THEME_SET_SOURCE_CHANNEL } from '../shared/theme-api'
 import { TranscriptSession } from './transcript-session'
 import {
   ENGINE_AUDIO_CHANNEL,
-  ENGINE_CAPTURE_ERROR_CHANNEL,
+  ENGINE_CAPTURE_STATUS_CHANNEL,
   ENGINE_EVENT_CHANNEL,
   ENGINE_LIST_DEVICES_CHANNEL,
   ENGINE_SET_INPUT_CHANNEL,
@@ -53,6 +53,7 @@ import {
   ENGINE_STOP_CHANNEL,
   type EngineEvent,
   type EngineInputDevice,
+  type EngineCaptureStatus,
   type EngineStartRequest
 } from '../shared/engine-events'
 
@@ -247,14 +248,17 @@ app.whenReady().then(() => {
   }
 
   // Windows capture bridge: PCM frames + failure reports from the renderer.
-  ipcMain.on(ENGINE_AUDIO_CHANNEL, (_event, payload: { channel?: string; samples?: unknown }) => {
-    if (engine instanceof WinEngineHost && payload.samples instanceof Float32Array) {
-      engine.pushAudio(String(payload.channel ?? ''), payload.samples)
+  ipcMain.on(
+    ENGINE_AUDIO_CHANNEL,
+    (_event, payload: { sessionId?: unknown; channel?: string; samples?: unknown }) => {
+      if (engine instanceof WinEngineHost && payload.samples instanceof Float32Array) {
+        engine.pushAudio(Number(payload.sessionId), String(payload.channel ?? ''), payload.samples)
+      }
     }
-  })
-  ipcMain.on(ENGINE_CAPTURE_ERROR_CHANNEL, (_event, message: unknown) => {
-    if (engine instanceof WinEngineHost) {
-      engine.captureFailed(String(message ?? 'Audio capture failed'))
+  )
+  ipcMain.on(ENGINE_CAPTURE_STATUS_CHANNEL, (_event, payload: unknown) => {
+    if (engine instanceof WinEngineHost && payload && typeof payload === 'object') {
+      engine.captureStatus(payload as EngineCaptureStatus)
     }
   })
 

--- a/apps/desktop/src/main/release-packaging.test.ts
+++ b/apps/desktop/src/main/release-packaging.test.ts
@@ -21,6 +21,7 @@ const ciWorkflow = readFileSync(
 )
 const modelsView = readFileSync(new URL('../renderer/src/ModelsView.tsx', import.meta.url), 'utf8')
 const desktopPackage = readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
+const updaterSource = readFileSync(new URL('./updater.ts', import.meta.url), 'utf8')
 
 function pngMetadata(url: URL): { width: number; height: number; colorType: number } {
   const png = readFileSync(url)
@@ -101,6 +102,7 @@ test('Windows website betas cannot replace the production updater feed', () => {
   assert.match(windowsBetaPublishScript, /-beta-setup\.exe/)
   assert.match(windowsBetaPublishScript, /put\('updates\/latest-beta\.yml'/)
   assert.doesNotMatch(windowsBetaPublishScript, /put\('updates\/latest\.yml'/)
+  assert.match(updaterSource, /applyUpdatePolicy\(autoUpdater\)/)
 })
 
 test('macOS-only settings are gated out of the Windows UI', () => {

--- a/apps/desktop/src/main/release-packaging.test.ts
+++ b/apps/desktop/src/main/release-packaging.test.ts
@@ -85,6 +85,7 @@ test('Windows builds an x64 NSIS updater with the Windows icon and native engine
   assert.match(builderConfig, /artifactName:\s*\$\{productName\}-\$\{version\}-setup\.\$\{ext\}/)
   assert.match(publishScript, /name === 'latest\.yml'/)
   assert.match(publishScript, /name\.endsWith\('\.exe\.blockmap'\)/)
+  assert.match(builderConfig, /publish:\s+[\s\S]*useMultipleRangeRequest:\s*false/)
 })
 
 test('CI builds and retains a real Windows installer', () => {

--- a/apps/desktop/src/main/release-packaging.test.ts
+++ b/apps/desktop/src/main/release-packaging.test.ts
@@ -100,7 +100,6 @@ test('CI builds and retains a real Windows installer', () => {
 test('Windows website betas cannot replace the production updater feed', () => {
   assert.match(desktopPackage, /publish:win-beta[\s\S]*publish-windows-beta\.mjs/)
   assert.match(windowsBetaPublishScript, /-beta-setup\.exe/)
-  assert.match(windowsBetaPublishScript, /put\('updates\/latest-beta\.yml'/)
   assert.doesNotMatch(windowsBetaPublishScript, /put\('updates\/latest\.yml'/)
   assert.match(updaterSource, /applyUpdatePolicy\(autoUpdater\)/)
 })

--- a/apps/desktop/src/main/update-policy.test.ts
+++ b/apps/desktop/src/main/update-policy.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { applyUpdatePolicy, type UpdatePolicyTarget } from './update-policy'
+import {
+  applyUpdatePolicy,
+  publicUpdateErrorMessage,
+  type UpdatePolicyTarget
+} from './update-policy'
 
 function updaterPolicy(): UpdatePolicyTarget {
   return {
@@ -32,4 +36,11 @@ test('other platforms retain their configured update policy', () => {
     allowPrerelease: false,
     allowDowngrade: true
   })
+})
+
+test('updater failures do not expose internal HTTP or filesystem details', () => {
+  const message = publicUpdateErrorMessage()
+
+  assert.equal(message, 'Could not check for updates. Please try again.')
+  assert.doesNotMatch(message, /HttpError|AppData|app\.asar/)
 })

--- a/apps/desktop/src/main/update-policy.test.ts
+++ b/apps/desktop/src/main/update-policy.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { applyUpdatePolicy, type UpdatePolicyTarget } from './update-policy'
+
+function updaterPolicy(): UpdatePolicyTarget {
+  return {
+    channel: null,
+    allowPrerelease: false,
+    allowDowngrade: true
+  }
+}
+
+test('Windows checks the beta feed without allowing a downgrade', () => {
+  const updater = updaterPolicy()
+
+  applyUpdatePolicy(updater, 'win32')
+
+  assert.deepEqual(updater, {
+    channel: 'beta',
+    allowPrerelease: true,
+    allowDowngrade: false
+  })
+})
+
+test('other platforms retain their configured update policy', () => {
+  const updater = updaterPolicy()
+
+  applyUpdatePolicy(updater, 'darwin')
+
+  assert.deepEqual(updater, {
+    channel: null,
+    allowPrerelease: false,
+    allowDowngrade: true
+  })
+})

--- a/apps/desktop/src/main/update-policy.ts
+++ b/apps/desktop/src/main/update-policy.ts
@@ -1,0 +1,23 @@
+export interface UpdatePolicyTarget {
+  channel: string | null
+  allowPrerelease: boolean
+  allowDowngrade: boolean
+}
+
+/**
+ * Windows is currently distributed through the public beta feed
+ * (`latest-beta.yml`). Other platforms retain electron-updater's configured
+ * default channel.
+ */
+export function applyUpdatePolicy(
+  updater: UpdatePolicyTarget,
+  platform: NodeJS.Platform = process.platform
+): void {
+  if (platform !== 'win32') return
+
+  // Setting the channel opts electron-updater into downgrade support. Reset it
+  // immediately so a stale beta manifest can never replace a newer install.
+  updater.channel = 'beta'
+  updater.allowPrerelease = true
+  updater.allowDowngrade = false
+}

--- a/apps/desktop/src/main/update-policy.ts
+++ b/apps/desktop/src/main/update-policy.ts
@@ -4,10 +4,14 @@ export interface UpdatePolicyTarget {
   allowDowngrade: boolean
 }
 
+export function publicUpdateErrorMessage(): string {
+  return 'Could not check for updates. Please try again.'
+}
+
 /**
- * Windows is currently distributed through the public beta feed
- * (`latest-beta.yml`). Other platforms retain electron-updater's configured
- * default channel.
+ * Windows is currently distributed through the public beta channel
+ * (`beta.yml`). Other platforms retain electron-updater's configured default
+ * channel.
  */
 export function applyUpdatePolicy(
   updater: UpdatePolicyTarget,

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -7,7 +7,7 @@ import {
   UPDATE_STATE_EVENT_CHANNEL,
   type UpdateState
 } from '../shared/update-api'
-import { applyUpdatePolicy } from './update-policy'
+import { applyUpdatePolicy, publicUpdateErrorMessage } from './update-policy'
 
 const { autoUpdater } = updaterPkg
 
@@ -107,7 +107,7 @@ export function initAutoUpdater(
   })
   autoUpdater.on('error', (error) => {
     console.error('[updater]', error.message)
-    setState({ status: 'error', error: error.message })
+    setState({ status: 'error', error: publicUpdateErrorMessage() })
   })
 
   void autoUpdater.checkForUpdates().catch(() => {})

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -7,6 +7,7 @@ import {
   UPDATE_STATE_EVENT_CHANNEL,
   type UpdateState
 } from '../shared/update-api'
+import { applyUpdatePolicy } from './update-policy'
 
 const { autoUpdater } = updaterPkg
 
@@ -76,6 +77,7 @@ export function initAutoUpdater(
 
   if (!app.isPackaged) return
 
+  applyUpdatePolicy(autoUpdater)
   autoUpdater.autoDownload = true
   autoUpdater.autoInstallOnAppQuit = true
 

--- a/apps/desktop/src/main/windows-beta-manifest.test.ts
+++ b/apps/desktop/src/main/windows-beta-manifest.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { buildWindowsBetaManifests } from '../../scripts/windows-beta-manifest.mjs'
+
+test('Windows beta publication serves the updater channel and website alias', () => {
+  const source = [
+    'version: 0.4.20',
+    'files:',
+    '  - url: DoodleNote-0.4.20-setup.exe',
+    'path: DoodleNote-0.4.20-setup.exe',
+    ''
+  ].join('\n')
+
+  assert.deepEqual(buildWindowsBetaManifests(source, 'DoodleNote-0.4.20-setup.exe'), [
+    {
+      pathname: 'updates/beta.yml',
+      body: source.replaceAll('DoodleNote-0.4.20-setup.exe', 'DoodleNote-0.4.20-beta-setup.exe')
+    },
+    {
+      pathname: 'updates/latest-beta.yml',
+      body: source.replaceAll('DoodleNote-0.4.20-setup.exe', 'DoodleNote-0.4.20-beta-setup.exe')
+    }
+  ])
+})

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -5,7 +5,7 @@ import {
   ENGINE_BATCH_DATA_CHANNEL,
   ENGINE_BATCH_READ_CHANNEL,
   ENGINE_CAPTURE_CONTROL_CHANNEL,
-  ENGINE_CAPTURE_ERROR_CHANNEL,
+  ENGINE_CAPTURE_STATUS_CHANNEL,
   ENGINE_EVENT_CHANNEL,
   ENGINE_LIST_DEVICES_CHANNEL,
   ENGINE_SET_INPUT_CHANNEL,
@@ -13,6 +13,7 @@ import {
   ENGINE_START_CHANNEL,
   ENGINE_STOP_CHANNEL,
   type EngineCaptureControl,
+  type EngineCaptureStatus,
   type EngineBatchControl,
   type EngineBatchMessage,
   type EngineApi,
@@ -220,12 +221,12 @@ const engineApi: EngineApi = {
     }
   },
 
-  sendAudio(channel: string, samples: Float32Array): void {
-    ipcRenderer.send(ENGINE_AUDIO_CHANNEL, { channel, samples })
+  sendAudio(sessionId: number, channel: string, samples: Float32Array): void {
+    ipcRenderer.send(ENGINE_AUDIO_CHANNEL, { sessionId, channel, samples })
   },
 
-  reportCaptureError(message: string): void {
-    ipcRenderer.send(ENGINE_CAPTURE_ERROR_CHANNEL, message)
+  reportCaptureStatus(status: EngineCaptureStatus): void {
+    ipcRenderer.send(ENGINE_CAPTURE_STATUS_CHANNEL, status)
   },
 
   onBatchControl(cb: (control: EngineBatchControl) => void): () => void {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -117,11 +117,15 @@ function App(): React.JSX.Element {
   useEffect(() => {
     return window.engine.onCaptureControl((control) => {
       if (control.action === 'start') {
-        void startWinCapture(control.channels ?? ['mic', 'system'], control.inputDevice)
+        void startWinCapture(
+          control.sessionId,
+          control.channels ?? ['mic', 'system'],
+          control.inputDevice
+        )
       } else if (control.action === 'switch-input') {
-        void switchWinInputDevice(control.inputDevice)
+        void switchWinInputDevice(control.sessionId, control.inputDevice)
       } else {
-        stopWinCapture()
+        stopWinCapture(control.sessionId)
       }
     })
   }, [])

--- a/apps/desktop/src/renderer/src/lib/win-capture.test.ts
+++ b/apps/desktop/src/renderer/src/lib/win-capture.test.ts
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+test('a microphone permission result cannot reopen capture after Stop', async () => {
+  let resolveMicrophone!: (stream: MediaStream) => void
+  const microphone = new Promise<MediaStream>((resolve) => {
+    resolveMicrophone = resolve
+  })
+  let stoppedTracks = 0
+  const stream = {
+    getTracks: () => [{ stop: () => stoppedTracks++ }],
+    getAudioTracks: () => [{}],
+    getVideoTracks: () => [],
+    removeTrack: () => {}
+  } as unknown as MediaStream
+  const contexts: Array<{ closed: boolean }> = []
+  const statuses: Array<{ type: string; sessionId: number }> = []
+
+  class TestAudioContext {
+    destination = {}
+    closed = false
+
+    constructor() {
+      contexts.push(this)
+    }
+
+    createMediaStreamSource(): { connect(): void } {
+      return { connect: () => undefined }
+    }
+
+    createScriptProcessor(): { connect(): void; onaudioprocess: unknown } {
+      return { connect: () => undefined, onaudioprocess: null }
+    }
+
+    createGain(): { connect(): void; gain: { value: number } } {
+      return { connect: () => undefined, gain: { value: 1 } }
+    }
+
+    async close(): Promise<void> {
+      this.closed = true
+    }
+  }
+
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { mediaDevices: { getUserMedia: () => microphone } }
+  })
+  Object.defineProperty(globalThis, 'AudioContext', {
+    configurable: true,
+    value: TestAudioContext
+  })
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      engine: {
+        sendAudio: () => undefined,
+        reportCaptureStatus(status: { type: string; sessionId: number }) {
+          statuses.push(status)
+        }
+      }
+    }
+  })
+
+  const { startWinCapture, stopWinCapture } = await import('./win-capture')
+  const starting = startWinCapture(7, ['mic'])
+  stopWinCapture(7)
+  resolveMicrophone(stream)
+  await starting
+
+  assert.equal(stoppedTracks, 1)
+  assert.equal(contexts.length, 0)
+  assert.deepEqual(statuses, [{ type: 'drained', sessionId: 7 }])
+})
+
+test('ready, PCM, and drained acknowledgements preserve renderer IPC order', async () => {
+  const events: string[] = []
+  let stoppedTracks = 0
+  const stream = {
+    getTracks: () => [{ stop: () => stoppedTracks++ }],
+    getAudioTracks: () => [{}],
+    getVideoTracks: () => [],
+    removeTrack: () => {}
+  } as unknown as MediaStream
+  type AudioCallback = (event: { inputBuffer: { getChannelData(): Float32Array } }) => void
+  interface TestNode {
+    connect(): void
+    disconnect(): void
+  }
+  interface TestProcessor extends TestNode {
+    onaudioprocess: AudioCallback | null
+  }
+  let processor: TestProcessor | undefined
+  const node = (): TestNode => ({
+    connect: () => undefined,
+    disconnect: () => undefined
+  })
+
+  class TestAudioContext {
+    destination = {}
+    createMediaStreamSource(): TestNode {
+      return node()
+    }
+    createScriptProcessor(): TestProcessor {
+      processor = { ...node(), onaudioprocess: null }
+      return processor
+    }
+    createGain(): TestNode & { gain: { value: number } } {
+      return { ...node(), gain: { value: 1 } }
+    }
+    async close(): Promise<void> {
+      await Promise.resolve()
+    }
+  }
+
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { mediaDevices: { getUserMedia: async () => stream } }
+  })
+  Object.defineProperty(globalThis, 'AudioContext', {
+    configurable: true,
+    value: TestAudioContext
+  })
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      engine: {
+        sendAudio(sessionId: number) {
+          events.push(`audio:${sessionId}`)
+        },
+        reportCaptureStatus(status: { type: string; sessionId: number }) {
+          events.push(`${status.type}:${status.sessionId}`)
+        }
+      }
+    }
+  })
+
+  const { startWinCapture, stopWinCapture } = await import('./win-capture')
+  await startWinCapture(8, ['mic'])
+  const staleCallback = processor?.onaudioprocess
+  assert.ok(staleCallback)
+  staleCallback({ inputBuffer: { getChannelData: () => new Float32Array([0.5]) } })
+  stopWinCapture(8)
+  staleCallback({ inputBuffer: { getChannelData: () => new Float32Array([0.75]) } })
+
+  assert.deepEqual(events, ['ready:8', 'audio:8', 'drained:8'])
+  assert.equal(stoppedTracks, 1)
+})

--- a/apps/desktop/src/renderer/src/lib/win-capture.ts
+++ b/apps/desktop/src/renderer/src/lib/win-capture.ts
@@ -2,49 +2,82 @@ import type { EngineInputDevice } from '../../../shared/engine-events'
 import { mapWindowsInputDevices } from '../../../shared/win-audio-utils'
 
 /**
- * Windows audio capture, in the renderer where Chromium does the heavy
- * lifting: microphone via getUserMedia (with Chromium's AEC scrubbing the
- * far side out of the "You" channel) and system audio via getDisplayMedia,
- * which main grants as WASAPI loopback (setDisplayMediaRequestHandler).
- * Frames leave as 16kHz mono Float32 chunks over window.engine.sendAudio —
- * the main process forwards them to the sherpa-onnx engine.
- *
- * Driven by ENGINE_CAPTURE_CONTROL messages from WinEngineHost; never runs
- * on macOS (the Swift engine owns capture there).
+ * Windows audio capture lives in the renderer so Chromium can provide the
+ * microphone and WASAPI loopback streams. Every asynchronous operation is
+ * scoped to a main-process session id. That keeps a late permission result or
+ * microphone switch from reviving an old capture after Stop.
  */
 
 interface ChannelCapture {
   channel: string
   stream: MediaStream
   context: AudioContext
+  source: MediaStreamAudioSourceNode
+  processor: ScriptProcessorNode
+  mute: GainNode
 }
 
 let captures: ChannelCapture[] = []
+let pendingStreams: MediaStream[] = []
 let activeInputDevice: string | undefined
+let activeSessionId: number | null = null
+let sessionGeneration = 0
+let switchGeneration = 0
 
-export async function startWinCapture(channels: string[], inputDevice?: string): Promise<void> {
-  stopWinCapture()
+function microphoneConstraints(inputDevice?: string): MediaTrackConstraints {
+  return {
+    ...(inputDevice && inputDevice !== 'default' ? { deviceId: { exact: inputDevice } } : {}),
+    channelCount: 1,
+    echoCancellation: true,
+    noiseSuppression: true,
+    autoGainControl: true
+  }
+}
+
+function current(sessionId: number, generation: number): boolean {
+  return activeSessionId === sessionId && sessionGeneration === generation
+}
+
+function stopStream(stream: MediaStream): void {
+  for (const track of stream.getTracks()) track.stop()
+}
+
+export async function startWinCapture(
+  sessionId: number,
+  channels: string[],
+  inputDevice?: string
+): Promise<void> {
+  cancelCapture()
+  const generation = ++sessionGeneration
+  activeSessionId = sessionId
   activeInputDevice = inputDevice
+  const acquired: Array<{ channel: string; stream: MediaStream }> = []
+  const prepared: ChannelCapture[] = []
+
   try {
     if (channels.includes('mic')) {
       const mic = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          ...(inputDevice && inputDevice !== 'default' ? { deviceId: { exact: inputDevice } } : {}),
-          channelCount: 1,
-          echoCancellation: true, // scrubs speaker bleed out of "You"
-          noiseSuppression: true,
-          autoGainControl: true
-        }
+        audio: microphoneConstraints(inputDevice)
       })
-      captures.push(pump(mic, 'mic'))
+      if (!current(sessionId, generation)) {
+        stopStream(mic)
+        return
+      }
+      pendingStreams.push(mic)
+      acquired.push({ channel: 'mic', stream: mic })
     }
+
     if (channels.includes('system')) {
       // Main's display-media handler answers this with audio: 'loopback'.
       const display = await navigator.mediaDevices.getDisplayMedia({
         audio: true,
         video: { width: 2, height: 2, frameRate: 1 }
       })
-      // Only the loopback audio is wanted; drop the video track immediately.
+      if (!current(sessionId, generation)) {
+        stopStream(display)
+        return
+      }
+      pendingStreams.push(display)
       for (const track of display.getVideoTracks()) {
         track.stop()
         display.removeTrack(track)
@@ -52,32 +85,56 @@ export async function startWinCapture(channels: string[], inputDevice?: string):
       if (display.getAudioTracks().length === 0) {
         throw new Error('System audio loopback is unavailable on this machine')
       }
-      captures.push(pump(display, 'system'))
+      acquired.push({ channel: 'system', stream: display })
     }
-  } catch (err) {
-    stopWinCapture()
-    window.engine.reportCaptureError(
-      err instanceof Error ? err.message : 'Audio capture failed to start'
+
+    if (!current(sessionId, generation)) return
+    for (const { channel, stream } of acquired) {
+      prepared.push(pump(stream, channel, sessionId, generation))
+    }
+    captures = prepared
+    pendingStreams = []
+    window.engine.reportCaptureStatus({ type: 'ready', sessionId })
+  } catch (error) {
+    if (!current(sessionId, generation)) return
+    for (const capture of prepared) stopCapture(capture)
+    pendingStreams = pendingStreams.filter(
+      (stream) => !prepared.some((capture) => capture.stream === stream)
     )
+    cancelCapture()
+    window.engine.reportCaptureStatus({
+      type: 'error',
+      sessionId,
+      message: error instanceof Error ? error.message : 'Audio capture failed to start'
+    })
   }
 }
 
-/** Wire a stream into a 16k AudioContext and ship PCM frames to main. */
-function pump(stream: MediaStream, channel: string): ChannelCapture {
-  // Chromium resamples to the context rate — 16k mono lands here for free.
+/** Wire a stream into a 16 kHz AudioContext and ship PCM frames to main. */
+function pump(
+  stream: MediaStream,
+  channel: string,
+  sessionId: number,
+  generation: number
+): ChannelCapture {
   const context = new AudioContext({ sampleRate: 16000 })
   const source = context.createMediaStreamSource(stream)
   const processor = context.createScriptProcessor(4096, 1, 1)
   processor.onaudioprocess = (event) => {
+    if (!current(sessionId, generation)) return
     // The buffer is reused by the audio thread — copy before shipping.
-    window.engine.sendAudio(channel, new Float32Array(event.inputBuffer.getChannelData(0)))
+    window.engine.sendAudio(
+      sessionId,
+      channel,
+      new Float32Array(event.inputBuffer.getChannelData(0))
+    )
   }
   const mute = context.createGain()
   mute.gain.value = 0
   source.connect(processor)
   processor.connect(mute)
-  mute.connect(context.destination) // ScriptProcessor only runs when routed
-  return { channel, stream, context }
+  mute.connect(context.destination)
+  return { channel, stream, context, source, processor, mute }
 }
 
 export async function listWinInputDevices(): Promise<EngineInputDevice[]> {
@@ -87,35 +144,65 @@ export async function listWinInputDevices(): Promise<EngineInputDevice[]> {
 }
 
 /** Replace only the microphone stream; system loopback keeps flowing. */
-export async function switchWinInputDevice(inputDevice?: string): Promise<void> {
-  const current = captures.find((capture) => capture.channel === 'mic')
-  if (!current || inputDevice === activeInputDevice) return
+export async function switchWinInputDevice(sessionId: number, inputDevice?: string): Promise<void> {
+  const currentCapture = captures.find((capture) => capture.channel === 'mic')
+  if (activeSessionId !== sessionId || !currentCapture) return
+  if (inputDevice === activeInputDevice) {
+    window.engine.reportCaptureStatus({ type: 'switch-complete', sessionId })
+    return
+  }
+  const generation = sessionGeneration
+  const attempt = ++switchGeneration
   try {
     const replacement = await navigator.mediaDevices.getUserMedia({
-      audio: {
-        ...(inputDevice && inputDevice !== 'default' ? { deviceId: { exact: inputDevice } } : {}),
-        channelCount: 1,
-        echoCancellation: true,
-        noiseSuppression: true,
-        autoGainControl: true
-      }
+      audio: microphoneConstraints(inputDevice)
     })
-    const next = pump(replacement, 'mic')
-    stopCapture(current)
-    captures = captures.map((capture) => (capture === current ? next : capture))
+    if (
+      !current(sessionId, generation) ||
+      switchGeneration !== attempt ||
+      !captures.includes(currentCapture)
+    ) {
+      stopStream(replacement)
+      return
+    }
+    const next = pump(replacement, 'mic', sessionId, generation)
+    stopCapture(currentCapture)
+    captures = captures.map((capture) => (capture === currentCapture ? next : capture))
     activeInputDevice = inputDevice
+    window.engine.reportCaptureStatus({ type: 'switch-complete', sessionId })
   } catch (error) {
-    console.error('[win-capture] could not switch microphones:', error)
+    if (!current(sessionId, generation) || switchGeneration !== attempt) return
+    window.engine.reportCaptureStatus({
+      type: 'switch-error',
+      sessionId,
+      message: error instanceof Error ? error.message : 'Could not switch microphones'
+    })
   }
 }
 
 function stopCapture(capture: ChannelCapture): void {
-  for (const track of capture.stream.getTracks()) track.stop()
+  capture.processor.onaudioprocess = null
+  capture.source.disconnect()
+  capture.processor.disconnect()
+  capture.mute.disconnect()
+  stopStream(capture.stream)
   void capture.context.close().catch(() => {})
 }
 
-export function stopWinCapture(): void {
+function cancelCapture(): void {
+  sessionGeneration++
+  switchGeneration++
   for (const capture of captures) stopCapture(capture)
+  for (const stream of pendingStreams) stopStream(stream)
   captures = []
+  pendingStreams = []
   activeInputDevice = undefined
+  activeSessionId = null
+}
+
+export function stopWinCapture(sessionId: number): void {
+  if (activeSessionId === sessionId) cancelCapture()
+  // IPC messages from one renderer arrive at main in send order. Once this
+  // acknowledgement arrives, all PCM sent before disconnection has arrived.
+  window.engine.reportCaptureStatus({ type: 'drained', sessionId })
 }

--- a/apps/desktop/src/shared/engine-events.ts
+++ b/apps/desktop/src/shared/engine-events.ts
@@ -10,8 +10,8 @@
 export const ENGINE_CAPTURE_CONTROL_CHANNEL = 'engine:capture-control'
 /** renderer → main (Windows): one 16k mono Float32 frame for a channel. */
 export const ENGINE_AUDIO_CHANNEL = 'engine:audio'
-/** renderer → main (Windows): capture could not start (permissions etc.). */
-export const ENGINE_CAPTURE_ERROR_CHANNEL = 'engine:capture-error'
+/** renderer → main (Windows): capture readiness, drain, and error acknowledgements. */
+export const ENGINE_CAPTURE_STATUS_CHANNEL = 'engine:capture-status'
 /** main → renderer (Windows): decode an imported file with Chromium's media stack. */
 export const ENGINE_BATCH_CONTROL_CHANNEL = 'engine:batch-control'
 /** renderer → main (Windows): decoded PCM lifecycle for an imported file. */
@@ -21,9 +21,15 @@ export const ENGINE_BATCH_READ_CHANNEL = 'engine:batch-read'
 
 export interface EngineCaptureControl {
   action: 'start' | 'stop' | 'switch-input'
+  /** Identifies one live capture so delayed callbacks cannot cross session boundaries. */
+  sessionId: number
   channels?: string[]
   inputDevice?: string
 }
+
+export type EngineCaptureStatus =
+  | { type: 'ready' | 'drained' | 'switch-complete'; sessionId: number }
+  | { type: 'error' | 'switch-error'; sessionId: number; message: string }
 
 export interface EngineBatchControl {
   action: 'decode'
@@ -263,8 +269,8 @@ export interface EngineApi {
   tapSelfTest(): Promise<{ ok: boolean; reason?: string }>
   /** Windows capture bridge (no-ops on macOS). */
   onCaptureControl(cb: (control: EngineCaptureControl) => void): () => void
-  sendAudio(channel: string, samples: Float32Array): void
-  reportCaptureError(message: string): void
+  sendAudio(sessionId: number, channel: string, samples: Float32Array): void
+  reportCaptureStatus(status: EngineCaptureStatus): void
   /** Windows imported-audio decoder bridge (no events are sent on macOS). */
   onBatchControl(cb: (control: EngineBatchControl) => void): () => void
   readBatchAudio(jobId: string): Promise<ArrayBuffer>

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,16 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.19",
+    date: "September 4, 2026",
+    highlights: [
+      "Preserve the final spoken words when stopping a Windows recording",
+      "Prevent delayed microphone starts and switches from crossing recording sessions",
+      "Show recording readiness and microphone switch failures accurately on Windows",
+      "Route Windows beta update checks through the Windows beta release feed",
+    ],
+  },
+  {
     version: "0.4.18",
     date: "September 1, 2026",
     highlights: [

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,14 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.20",
+    date: "September 4, 2026",
+    highlights: [
+      "Restore Check for updates for Windows beta installations",
+      "Replace internal updater diagnostics with a short, readable error message",
+    ],
+  },
+  {
     version: "0.4.19",
     date: "September 4, 2026",
     highlights: [

--- a/apps/web/app/updates/[...path]/route.ts
+++ b/apps/web/app/updates/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import {
+  isMultiRangeRequest,
   updateProxyRequestHeaders,
   updateProxyResponseInit,
 } from "@/lib/update-proxy";
@@ -32,6 +33,17 @@ export async function GET(
   const name = parts.join("/");
   if (parts.length !== 1 || !SAFE_NAME.test(name)) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Vercel Blob accepts one range but treats a combined range as a full-file
+  // request. Reject combined ranges immediately so older electron-updater
+  // clients abandon the differential attempt and fall back to one full stream.
+  // New packages disable combined-range downloads in app-update.yml below.
+  if (isMultiRangeRequest(request.headers.get("range"))) {
+    return new NextResponse(null, {
+      status: 416,
+      headers: { "accept-ranges": "bytes" },
+    });
   }
 
   const upstream = await fetch(`${BLOB_BASE}/${encodeURIComponent(name)}`, {

--- a/apps/web/app/updates/[...path]/route.ts
+++ b/apps/web/app/updates/[...path]/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
 
+import {
+  updateProxyRequestHeaders,
+  updateProxyResponseInit,
+} from "@/lib/update-proxy";
+
 /**
  * Update-feed proxy: serves latest*.yml manifests and installer artifacts
  * from the Blob store THROUGH the app's own domain. Born from an outage:
@@ -31,6 +36,7 @@ export async function GET(
 
   const upstream = await fetch(`${BLOB_BASE}/${encodeURIComponent(name)}`, {
     redirect: "follow",
+    headers: updateProxyRequestHeaders(request),
     // Manifests must be fresh; Next's fetch cache would defeat the 60s TTL.
     cache: "no-store",
   });
@@ -41,17 +47,5 @@ export async function GET(
     );
   }
 
-  const isManifest = name.endsWith(".yml");
-  const headers = new Headers({
-    "content-type":
-      upstream.headers.get("content-type") ?? "application/octet-stream",
-    // Versioned artifacts are immutable; manifests revalidate fast.
-    "cache-control": isManifest
-      ? "public, max-age=60"
-      : "public, max-age=31536000, immutable",
-  });
-  const length = upstream.headers.get("content-length");
-  if (length) headers.set("content-length", length);
-
-  return new NextResponse(upstream.body, { status: 200, headers });
+  return new NextResponse(upstream.body, updateProxyResponseInit(name, upstream));
 }

--- a/apps/web/lib/update-proxy.ts
+++ b/apps/web/lib/update-proxy.ts
@@ -1,3 +1,7 @@
+export function isMultiRangeRequest(range: string | null): boolean {
+  return range?.includes(",") ?? false;
+}
+
 export function updateProxyRequestHeaders(request: Request): Headers {
   const headers = new Headers();
   const range = request.headers.get("range");

--- a/apps/web/lib/update-proxy.ts
+++ b/apps/web/lib/update-proxy.ts
@@ -1,0 +1,33 @@
+export function updateProxyRequestHeaders(request: Request): Headers {
+  const headers = new Headers();
+  const range = request.headers.get("range");
+  if (range) headers.set("range", range);
+  return headers;
+}
+
+export function updateProxyResponseInit(
+  name: string,
+  upstream: Response,
+): { status: number; headers: Headers } {
+  const isManifest = name.endsWith(".yml");
+  const headers = new Headers({
+    "content-type":
+      upstream.headers.get("content-type") ?? "application/octet-stream",
+    "cache-control": isManifest
+      ? "public, max-age=60"
+      : "public, max-age=31536000, immutable",
+  });
+
+  for (const name of [
+    "accept-ranges",
+    "content-length",
+    "content-range",
+    "etag",
+    "last-modified",
+  ]) {
+    const value = upstream.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+
+  return { status: upstream.status, headers };
+}

--- a/apps/web/tests/update-proxy.test.ts
+++ b/apps/web/tests/update-proxy.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  updateProxyRequestHeaders,
+  updateProxyResponseInit,
+} from "../lib/update-proxy";
+
+test("update proxy preserves byte-range requests and partial responses", () => {
+  const request = new Request("https://www.doodlenote.ai/updates/setup.exe", {
+    headers: { range: "bytes=0-0" },
+  });
+
+  assert.equal(updateProxyRequestHeaders(request).get("range"), "bytes=0-0");
+
+  const upstream = new Response(new Uint8Array([0]), {
+    status: 206,
+    headers: {
+      "accept-ranges": "bytes",
+      "content-length": "1",
+      "content-range": "bytes 0-0/178818312",
+      "content-type": "application/octet-stream",
+    },
+  });
+  const response = updateProxyResponseInit("setup.exe", upstream);
+
+  assert.equal(response.status, 206);
+  assert.equal(response.headers.get("accept-ranges"), "bytes");
+  assert.equal(response.headers.get("content-length"), "1");
+  assert.equal(response.headers.get("content-range"), "bytes 0-0/178818312");
+});

--- a/apps/web/tests/update-proxy.test.ts
+++ b/apps/web/tests/update-proxy.test.ts
@@ -2,9 +2,16 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  isMultiRangeRequest,
   updateProxyRequestHeaders,
   updateProxyResponseInit,
 } from "../lib/update-proxy";
+
+test("update proxy identifies unsupported combined range requests", () => {
+  assert.equal(isMultiRangeRequest(null), false);
+  assert.equal(isMultiRangeRequest("bytes=0-0"), false);
+  assert.equal(isMultiRangeRequest("bytes=0-0,2-2"), true);
+});
 
 test("update proxy preserves byte-range requests and partial responses", () => {
   const request = new Request("https://www.doodlenote.ai/updates/setup.exe", {

--- a/packages/doodle-note-mcp/package.json
+++ b/packages/doodle-note-mcp/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "esbuild src/cli.ts --bundle --platform=node --format=esm --outfile=dist/cli.js --banner:js=\"#!/usr/bin/env node\" && chmod +x dist/cli.js",
+    "build": "esbuild src/cli.ts --bundle --platform=node --format=esm --outfile=dist/cli.js --banner:js=\"#!/usr/bin/env node\" && node -e \"require('node:fs').chmodSync('dist/cli.js', 0o755)\"",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test src/*.test.ts",
     "prepublishOnly": "pnpm test && pnpm build"


### PR DESCRIPTION
Windows recordings could lose final or delayed microphone frames because Stop reached the transcription worker before renderer-side PCM had drained. Pending microphone starts and switches could also outlive their recording session.

This change adds session-scoped capture messages and an explicit renderer drain acknowledgement before worker finalization. It cancels stale starts and switches, reports readiness only after capture is established, surfaces switch failures, and adds 0.5 seconds of recognizer-only tail silence while bounding transcript timing to real audio.

Installed testing also exposed three related Windows beta updater problems. Electron-updater requested `beta.yml`, while the publisher only created `latest-beta.yml`; the publisher now writes both aliases to the same artifact. The web download proxy also discarded `Range` and returned a full `200` response, leaving Electron's differential download at 0%. It now preserves valid single-range responses. Because Vercel Blob does not support Electron's combined ranges, the proxy rejects those immediately so older clients use their built-in full-download fallback, and future packages disable combined-range requests. Settings replaces internal updater stack traces with a short failure message.

Linear: [ONY-226](https://linear.app/onyxdevlabs/issue/ONY-226/preserve-windows-microphone-audio-through-startup-switching-and-stop)

Validation:
- All GitHub checks pass, including shared CI, CodeQL, and Windows packaging.
- Desktop tests: 151 total, 146 passed, 5 expected native-media skips.
- Desktop node and web typechecks pass.
- Changed-file ESLint passes.
- Packaged sherpa and llama native-module smoke passes.
- Installer SHA-256: `7B3EC4C9BE4C472F0E814B0D03560869BBADF12C9A32494AF8C594711BBD3A3C`.
- The unsigned 0.4.20 beta is published at https://www.doodlenote.ai/download/win.
- Both beta manifests and artifacts were verified publicly; production `latest.yml` remains at 0.3.4.
- The production installer proxy returns `206 Partial Content` for a one-byte range probe (`bytes 0-0/178818312`).
- The production proxy returns `416` immediately for a combined-range probe, allowing 0.4.19 to fall back instead of hanging while Blob streams the entire installer.

Installed Windows microphone and updater QA remains required before the issue is complete.
