### PR TITLE
[ONY-231] Finish Windows recordings before refining transcripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Build Windows installer
         run: pnpm --filter desktop package:win
 
+      - name: Test recorder with packaged Electron runtime
+        run: node apps/desktop/scripts/test-electron-runtime.cjs apps/desktop/release/win-unpacked/DoodleNote.exe
+
       - name: Smoke packaged Windows native modules
         shell: pwsh
         run: |

--- a/apps/desktop/scripts/smoke-windows-refinement.cjs
+++ b/apps/desktop/scripts/smoke-windows-refinement.cjs
@@ -1,0 +1,123 @@
+// Run against a packaged app with synthetic speech and an isolated profile.
+// Requires Playwright 1.62.1 (set DOODLE_PLAYWRIGHT_MODULE for an external install).
+const { _electron } = require(process.env.DOODLE_PLAYWRIGHT_MODULE || 'playwright')
+const fs = require('node:fs')
+const path = require('node:path')
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+
+async function main() {
+  const [executable, models, speech, expected] = process.argv.slice(2)
+  if (!executable || !models || !speech || !expected) {
+    throw new Error(
+      'Usage: node smoke-windows-refinement.cjs <exe> <models-dir> <synthetic.wav> <expected phrase>'
+    )
+  }
+  const profile = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'doodlenote-release-qa-'))
+  fs.cpSync(path.resolve(models), path.join(profile, 'asr-models'), { recursive: true })
+  const env = { ...process.env }
+  delete env.ELECTRON_RUN_AS_NODE
+  const electron = await _electron.launch({
+    executablePath: path.resolve(executable),
+    args: [
+      `--user-data-dir=${profile}`,
+      '--use-fake-ui-for-media-stream',
+      '--use-fake-device-for-media-stream',
+      `--use-file-for-fake-audio-capture=${path.resolve(speech)}%noloop`
+    ],
+    env,
+    timeout: 60000
+  })
+  try {
+    const actual = await electron.evaluate(({ app, BrowserWindow }) => {
+      for (const window of BrowserWindow.getAllWindows())
+        window.webContents.setBackgroundThrottling(false)
+      return {
+        profile: app.getPath('userData'),
+        version: app.getVersion(),
+        packaged: app.isPackaged
+      }
+    })
+    assert.equal(
+      path.resolve(actual.profile),
+      path.resolve(profile),
+      'QA must use an isolated profile'
+    )
+    assert.equal(actual.packaged, true, 'Use the packaged application')
+    const page = await electron.firstWindow()
+    await page.evaluate(() => {
+      localStorage.setItem('doodle-setup-wizard-done', '1')
+      localStorage.setItem('doodle-onboarding-done', '1')
+    })
+    await page.reload()
+    await page.bringToFront()
+    await page.locator('body').click({ position: { x: 400, y: 100 } })
+    const events = await page.evaluate(async () => {
+      const ready = await window.wizard.runPreflight()
+      if (!ready.ok) throw new Error('Live model preflight failed')
+      return new Promise((resolve, reject) => {
+        const events = []
+        const timeout = setTimeout(() => reject(new Error('Refinement timed out')), 120000)
+        const unsubscribe = window.engine.onEvent((event) => {
+          events.push(event)
+          if (event.event === 'ready' && event.mode === 'live')
+            setTimeout(() => window.engine.stop(), 12000)
+          if (event.event === 'exit') {
+            clearTimeout(timeout)
+            unsubscribe()
+            resolve(events)
+          }
+        })
+        window.engine.start('live', undefined, {
+          source: 'mic',
+          meetingId: 'synthetic-release-qa',
+          persistAudio: true
+        })
+      })
+    })
+    assert.ok(
+      events.some((event) => event.event === 'partial'),
+      'Live captions must be available'
+    )
+    assert.ok(
+      events.some((event) => event.event === 'audio'),
+      'Recorded audio must finalize'
+    )
+    assert.ok(
+      events.some((event) => event.event === 'refined'),
+      'Final refinement must execute'
+    )
+    assert.ok(
+      events.some((event) => event.event === 'segments-replaced'),
+      'Final transcript must replace provisional text'
+    )
+    assert.equal(events.filter((event) => event.event === 'error').length, 0)
+    const text = events
+      .filter((event) => event.event === 'refined')
+      .flatMap((event) => event.transcripts.map((t) => t.text))
+      .join(' ')
+    assert.ok(
+      text.toLowerCase().includes(expected.toLowerCase()),
+      'Expected synthetic phrase must survive refinement'
+    )
+    const sessions = path.join(profile, 'sessions')
+    assert.ok(
+      fs.readdirSync(sessions).some((name) => name.endsWith('.json')),
+      'Final transcript must persist'
+    )
+    console.log(`Packaged Windows capture/refinement passed: ${actual.version}`)
+    console.log(`Isolated QA evidence: ${profile}`)
+  } finally {
+    // Terminate only this test process tree, including native model workers.
+    spawnSync('taskkill', ['/PID', String(electron.process().pid), '/T', '/F'], {
+      windowsHide: true
+    })
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/apps/desktop/scripts/test-electron-runtime.cjs
+++ b/apps/desktop/scripts/test-electron-runtime.cjs
@@ -1,0 +1,21 @@
+// Run filesystem regressions with the runtime users receive. Host Node and
+// Electron do not always have identical Windows file deletion behavior.
+const { spawnSync } = require('node:child_process')
+const { resolve } = require('node:path')
+const executable = process.argv[2] ? resolve(process.argv[2]) : require('electron')
+const result = spawnSync(
+  executable,
+  ['--import', 'tsx', '--test', 'src/main/win-audio-recorder.test.ts'],
+  {
+    cwd: resolve(__dirname, '..'),
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    encoding: 'utf8',
+    windowsHide: true,
+    timeout: 60_000
+  }
+)
+process.stdout.write(result.stdout ?? '')
+process.stderr.write(result.stderr ?? '')
+if (result.error) console.error(result.error.message)
+if (result.status !== 0 || result.error) process.exit(1)
+console.log('Electron recorder regression checks passed')

--- a/apps/desktop/src/main/audio-recovery.test.ts
+++ b/apps/desktop/src/main/audio-recovery.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { WinSessionRecorder } from './win-audio-recorder'
+
+test(
+  'startup recovery leaves active capture alone while recovering a crashed session',
+  { skip: process.platform !== 'win32' },
+  async () => {
+    const { AudioService } = await import('./audio-service')
+    const root = mkdtempSync(join(tmpdir(), 'audio-recovery-test-'))
+    const service = new AudioService(root, '')
+    const activeDir = service.beginSession('active-meeting')!
+    const active = new WinSessionRecorder(activeDir)
+    const orphanDir = join(root, 'crashed-meeting', '1000')
+    const orphan = new WinSessionRecorder(orphanDir)
+    try {
+      active.write('mic', new Float32Array(16000).fill(0.2))
+      orphan.write('mic', new Float32Array(16000).fill(0.1))
+      orphan.abort()
+      await service.recoverOrphans()
+      assert.equal(existsSync(join(activeDir, 'audio.wav')), false)
+      assert.equal(existsSync(join(activeDir, 'checkpoints', 'mic-000001.f32')), true)
+      assert.equal(service.list('crashed-meeting').length, 1)
+      active.write('mic', new Float32Array(16000).fill(0.3))
+      const saved = await active.finish()
+      assert.equal(saved?.durationMs, 2000)
+    } finally {
+      active.abort()
+      orphan.abort()
+      rmSync(root, { recursive: true, force: true })
+    }
+  }
+)

--- a/apps/desktop/src/main/audio-service.ts
+++ b/apps/desktop/src/main/audio-service.ts
@@ -320,6 +320,9 @@ export class AudioService {
       for (const session of sessions) {
         if (!SAFE_SESSION_DIR.test(session)) continue
         const dir = join(this.baseDir, meeting, session)
+        // The delayed startup scan can run after the user begins recording.
+        // Its open checkpoints belong to the live host, not crash recovery.
+        if (dir === this.activeSessionDir) continue
         if (audioFileIn(dir) !== null) continue
         const checkpoints = join(dir, 'checkpoints')
         let chunkCount = 0
@@ -339,6 +342,7 @@ export class AudioService {
       }
     }
     for (const dir of orphans) {
+      if (dir === this.activeSessionDir) continue
       console.log('[audio] recovering crashed session:', dir)
       // Windows sessions checkpoint raw PCM (merged in-process); macOS
       // sessions checkpoint CAF (merged by the Swift engine binary).

--- a/apps/desktop/src/main/win-audio-recorder.test.ts
+++ b/apps/desktop/src/main/win-audio-recorder.test.ts
@@ -138,6 +138,21 @@ test('empty / missing session dirs merge to null', async () => {
   }
 })
 
+test('system-only recording retains the right channel for batch speaker attribution', async () => {
+  const dir = tempDir('system-only')
+  try {
+    const recorder = new WinSessionRecorder(dir)
+    recorder.write('system', frames(0.25, 16_000))
+    assert.ok(await recorder.finish())
+    const wav = readWav(join(dir, 'audio.wav'))
+    assert.equal(wav.channels, 2)
+    assert.equal(wav.sample(100, 0), 0)
+    assert.ok(Math.abs(wav.sample(100, 1) - 0.25) < 0.001)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('clipping: out-of-range floats clamp instead of wrapping', async () => {
   const dir = tempDir('clip')
   try {

--- a/apps/desktop/src/main/win-audio-recorder.ts
+++ b/apps/desktop/src/main/win-audio-recorder.ts
@@ -158,6 +158,11 @@ export async function mergeWinSession(dir: string): Promise<WinMergedAudio | nul
     chunksByChannel.set(match[1]!, list)
   }
   if (chunksByChannel.size === 0) return null
+  // Batch decoding assigns mono to the microphone. Keep system audio on the
+  // right even when no microphone frames were captured.
+  if (chunksByChannel.has('system') && !chunksByChannel.has('mic')) {
+    chunksByChannel.set('mic', [])
+  }
 
   let epochs: Record<string, number> = {}
   try {
@@ -220,6 +225,10 @@ export async function mergeWinSession(dir: string): Promise<WinMergedAudio | nul
     }
   } finally {
     closeSync(fd)
+    // The final read can end exactly at the requested frame count, without
+    // another read returning EOF. Close every input before deleting chunks:
+    // Electron on Windows rejects deletion while those handles are open.
+    for (const reader of readers) reader.close()
   }
 
   rmSync(checkpointsDir, { recursive: true, force: true })
@@ -278,6 +287,13 @@ class ChannelChunkReader {
       }
     }
     this.totalFrames = frames
+  }
+
+  close(): void {
+    if (this.fd !== null) {
+      closeSync(this.fd)
+      this.fd = null
+    }
   }
 
   /** Fill the first `frames` entries of `target` (already zeroed). */


### PR DESCRIPTION
Windows could stop recording without reaching final transcript refinement: checkpoint file handles stayed open under Electron, so Windows refused cleanup. Close every reader before removing checkpoints. Also preserve system-only audio in the right channel and keep startup recovery from treating an active recording as a crashed session.

Related: https://linear.app/onyxdevlabs/issue/ONY-231/refine-windows-transcripts-with-high-accuracy-local-asr

Validation: the recorder tests reproduced four EPERM failures under the installed Electron runtime before the fix; all six now pass. The active-session recovery regression failed before the guard and passes afterward. Desktop TypeScript checks pass. A synthetic microphone test of the built app reached saved audio, Whisper refinement, transcript replacement, and persisted session data. Add a packaged-runtime CI check and reusable isolated-profile recording smoke script.

Release limitation: the synthetic sentence still misrecognized one digit. This verifies the recording/refinement flow, not broad transcription accuracy. Physical microphone, system-audio, long-meeting, and final packaged installer QA remain required. No real meeting data was used.