### PR TITLE
[ONY-231] Refine Windows transcripts with high-accuracy local ASR

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "private": true,
   "description": "DoodleNote desktop app for privacy-first local capture, transcription, and AI meeting notes",
   "main": "./out/main/index.js",

--- a/apps/desktop/src/main/engine-host-win.ts
+++ b/apps/desktop/src/main/engine-host-win.ts
@@ -1,4 +1,6 @@
 import { join } from 'node:path'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { app, utilityProcess, type UtilityProcess } from 'electron'
 import {
   ENGINE_CAPTURE_CONTROL_CHANNEL,
@@ -12,6 +14,7 @@ import type { EngineEventListener } from './engine-process'
 import { WinSessionRecorder } from './win-audio-recorder'
 import { join as joinPath } from 'node:path'
 import type { WizardPreflightEvent, WizardPreflightResult } from '../shared/wizard-api'
+import type { BatchProgress, BatchTranscription } from './import-logic'
 
 const RESTART_DELAY_MS = 3_000
 const CAPTURE_DRAIN_TIMEOUT_MS = 2_000
@@ -29,11 +32,13 @@ export class WinEngineHost {
   private child: UtilityProcess | null = null
   private ready = false
   private sessionActive = false
-  private captureState: 'idle' | 'starting' | 'capturing' | 'draining' | 'finishing' = 'idle'
+  private captureState: 'idle' | 'starting' | 'capturing' | 'draining' | 'finishing' | 'refining' =
+    'idle'
   private nextSessionId = 0
   private activeSessionId: number | null = null
   private workerStarted = false
   private drainTimer: NodeJS.Timeout | null = null
+  private workerFinishTimer: NodeJS.Timeout | null = null
   private restartTimer: NodeJS.Timeout | null = null
   private disposed = false
   private readonly listeners = new Set<EngineEventListener>()
@@ -45,6 +50,13 @@ export class WinEngineHost {
   private activeChannels: string[] = []
   /** Tees renderer PCM frames to disk when the session persists audio. */
   private recorder: WinSessionRecorder | null = null
+  private ephemeralAudioDir: string | null = null
+  private finalRefiner:
+    | ((
+        path: string,
+        onProgress?: (progress: BatchProgress) => void
+      ) => Promise<BatchTranscription>)
+    | null = null
 
   constructor(private readonly broadcast: (channel: string, payload: unknown) => void) {}
 
@@ -57,6 +69,15 @@ export class WinEngineHost {
 
   get running(): boolean {
     return this.sessionActive
+  }
+
+  setFinalRefiner(
+    refiner: (
+      path: string,
+      onProgress?: (progress: BatchProgress) => void
+    ) => Promise<BatchTranscription>
+  ): void {
+    this.finalRefiner = refiner
   }
 
   /** Fork the engine and load models (call once, after app ready). */
@@ -86,11 +107,14 @@ export class WinEngineHost {
         this.workerStarted = false
         if (this.drainTimer) clearTimeout(this.drainTimer)
         this.drainTimer = null
+        if (this.workerFinishTimer) clearTimeout(this.workerFinishTimer)
+        this.workerFinishTimer = null
         if (sessionId !== null) this.stopCaptureInRenderer(sessionId)
         // Engine crashed mid-session: keep the checkpoint chunks on disk —
         // next launch's orphan recovery merges them.
         this.recorder?.abort()
         this.recorder = null
+        this.removeEphemeralAudio()
         this.emit({ event: 'exit', code: null, signal: 'SIGTERM' })
       }
       if (!this.disposed) {
@@ -132,38 +156,80 @@ export class WinEngineHost {
     }
     // Model download/boot progress is host-side noise, not session traffic.
     if (!this.sessionActive) return
-    this.emit(event as unknown as EngineSidecarEvent)
     if (event.event === 'done') {
-      if (this.drainTimer) clearTimeout(this.drainTimer)
-      this.drainTimer = null
-      this.sessionActive = false
-      this.captureState = 'idle'
-      const sessionId = this.activeSessionId
-      this.activeSessionId = null
-      this.workerStarted = false
-      if (sessionId !== null) this.stopCaptureInRenderer(sessionId)
-      // Merge the session's audio off the event path; the 'audio' event
-      // follows 'exit' here (order is not part of the contract — listeners
-      // react to each event independently).
-      const recorder = this.recorder
-      this.recorder = null
-      if (recorder) {
-        void recorder
-          .finish()
-          .then((saved) => {
-            if (saved) {
-              this.emit({
-                event: 'audio',
-                path: joinPath(recorder.dir, 'audio.wav'),
-                durationMs: saved.durationMs,
-                startEpochMs: saved.startEpochMs
-              })
-            }
-          })
-          .catch((err) => console.error('[win-audio] merge failed:', err))
-      }
-      this.emit({ event: 'exit', code: 0, signal: null })
+      if (this.workerFinishTimer) clearTimeout(this.workerFinishTimer)
+      this.workerFinishTimer = null
+      void this.completeSession()
+      return
     }
+    this.emit(event as unknown as EngineSidecarEvent)
+  }
+
+  private async completeSession(): Promise<void> {
+    if (!this.sessionActive || this.captureState === 'refining') return
+    this.captureState = 'refining'
+    if (this.drainTimer) clearTimeout(this.drainTimer)
+    this.drainTimer = null
+    const sessionId = this.activeSessionId
+    if (sessionId !== null) this.stopCaptureInRenderer(sessionId)
+    const recorder = this.recorder
+    this.recorder = null
+    let audioPath: string | null = null
+    try {
+      const saved = await recorder?.finish()
+      if (saved && recorder) {
+        audioPath = joinPath(recorder.dir, 'audio.wav')
+        if (!this.ephemeralAudioDir) {
+          this.emit({
+            event: 'audio',
+            path: audioPath,
+            durationMs: saved.durationMs,
+            startEpochMs: saved.startEpochMs
+          })
+        }
+      }
+    } catch (error) {
+      console.error('[win-audio] merge failed:', error)
+    }
+
+    if (audioPath && this.finalRefiner && !this.disposed) {
+      try {
+        const refinementPath = audioPath
+        this.emit({ event: 'status', stage: 'refining_transcript' })
+        const result = await this.finalRefiner(refinementPath, (progress) => {
+          if (progress.stage === 'downloading_model') {
+            this.emit({ event: 'download', progress: progress.progress ?? 0 })
+          } else if (progress.stage === 'transcribing') {
+            this.emit({ event: 'status', stage: 'refining_transcript' })
+          }
+        })
+        const transcripts = (['mic', 'system'] as const).flatMap((channel) => {
+          const text = result.segments
+            .filter((segment) => segment.channel === channel && !segment.echo)
+            .sort((a, b) => a.startMs - b.startMs)
+            .map((segment) => segment.text.trim())
+            .filter(Boolean)
+            .join(' ')
+          return text ? [{ channel, text, audioSeconds: result.audioSeconds }] : []
+        })
+        if (transcripts.length > 0) this.emit({ event: 'refined', transcripts })
+      } catch {
+        console.error('[win-asr] final refinement failed')
+        this.emit({
+          event: 'error',
+          message: 'High-accuracy refinement could not finish; the live transcript was kept.'
+        })
+      }
+    }
+
+    this.removeEphemeralAudio()
+    if (this.disposed || !this.sessionActive || this.activeSessionId !== sessionId) return
+    this.sessionActive = false
+    this.captureState = 'idle'
+    this.activeSessionId = null
+    this.workerStarted = false
+    this.emit({ event: 'done' })
+    this.emit({ event: 'exit', code: 0, signal: null })
   }
 
   start(command: EngineCommand, filePath?: string, opts: EngineStartOptions = {}): void {
@@ -201,7 +267,9 @@ export class WinEngineHost {
     this.workerStarted = false
     this.activeChannels = channels
     this.inputDevice = opts.inputDevice
-    this.recorder = opts.audioDir ? new WinSessionRecorder(opts.audioDir) : null
+    const audioDir = opts.audioDir ?? mkdtempSync(join(tmpdir(), 'doodlenote-asr-'))
+    this.ephemeralAudioDir = opts.audioDir ? null : audioDir
+    this.recorder = new WinSessionRecorder(audioDir)
     this.emit({ event: 'started', command, filePath, binaryPath: 'sherpa-onnx (in-process)' })
     this.broadcast(ENGINE_CAPTURE_CONTROL_CHANNEL, {
       action: 'start',
@@ -238,12 +306,12 @@ export class WinEngineHost {
       this.handleEngineEvent({ event: 'done' })
       return
     }
-    const escalate = setTimeout(() => {
-      if (this.sessionActive && this.child) {
+    this.workerFinishTimer = setTimeout(() => {
+      if (this.sessionActive && this.captureState === 'finishing' && this.child) {
         this.child.kill() // exit handler synthesizes the session end
       }
     }, 15_000)
-    escalate.unref()
+    this.workerFinishTimer.unref()
   }
 
   /** Renderer capture frames land here (via ENGINE_AUDIO_CHANNEL). */
@@ -336,13 +404,21 @@ export class WinEngineHost {
     this.broadcast(ENGINE_CAPTURE_CONTROL_CHANNEL, { action: 'stop', sessionId })
   }
 
+  private removeEphemeralAudio(): void {
+    if (!this.ephemeralAudioDir) return
+    rmSync(this.ephemeralAudioDir, { recursive: true, force: true })
+    this.ephemeralAudioDir = null
+  }
+
   dispose(): void {
     this.disposed = true
     if (this.restartTimer) clearTimeout(this.restartTimer)
     if (this.drainTimer) clearTimeout(this.drainTimer)
+    if (this.workerFinishTimer) clearTimeout(this.workerFinishTimer)
     // Quit mid-recording: chunks stay for next-launch recovery.
     this.recorder?.abort()
     this.recorder = null
+    this.removeEphemeralAudio()
     this.child?.kill()
     this.child = null
     this.listeners.clear()

--- a/apps/desktop/src/main/engine-win.ts
+++ b/apps/desktop/src/main/engine-win.ts
@@ -23,6 +23,7 @@ import {
   boundedTokenWindow,
   finishOnlineStream
 } from './engine-win-finalize'
+import { ensureWindowsWhisperModel, splitWhisperWindows } from './windows-whisper-model'
 
 const MODEL_NAME = 'sherpa-onnx-streaming-zipformer-en-2023-06-26'
 const MODEL_URL = `https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/${MODEL_NAME}.tar.bz2`
@@ -40,7 +41,7 @@ interface AudioMessage {
 }
 
 type InMessage =
-  | { t: 'init'; modelsDir: string }
+  | { t: 'init'; modelsDir: string; quality?: 'live' | 'final' }
   | { t: 'start'; channels: string[]; sessionId?: number }
   | AudioMessage
   | { t: 'stop'; sessionId?: number }
@@ -124,6 +125,15 @@ function download(url: string, dest: string, onPct: (pct: number) => void): Prom
 
 interface SherpaModule {
   OnlineRecognizer: new (config: unknown) => SherpaRecognizer
+  OfflineRecognizer: new (config: unknown) => SherpaOfflineRecognizer
+}
+interface SherpaOfflineStream {
+  acceptWaveform(obj: { samples: Float32Array; sampleRate: number }): void
+}
+interface SherpaOfflineRecognizer {
+  createStream(): SherpaOfflineStream
+  decode(stream: SherpaOfflineStream): void
+  getResult(stream: SherpaOfflineStream): { text: string }
 }
 interface SherpaStream {
   acceptWaveform(obj: { samples: Float32Array; sampleRate: number }): void
@@ -134,6 +144,25 @@ interface SherpaRecognizer {
   isReady(stream: SherpaStream): boolean
   decode(stream: SherpaStream): void
   getResult(stream: SherpaStream): { text: string; tokens?: string[]; timestamps?: number[] }
+}
+
+function createOnlineRecognizer(sherpa: SherpaModule, dir: string): SherpaRecognizer {
+  return new sherpa.OnlineRecognizer({
+    featConfig: { sampleRate: 16000, featureDim: 80 },
+    modelConfig: {
+      transducer: {
+        encoder: join(dir, 'encoder-epoch-99-avg-1-chunk-16-left-128.int8.onnx'),
+        decoder: join(dir, 'decoder-epoch-99-avg-1-chunk-16-left-128.onnx'),
+        joiner: join(dir, 'joiner-epoch-99-avg-1-chunk-16-left-128.int8.onnx')
+      },
+      tokens: join(dir, 'tokens.txt'),
+      numThreads: 2,
+      provider: 'cpu',
+      modelType: 'zipformer2'
+    },
+    decodingMethod: 'greedy_search',
+    enableEndpoint: 0
+  })
 }
 
 class ChannelPipeline {
@@ -226,41 +255,59 @@ function joinedText(result: { text: string }): string {
 /* ---- session orchestration ---- */
 
 let recognizer: SherpaRecognizer | null = null
+let offlineRecognizer: SherpaOfflineRecognizer | null = null
+let quality: 'live' | 'final' = 'live'
 let pipelines = new Map<string, ChannelPipeline>()
+let offlineAudio = new Map<string, Float32Array[]>()
 let sessionActive = false
 let activeSessionId: number | null = null
 
-async function init(modelsDir: string): Promise<void> {
+async function init(modelsDir: string, requestedQuality: 'live' | 'final' = 'live'): Promise<void> {
   try {
-    const dir = await ensureModel(modelsDir)
+    quality = requestedQuality
+    const dir =
+      quality === 'final'
+        ? await ensureWindowsWhisperModel(modelsDir, (progress) =>
+            emit({ event: 'download', progress })
+          )
+        : await ensureModel(modelsDir)
     emit({ event: 'status', stage: 'serve_loading_models' })
     // Deferred require: the native addon must not load before it's needed.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const sherpa = require('sherpa-onnx-node') as SherpaModule
-    recognizer = new sherpa.OnlineRecognizer({
-      featConfig: { sampleRate: 16000, featureDim: 80 },
-      modelConfig: {
-        transducer: {
-          encoder: join(dir, 'encoder-epoch-99-avg-1-chunk-16-left-128.int8.onnx'),
-          decoder: join(dir, 'decoder-epoch-99-avg-1-chunk-16-left-128.onnx'),
-          joiner: join(dir, 'joiner-epoch-99-avg-1-chunk-16-left-128.int8.onnx')
-        },
-        tokens: join(dir, 'tokens.txt'),
-        numThreads: 2,
-        provider: 'cpu',
-        modelType: 'zipformer2'
-      },
-      decodingMethod: 'greedy_search',
-      enableEndpoint: 0
-    })
+    if (quality === 'final') {
+      offlineRecognizer = new sherpa.OfflineRecognizer({
+        featConfig: { sampleRate: 16000, featureDim: 80 },
+        modelConfig: {
+          whisper: {
+            encoder: join(dir, 'tiny.en-encoder.int8.onnx'),
+            decoder: join(dir, 'tiny.en-decoder.int8.onnx'),
+            language: 'en',
+            task: 'transcribe',
+            tailPaddings: -1
+          },
+          tokens: join(dir, 'tiny.en-tokens.txt'),
+          numThreads: 2,
+          provider: 'cpu',
+          debug: 0
+        }
+      })
+      recognizer = createOnlineRecognizer(sherpa, await ensureModel(modelsDir))
+    } else recognizer = createOnlineRecognizer(sherpa, dir)
     emit({ event: 'status', stage: 'serve_ready' })
   } catch (err) {
-    emit({ event: 'error', message: `engine init failed: ${String(err)}` })
+    emit({
+      event: 'error',
+      message:
+        quality === 'final'
+          ? 'The high-accuracy speech model could not be prepared. Check your connection and try again.'
+          : `engine init failed: ${String(err)}`
+    })
   }
 }
 
 function startSession(channels: string[], sessionId = 0): void {
-  if (!recognizer) {
+  if (quality === 'final' ? !offlineRecognizer : !recognizer) {
     emit({ event: 'error', message: 'engine is not ready yet' })
     emit({ event: 'done' })
     return
@@ -274,7 +321,8 @@ function startSession(channels: string[], sessionId = 0): void {
   pipelines = new Map(
     channels.map((channel) => [channel, new ChannelPipeline(channel, recognizer!)])
   )
-  emit({ event: 'ready', mode: 'live', channels })
+  offlineAudio = new Map(channels.map((channel) => [channel, []]))
+  emit({ event: 'ready', mode: quality, channels })
   emit({ event: 'status', stage: 'transcribing' })
 }
 
@@ -282,10 +330,40 @@ function stopSession(sessionId = 0): void {
   if (!sessionActive || activeSessionId !== sessionId) return
   sessionActive = false
   emit({ event: 'status', stage: 'finishing' })
-  for (const pipeline of pipelines.values()) {
-    pipeline.finish()
+  if (quality === 'final' && offlineRecognizer) {
+    for (const pipeline of pipelines.values()) pipeline.finish()
+    for (const [channel, chunks] of offlineAudio) {
+      const length = chunks.reduce((sum, chunk) => sum + chunk.length, 0)
+      const samples = new Float32Array(length)
+      let offset = 0
+      for (const chunk of chunks) {
+        samples.set(chunk, offset)
+        offset += chunk.length
+      }
+      if (samples.length === 0) continue
+      const text: string[] = []
+      for (const window of splitWhisperWindows(samples)) {
+        const stream = offlineRecognizer.createStream()
+        stream.acceptWaveform({
+          samples: window,
+          sampleRate: WINDOWS_ASR_SAMPLE_RATE
+        })
+        offlineRecognizer.decode(stream)
+        const windowText = joinedText(offlineRecognizer.getResult(stream))
+        if (windowText) text.push(windowText)
+      }
+      emit({
+        event: 'final',
+        channel,
+        text: text.join(' '),
+        audioSeconds: samples.length / WINDOWS_ASR_SAMPLE_RATE
+      })
+    }
+  } else {
+    for (const pipeline of pipelines.values()) pipeline.finish()
   }
   pipelines = new Map()
+  offlineAudio = new Map()
   activeSessionId = null
   emit({ event: 'done' })
 }
@@ -294,16 +372,16 @@ port.on('message', (message: Electron.MessageEvent) => {
   const data = message.data as InMessage
   switch (data.t) {
     case 'init':
-      void init(data.modelsDir)
+      void init(data.modelsDir, data.quality)
       break
     case 'start':
       startSession(data.channels, data.sessionId)
       break
     case 'audio': {
       if (sessionActive && activeSessionId === (data.sessionId ?? 0)) {
-        const pipeline = pipelines.get(data.channel)
-        if (pipeline && data.samples instanceof Float32Array && data.samples.length > 0) {
-          pipeline.ingest(data.samples)
+        if (data.samples instanceof Float32Array && data.samples.length > 0) {
+          pipelines.get(data.channel)?.ingest(data.samples)
+          if (quality === 'final') offlineAudio.get(data.channel)?.push(data.samples)
         }
       }
       if (typeof data.sequence === 'number') {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -398,6 +398,9 @@ app.whenReady().then(() => {
   if (engine instanceof WinEngineHost) {
     winBatchTranscriber = new WinBatchTranscriber((onEvent) => engine.preflight(onEvent))
     winBatchTranscriber.registerIpc()
+    engine.setFinalRefiner((filePath, onProgress) =>
+      winBatchTranscriber!.transcribe(filePath, onProgress)
+    )
   }
 
   // Audio import + re-transcription: batch engine runs in its own process,

--- a/apps/desktop/src/main/transcript-refinement.test.ts
+++ b/apps/desktop/src/main/transcript-refinement.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import type { TranscriptSegment } from '../shared/engine-events'
+import { reconcileChannelSegments, reconcileRefinedTranscript } from './transcript-refinement'
+
+function segment(
+  id: string,
+  channel: 'mic' | 'system',
+  text: string,
+  startMs: number,
+  extra: Partial<TranscriptSegment> = {}
+): TranscriptSegment {
+  return {
+    id,
+    channel,
+    speaker: channel === 'mic' ? 'Sean' : 'Alec',
+    speakerId: channel === 'mic' ? 'speaker:me' : 'speaker:them',
+    text,
+    startMs,
+    endMs: startMs + 2_000,
+    absoluteStartMs: 10_000 + startMs,
+    confidence: 0.75,
+    ...extra
+  }
+}
+
+test('corrects the reported substitution while preserving live timing and identity', () => {
+  const first = segment('seg_1', 'mic', 'THE VAUDE CONFIRMATION NUMBER IS SEVEN FOUR NINE', 0)
+  const second = segment('seg_2', 'mic', 'THEN STOP IMMEDIATELY', 4_000)
+
+  const result = reconcileChannelSegments([first, second], {
+    channel: 'mic',
+    text: 'The final confirmation number is 749, then stop immediately.'
+  })
+
+  assert.deepEqual(
+    result.map(({ id, text, startMs, absoluteStartMs, speaker }) => ({
+      id,
+      text,
+      startMs,
+      absoluteStartMs,
+      speaker
+    })),
+    [
+      {
+        id: 'seg_1',
+        text: 'The final confirmation number is 749,',
+        startMs: 0,
+        absoluteStartMs: 10_000,
+        speaker: 'Sean'
+      },
+      {
+        id: 'seg_2',
+        text: 'then stop immediately.',
+        startMs: 4_000,
+        absoluteStartMs: 14_000,
+        speaker: 'Sean'
+      }
+    ]
+  )
+})
+
+test('insertions and deletions stay near aligned live segment boundaries', () => {
+  const result = reconcileChannelSegments(
+    [segment('a', 'mic', 'alpha beta', 0), segment('b', 'mic', 'delta echo', 3_000)],
+    { channel: 'mic', text: 'Alpha beta gamma delta.' }
+  )
+  assert.deepEqual(
+    result.map((item) => [item.id, item.text]),
+    [
+      ['a', 'Alpha beta'],
+      ['b', 'gamma delta.']
+    ]
+  )
+})
+
+test('empty or failed refinement cannot erase a usable provisional transcript', () => {
+  const source = [segment('a', 'mic', 'keep this text', 0)]
+  assert.deepEqual(reconcileChannelSegments(source, { channel: 'mic', text: '  ' }), source)
+})
+
+test('both channels are replaced atomically and remain chronologically ordered', () => {
+  const source = [
+    segment('mic', 'mic', 'helo there', 1_000),
+    segment('system', 'system', 'good mornin', 0, { echo: false })
+  ]
+  const result = reconcileRefinedTranscript(source, [
+    { channel: 'mic', text: 'Hello there.' },
+    { channel: 'system', text: 'Good morning.' }
+  ])
+  assert.deepEqual(
+    result.map((item) => [item.id, item.text]),
+    [
+      ['system', 'Good morning.'],
+      ['mic', 'Hello there.']
+    ]
+  )
+})
+
+test('a final-only channel gets a bounded fallback segment', () => {
+  const result = reconcileChannelSegments([], {
+    channel: 'system',
+    text: 'A newly detected speaker.',
+    audioSeconds: 3.25
+  })
+  assert.deepEqual(result[0], {
+    id: 'refined_system_1',
+    channel: 'system',
+    speaker: 'Them',
+    speakerId: 'far',
+    text: 'A newly detected speaker.',
+    startMs: 0,
+    endMs: 3250,
+    confidence: 0.9
+  })
+})

--- a/apps/desktop/src/main/transcript-refinement.ts
+++ b/apps/desktop/src/main/transcript-refinement.ts
@@ -1,0 +1,150 @@
+import { defaultSpeakerId, defaultSpeakerLabel } from '@repo/meetings-store'
+import type { EngineChannel, TranscriptSegment } from '../shared/engine-events'
+
+export interface RefinedChannelText {
+  channel: EngineChannel
+  text: string
+  audioSeconds?: number
+}
+
+interface WordSlot {
+  text: string
+  normalized: string
+  segmentIndex: number
+}
+
+function words(text: string): string[] {
+  return text.trim().match(/\S+/g) ?? []
+}
+
+function normalize(text: string): string {
+  return text.toLocaleLowerCase('en-US').replace(/[^a-z0-9']/g, '')
+}
+
+/**
+ * Align final-model words to the live transcript's segment boundaries.
+ * Whisper tiny.en does not expose word timestamps through sherpa-onnx, so the
+ * reliable live timings remain authoritative while its corrected words replace
+ * provisional text. Existing ids, speakers, echo flags and seek anchors survive.
+ */
+export function reconcileChannelSegments(
+  provisional: TranscriptSegment[],
+  refined: RefinedChannelText
+): TranscriptSegment[] {
+  const finalWords = words(refined.text)
+  if (finalWords.length === 0) return provisional
+
+  if (provisional.length === 0) {
+    const endMs = Math.max(0, Math.round((refined.audioSeconds ?? 0) * 1000))
+    return [
+      {
+        id: `refined_${refined.channel}_1`,
+        channel: refined.channel,
+        speaker: defaultSpeakerLabel(refined.channel),
+        speakerId: defaultSpeakerId(refined.channel),
+        text: finalWords.join(' '),
+        startMs: 0,
+        endMs,
+        confidence: 0.9
+      }
+    ]
+  }
+
+  const baseline: WordSlot[] = provisional.flatMap((segment, segmentIndex) =>
+    words(segment.text).map((text) => ({ text, normalized: normalize(text), segmentIndex }))
+  )
+  if (baseline.length === 0) return provisional
+
+  const candidate = finalWords.map((text) => ({ text, normalized: normalize(text) }))
+  const rows = baseline.length + 1
+  const cols = candidate.length + 1
+  const cost = Array.from({ length: rows }, () => new Uint32Array(cols))
+  for (let i = 0; i < rows; i++) cost[i]![0] = i
+  for (let j = 0; j < cols; j++) cost[0]![j] = j
+
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < cols; j++) {
+      const substitution =
+        cost[i - 1]![j - 1]! +
+        (baseline[i - 1]!.normalized === candidate[j - 1]!.normalized ? 0 : 1)
+      cost[i]![j] = Math.min(cost[i - 1]![j]! + 1, cost[i]![j - 1]! + 1, substitution)
+    }
+  }
+
+  const assignments = new Array<number | undefined>(candidate.length)
+  let i = baseline.length
+  let j = candidate.length
+  while (i > 0 || j > 0) {
+    const diagonal = i > 0 && j > 0 ? cost[i - 1]![j - 1]! : Number.POSITIVE_INFINITY
+    const substitution =
+      i > 0 && j > 0 && baseline[i - 1]!.normalized !== candidate[j - 1]!.normalized ? 1 : 0
+    if (i > 0 && j > 0 && cost[i]![j] === diagonal + substitution) {
+      assignments[j - 1] = baseline[i - 1]!.segmentIndex
+      i--
+      j--
+    } else if (j > 0 && cost[i]![j] === cost[i]![j - 1]! + 1) {
+      j--
+    } else {
+      i--
+    }
+  }
+
+  // Inserted words inherit the nearest aligned segment, preferring the word
+  // immediately before them so punctuation and short additions stay together.
+  let previous: number | undefined
+  for (let k = 0; k < assignments.length; k++) {
+    if (assignments[k] !== undefined) previous = assignments[k]
+    else if (previous !== undefined) assignments[k] = previous
+  }
+  let next: number | undefined
+  for (let k = assignments.length - 1; k >= 0; k--) {
+    if (assignments[k] !== undefined) next = assignments[k]
+    else if (next !== undefined) assignments[k] = next
+  }
+  for (let k = 0; k < assignments.length; k++) {
+    assignments[k] ??= Math.min(
+      provisional.length - 1,
+      Math.floor((k * provisional.length) / assignments.length)
+    )
+  }
+
+  const grouped = provisional.map(() => [] as string[])
+  for (let k = 0; k < candidate.length; k++) {
+    grouped[assignments[k]!]!.push(candidate[k]!.text)
+  }
+
+  return provisional.flatMap((segment, segmentIndex) => {
+    const text = grouped[segmentIndex]!.join(' ').trim()
+    return text.length > 0 ? [{ ...segment, text }] : []
+  })
+}
+
+export function reconcileRefinedTranscript(
+  provisional: TranscriptSegment[],
+  refined: RefinedChannelText[]
+): TranscriptSegment[] {
+  const replacements = new Map<string, TranscriptSegment>()
+  const removed = new Set<string>()
+  const additions: TranscriptSegment[] = []
+
+  for (const result of refined) {
+    const source = provisional.filter((segment) => segment.channel === result.channel)
+    const next = reconcileChannelSegments(source, result)
+    for (const segment of source) removed.add(segment.id)
+    for (const segment of next) {
+      if (source.some((existing) => existing.id === segment.id))
+        replacements.set(segment.id, segment)
+      else additions.push(segment)
+    }
+  }
+
+  return provisional
+    .filter((segment) => !removed.has(segment.id) || replacements.has(segment.id))
+    .map((segment) => replacements.get(segment.id) ?? segment)
+    .concat(additions)
+    .sort(
+      (a, b) =>
+        (a.absoluteStartMs ?? a.startMs) - (b.absoluteStartMs ?? b.startMs) ||
+        a.channel.localeCompare(b.channel)
+    )
+}

--- a/apps/desktop/src/main/transcript-session.test.ts
+++ b/apps/desktop/src/main/transcript-session.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import type { EngineEvent } from '../shared/engine-events'
+import { TranscriptSession } from './transcript-session'
+
+test('persists refined wording while preserving the live seek anchor', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'doodlenote-session-test-'))
+  const events: EngineEvent[] = []
+  try {
+    const session = new TranscriptSession((event) => events.push(event), dir)
+    session.handle({ event: 'started', command: 'live', binaryPath: 'test' })
+    session.handle({ event: 'channel_start', channel: 'mic', epochMs: 1_000_000 })
+    session.handle({
+      event: 'timings',
+      channel: 'mic',
+      tokens: 'THE VAUDE CONFIRMATION NUMBER IS SEVEN FOUR NINE'.split(' ').map((word, index) => ({
+        token: ` ${word}`,
+        startSec: index * 0.3,
+        endSec: index * 0.3 + 0.2,
+        confidence: 0.8
+      }))
+    })
+    session.handle({
+      event: 'refined',
+      transcripts: [
+        { channel: 'mic', text: 'The final confirmation number is 749.', audioSeconds: 3 }
+      ]
+    })
+    session.handle({ event: 'done' })
+
+    const replacement = events.find((event) => event.event === 'segments-replaced')
+    assert.ok(replacement && replacement.event === 'segments-replaced')
+    assert.equal(replacement.segments[0]!.text, 'The final confirmation number is 749.')
+    assert.equal(replacement.segments[0]!.startMs, 0)
+    assert.equal(replacement.segments[0]!.absoluteStartMs, 1_000_000)
+
+    const file = join(dir, readdirSync(dir)[0]!)
+    const saved = JSON.parse(readFileSync(file, 'utf8')) as {
+      finals: { mic: string }
+      segments: Array<{ text: string; startMs: number }>
+    }
+    assert.equal(saved.finals.mic, 'The final confirmation number is 749.')
+    assert.equal(saved.segments[0]!.text, 'The final confirmation number is 749.')
+    assert.equal(saved.segments[0]!.startMs, 0)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/apps/desktop/src/main/transcript-session.ts
+++ b/apps/desktop/src/main/transcript-session.ts
@@ -2,6 +2,7 @@ import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type { EngineChannel, EngineEvent, TranscriptSegment } from '../shared/engine-events'
 import { SegmentAssembler } from './segmenter'
+import { reconcileRefinedTranscript } from './transcript-refinement'
 
 /**
  * Owns one live capture session: feeds engine timings through the
@@ -46,6 +47,14 @@ export class TranscriptSession {
         if (this.assembler && ev.channel) {
           this.finals[ev.channel] = ev.text
           this.publish(this.assembler.flush(ev.channel))
+        }
+        return
+      case 'refined':
+        if (this.assembler) {
+          this.publish(this.assembler.flush())
+          this.segments = reconcileRefinedTranscript(this.segments, ev.transcripts)
+          for (const transcript of ev.transcripts) this.finals[transcript.channel] = transcript.text
+          this.broadcast({ event: 'segments-replaced', segments: this.segments })
         }
         return
       case 'done':

--- a/apps/desktop/src/main/win-batch-transcriber.ts
+++ b/apps/desktop/src/main/win-batch-transcriber.ts
@@ -14,6 +14,7 @@ import {
 import type { WizardPreflightEvent, WizardPreflightResult } from '../shared/wizard-api'
 import type { BatchProgress, BatchTranscription } from './import-logic'
 import { SegmentAssembler } from './segmenter'
+import { reconcileRefinedTranscript } from './transcript-refinement'
 
 const TIMEOUT_MS = 30 * 60_000
 /** Chromium decodes the complete file in memory; this still covers hours of compressed audio. */
@@ -26,6 +27,7 @@ interface ActiveJob {
   child: UtilityProcess
   assembler: SegmentAssembler
   segments: TranscriptSegment[]
+  finals: Map<EngineChannel, { text: string; audioSeconds: number }>
   audioSeconds: number
   started: boolean
   settled: boolean
@@ -127,6 +129,7 @@ export class WinBatchTranscriber {
       child,
       assembler: new SegmentAssembler(),
       segments: [],
+      finals: new Map(),
       audioSeconds: 0,
       started: false,
       settled: false,
@@ -161,10 +164,18 @@ export class WinBatchTranscriber {
         this.finish(job, new Error('The Windows import engine stopped unexpectedly.'))
       }
     })
-    child.postMessage({ t: 'init', modelsDir: join(app.getPath('userData'), 'asr-models') })
+    child.postMessage({
+      t: 'init',
+      modelsDir: join(app.getPath('userData'), 'asr-models'),
+      quality: 'final'
+    })
   }
 
   private handleEngineEvent(job: ActiveJob, event: Record<string, unknown>): void {
+    if (event.event === 'download' && typeof event.progress === 'number') {
+      job.onProgress?.({ stage: 'downloading_model', progress: event.progress })
+      return
+    }
     if (event.event === 'status' && event.stage === 'serve_ready') {
       const window = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]
       if (!window || window.isDestroyed()) {
@@ -194,6 +205,15 @@ export class WinBatchTranscriber {
     }
     if (event.event === 'final' && typeof event.channel === 'string') {
       job.segments.push(...job.assembler.flush(event.channel as EngineChannel))
+      const channel = event.channel as EngineChannel
+      const text = typeof event.text === 'string' ? event.text.trim() : ''
+      if (text) {
+        job.finals.set(channel, {
+          text,
+          audioSeconds:
+            typeof event.audioSeconds === 'number' ? event.audioSeconds : job.audioSeconds
+        })
+      }
       return
     }
     if (event.event === 'error') {
@@ -255,6 +275,12 @@ export class WinBatchTranscriber {
       return
     }
     job.segments.push(...job.assembler.flush())
+    if (job.finals.size > 0) {
+      job.segments = reconcileRefinedTranscript(
+        job.segments,
+        [...job.finals].map(([channel, result]) => ({ channel, ...result }))
+      )
+    }
     job.segments.sort((a, b) => a.startMs - b.startMs)
     job.resolve({ segments: job.segments, audioSeconds: job.audioSeconds })
   }

--- a/apps/desktop/src/main/windows-whisper-model.test.ts
+++ b/apps/desktop/src/main/windows-whisper-model.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { modelFilesMatch, splitWhisperWindows } from './windows-whisper-model'
+
+test('modelFilesMatch requires every file at its exact expected size', () => {
+  const root = mkdtempSync(join(tmpdir(), 'doodlenote-whisper-test-'))
+  const model = join(root, 'model')
+  mkdirSync(model)
+  try {
+    writeFileSync(join(model, 'encoder.onnx'), Buffer.alloc(3))
+    writeFileSync(join(model, 'decoder.onnx'), Buffer.alloc(4))
+    const expected = { 'encoder.onnx': 3, 'decoder.onnx': 4 }
+    assert.equal(modelFilesMatch(model, expected), true)
+    writeFileSync(join(model, 'decoder.onnx'), Buffer.alloc(5))
+    assert.equal(modelFilesMatch(model, expected), false)
+    rmSync(join(model, 'encoder.onnx'))
+    assert.equal(modelFilesMatch(model, expected), false)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('long recordings are split below the Whisper hard limit without dropping their ending', () => {
+  const samples = Float32Array.from({ length: 27 }, (_, index) => index)
+  const windows = splitWhisperWindows(samples, 10)
+  assert.deepEqual(
+    windows.map((window) => [...window]),
+    [
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+      [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+      [20, 21, 22, 23, 24, 25, 26]
+    ]
+  )
+})

--- a/apps/desktop/src/main/windows-whisper-model.ts
+++ b/apps/desktop/src/main/windows-whisper-model.ts
@@ -1,0 +1,158 @@
+import { createHash, randomUUID } from 'node:crypto'
+import {
+  createReadStream,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  statSync
+} from 'node:fs'
+import { get as httpsGet } from 'node:https'
+import { join } from 'node:path'
+import { spawn } from 'node:child_process'
+
+export const WINDOWS_WHISPER_MODEL = 'sherpa-onnx-whisper-tiny.en'
+const MODEL_URL = `https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/${WINDOWS_WHISPER_MODEL}.tar.bz2`
+const ARCHIVE_SHA256 = '2bd6cf965c8bb3e068ef9fa2191387ee63a9dfa2a4e37582a8109641c20005dd'
+
+export const WINDOWS_WHISPER_FILES = {
+  'tiny.en-decoder.int8.onnx': 89_853_865,
+  'tiny.en-encoder.int8.onnx': 12_937_772,
+  'tiny.en-tokens.txt': 835_554
+} as const
+
+/** Sherpa's Whisper backend accepts less than 30 seconds per stream. */
+export function splitWhisperWindows(
+  samples: Float32Array,
+  windowSamples = 25 * 16_000
+): Float32Array[] {
+  if (windowSamples <= 0) throw new Error('Whisper window size must be positive.')
+  const windows: Float32Array[] = []
+  for (let start = 0; start < samples.length; start += windowSamples) {
+    windows.push(samples.subarray(start, start + windowSamples))
+  }
+  return windows
+}
+
+export function modelFilesMatch(
+  dir: string,
+  expected: Readonly<Record<string, number>> = WINDOWS_WHISPER_FILES
+): boolean {
+  return Object.entries(expected).every(([name, size]) => {
+    try {
+      return statSync(join(dir, name)).size === size
+    } catch {
+      return false
+    }
+  })
+}
+
+async function sha256(path: string): Promise<string> {
+  const hash = createHash('sha256')
+  for await (const chunk of createReadStream(path)) hash.update(chunk as Buffer)
+  return hash.digest('hex')
+}
+
+function downloadResumable(
+  url: string,
+  path: string,
+  onProgress: (progress: number) => void
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const follow = (target: string, redirects: number): void => {
+      if (redirects > 5) return reject(new Error('Too many model download redirects.'))
+      const existing = existsSync(path) ? statSync(path).size : 0
+      const request = httpsGet(
+        target,
+        existing > 0 ? { headers: { Range: `bytes=${existing}-` } } : {},
+        (response) => {
+          if (
+            response.statusCode &&
+            response.statusCode >= 300 &&
+            response.statusCode < 400 &&
+            response.headers.location
+          ) {
+            response.resume()
+            follow(new URL(response.headers.location, target).toString(), redirects + 1)
+            return
+          }
+          if (response.statusCode === 416 && existing > 0) {
+            response.resume()
+            resolve()
+            return
+          }
+          if (response.statusCode !== 200 && response.statusCode !== 206) {
+            response.resume()
+            reject(new Error(`Model download failed (HTTP ${response.statusCode ?? 'unknown'}).`))
+            return
+          }
+          const resumed = response.statusCode === 206
+          const offset = resumed ? existing : 0
+          const remaining = Number(response.headers['content-length'] ?? 0)
+          const total = offset + remaining
+          let received = offset
+          const output = createWriteStream(path, { flags: resumed ? 'a' : 'w' })
+          response.on('data', (chunk: Buffer) => {
+            received += chunk.length
+            if (total > 0) onProgress(Math.min(1, received / total))
+          })
+          response.on('error', reject)
+          output.on('error', reject)
+          output.on('finish', () => output.close(() => resolve()))
+          response.pipe(output)
+        }
+      )
+      request.setTimeout(60_000, () =>
+        request.destroy(new Error('The speech model download timed out. Please try again.'))
+      )
+      request.on('error', reject)
+    }
+    follow(url, 0)
+  })
+}
+
+function extract(archive: string, destination: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tar = spawn('tar', ['-xjf', archive, '-C', destination], { windowsHide: true })
+    tar.on('error', reject)
+    tar.on('exit', (code) =>
+      code === 0 ? resolve() : reject(new Error('The speech model could not be unpacked.'))
+    )
+  })
+}
+
+/** Download, verify, and atomically install the int8 English final-pass model. */
+export async function ensureWindowsWhisperModel(
+  modelsDir: string,
+  onProgress: (progress: number) => void
+): Promise<string> {
+  const target = join(modelsDir, WINDOWS_WHISPER_MODEL)
+  if (modelFilesMatch(target)) return target
+
+  mkdirSync(modelsDir, { recursive: true })
+  const partial = join(modelsDir, `${WINDOWS_WHISPER_MODEL}.tar.bz2.partial`)
+  await downloadResumable(MODEL_URL, partial, onProgress)
+  if ((await sha256(partial)) !== ARCHIVE_SHA256) {
+    rmSync(partial, { force: true })
+    throw new Error('The downloaded speech model failed verification. Please try again.')
+  }
+
+  const staging = join(modelsDir, `.${WINDOWS_WHISPER_MODEL}-${randomUUID()}`)
+  mkdirSync(staging, { recursive: true })
+  try {
+    await extract(partial, staging)
+    const extracted = join(staging, WINDOWS_WHISPER_MODEL)
+    if (!modelFilesMatch(extracted)) {
+      throw new Error('The speech model is incomplete. Please try again.')
+    }
+    rmSync(join(extracted, 'tiny.en-decoder.onnx'), { force: true })
+    rmSync(join(extracted, 'tiny.en-encoder.onnx'), { force: true })
+    rmSync(target, { recursive: true, force: true })
+    renameSync(extracted, target)
+    rmSync(partial, { force: true })
+    return target
+  } finally {
+    rmSync(staging, { recursive: true, force: true })
+  }
+}

--- a/apps/desktop/src/renderer/src/DevConsole.tsx
+++ b/apps/desktop/src/renderer/src/DevConsole.tsx
@@ -154,11 +154,26 @@ function reducer(state: ConsoleState, ev: EngineEvent): ConsoleState {
         statusKind: 'done',
         statusText: 'done'
       }
+    case 'refined':
+      return {
+        ...base,
+        liveFinals: Object.fromEntries(ev.transcripts.map((item) => [item.channel, item.text])),
+        statusKind: 'busy',
+        statusText: 'high-accuracy transcript ready'
+      }
     case 'segments': {
       const kept = ev.segments.filter((s) => !s.echo)
       const echoDropped = ev.segments.length - kept.length
       const merged = [...base.segments, ...kept].sort((a, b) => segmentTime(a) - segmentTime(b))
       return { ...base, segments: merged, echoCount: base.echoCount + echoDropped }
+    }
+    case 'segments-replaced': {
+      const kept = ev.segments.filter((s) => !s.echo)
+      return {
+        ...base,
+        segments: kept.sort((a, b) => segmentTime(a) - segmentTime(b)),
+        echoCount: ev.segments.length - kept.length
+      }
     }
     case 'session-saved':
       return {

--- a/apps/desktop/src/renderer/src/MeetingView.tsx
+++ b/apps/desktop/src/renderer/src/MeetingView.tsx
@@ -113,6 +113,9 @@ function sessionReducer(state: SessionState, ev: EngineEvent): SessionState {
       if (ev.stage === 'finishing' || ev.stage === 'saving_audio') {
         return { ...state, phase: 'finishing', statusText: 'Finishing up…' }
       }
+      if (ev.stage === 'refining_transcript') {
+        return { ...state, phase: 'finishing', statusText: 'Improving transcript locally…' }
+      }
       return { ...state, statusText: (ev.stage ?? 'working').replace(/_/g, ' ') }
     }
     case 'ready':
@@ -134,6 +137,16 @@ function sessionReducer(state: SessionState, ev: EngineEvent): SessionState {
       const merged = [...state.segments, ...kept].sort((a, b) => segmentTime(a) - segmentTime(b))
       return { ...state, segments: merged, echoCount: state.echoCount + echoDropped }
     }
+    case 'segments-replaced': {
+      if (!active) return state
+      const kept = ev.segments.filter((s) => !s.echo)
+      return {
+        ...state,
+        segments: kept.sort((a, b) => segmentTime(a) - segmentTime(b)),
+        echoCount: ev.segments.length - kept.length,
+        partials: {}
+      }
+    }
     case 'final':
       if (!active || !ev.channel) return state
       return {
@@ -145,6 +158,12 @@ function sessionReducer(state: SessionState, ev: EngineEvent): SessionState {
     case 'done':
       if (!active) return state
       return { ...state, phase: 'ended', statusText: '', partials: {} }
+    case 'download':
+      if (state.phase !== 'finishing') return state
+      return {
+        ...state,
+        statusText: `Preparing accurate transcript… ${Math.round(ev.progress * 100)}%`
+      }
     case 'session-saved':
       if (!active && state.phase !== 'ended') return state
       return { ...state, phase: 'ended', statusText: '', partials: {} }

--- a/apps/desktop/src/shared/engine-events.ts
+++ b/apps/desktop/src/shared/engine-events.ts
@@ -159,6 +159,12 @@ export interface EngineFinalEvent {
   tokens?: EngineTokenTiming[]
 }
 
+/** Windows: high-accuracy local text for each channel after live capture stops. */
+export interface EngineRefinedEvent {
+  event: 'refined'
+  transcripts: Array<{ channel: EngineChannel; text: string; audioSeconds?: number }>
+}
+
 export interface EngineErrorEvent {
   event: 'error'
   message: string
@@ -194,6 +200,7 @@ export type EngineSidecarEvent =
   | EnginePartialEvent
   | EngineTimingsEvent
   | EngineFinalEvent
+  | EngineRefinedEvent
   | EngineErrorEvent
   | EngineDoneEvent
   | EngineChannelStartEvent
@@ -246,11 +253,18 @@ export interface EngineSessionSavedEvent {
   segmentCount: number
 }
 
+/** Atomic replacement of the provisional live segments after local refinement. */
+export interface EngineSegmentsReplacedEvent {
+  event: 'segments-replaced'
+  segments: TranscriptSegment[]
+}
+
 export type EngineLifecycleEvent =
   | EngineStartedEvent
   | EngineSpawnErrorEvent
   | EngineExitEvent
   | EngineSegmentsEvent
+  | EngineSegmentsReplacedEvent
   | EngineSessionSavedEvent
 
 /** Everything the renderer can receive on ENGINE_EVENT_CHANNEL. */

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,15 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.21",
+    date: "September 4, 2026",
+    highlights: [
+      "Improve Windows transcript accuracy with a private, on-device final pass after recording",
+      "Keep live captions, speaker labels, timestamps, and saved audio while the final wording is refined",
+      "Use the same higher-accuracy Windows transcription path for imported recordings",
+    ],
+  },
+  {
     version: "0.4.20",
     date: "September 4, 2026",
     highlights: [


### PR DESCRIPTION
## Summary

Windows keeps the low-latency streaming Zipformer captions during recording, then runs a fully local Whisper tiny.en int8 pass after Stop and atomically reconciles the final wording onto the existing segment IDs, speakers, timestamps, echo flags, and playback anchors. The same hybrid timing + final-quality path now serves Windows imports and Re-transcribe. A refinement or model failure keeps the provisional transcript.

Fixes ONY-231.

## Affected surfaces

Windows desktop engine host and worker, batch transcription, transcript persistence/event contract, recording progress UI, Windows beta version 0.4.21, and the web changelog. macOS behavior is unchanged.

## Verification

- [x] Tests added or updated where behavior changed
- [x] Relevant typechecks/tests pass locally
- [ ] Visual changes include screenshots or a recording

- Desktop tests: 159 run; 154 passed; 5 expected native-fixture skips; 0 failed
- Node and renderer TypeScript checks passed
- Changed desktop files passed ESLint; production Electron build passed
- Native Electron utility-process smoke emitted live timings, provisional “VAUDE,” then final “The final confirmation number is 749, then stop immediately.”
- Five synthetic English fixtures (64 normalized words: names, email, numbers, business speech): streaming baseline 15 errors / 23.4% WER; tiny.en final 5 errors / 7.8% WER
- Reported 17.4s Windows sample: final pass 0.9–1.3s on this CPU; native-process RSS measured 186.7 MiB after model load and 346.8 MiB after decode
- A 224.4s synthetic recording ran as nine bounded windows and reached the final marker; Sherpa’s under-30-second Whisper input limit is handled explicitly
- Model archive SHA-256 is pinned; required int8 asset sizes are checked; partial downloads resume; unused full-precision weights are deleted
- Packaged candidate: DoodleNote-0.4.21-setup.exe, 178,830,804 bytes, SHA-256 E94C84FC734EE5F4E5E1295D7288CD84D37CE411002B82576050FAE8E18970A0

## Privacy, compatibility, and release impact

All audio and recognition remain local. No recording bytes or transcript content are uploaded. The high-accuracy model downloads lazily on the first final pass, is cached under app data, and reports bounded progress. The installer is an unsigned Windows beta candidate, consistent with the current Windows packaging configuration; it has not been published to the updater feed.

- [x] No real meeting content, credentials, tokens, signing files, or personal data are included
- [x] Documentation reflects any setup, permissions, or behavior changes
- [x] Unfinished functionality remains gated from release builds

## Follow-up

Physical Windows QA should cover the reported phrase, varied microphones and speech, both channels, immediate Stop, longer meetings, import/Re-transcribe, offline model failure, playback seeking, notes, export, and sync before merge or updater publication.