### PR TITLE
Recover stalled updates and prepare Windows beta 0.4.22

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "private": true,
   "description": "DoodleNote desktop app for privacy-first local capture, transcription, and AI meeting notes",
   "main": "./out/main/index.js",

--- a/apps/desktop/src/main/update-coordinator.test.ts
+++ b/apps/desktop/src/main/update-coordinator.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { UpdateCoordinator } from './update-coordinator'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: Error) => void
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes
+    reject = no
+  })
+  return { promise, resolve, reject }
+}
+
+test('stalled downloads cancel, preserve a readable error, and allow a successful retry', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  let download = deferred<string[]>()
+  let cancelled = 0
+  const token = {
+    cancel() {
+      cancelled++
+      download.reject(new Error('cancelled with private path'))
+    }
+  }
+  const updater = {
+    checkForUpdates: async () => ({
+      isUpdateAvailable: true,
+      updateInfo: { version: '0.4.22' },
+      cancellationToken: token
+    }),
+    downloadUpdate: () => download.promise
+  }
+  const controller = new UpdateCoordinator(updater, '0.4.21', true, () => {}, 100)
+  await controller.check()
+  assert.equal(controller.state.status, 'downloading')
+  t.mock.timers.tick(101)
+  await new Promise<void>((resolve) => setImmediate(resolve))
+  assert.equal(cancelled, 1)
+  assert.equal(controller.state.status, 'error')
+  assert.doesNotMatch(controller.state.error!, /private path/)
+  download = deferred<string[]>()
+  await controller.check()
+  controller.progress({ percent: 50, transferred: 100 })
+  download.resolve(['installer.exe'])
+  await new Promise<void>((resolve) => setImmediate(resolve))
+  assert.equal(controller.state.status, 'downloaded')
+  assert.equal(controller.state.percent, 100)
+})
+
+test('cancelled downloads ignore late progress and completion', async () => {
+  const download = deferred<string[]>()
+  const controller = new UpdateCoordinator(
+    {
+      checkForUpdates: async () => ({
+        isUpdateAvailable: true,
+        updateInfo: { version: '0.4.22' },
+        cancellationToken: { cancel() {} }
+      }),
+      downloadUpdate: () => download.promise
+    },
+    '0.4.21',
+    true,
+    () => {}
+  )
+  await controller.check()
+  controller.cancel()
+  controller.progress({ percent: 99, transferred: 999 })
+  download.resolve(['installer.exe'])
+  await new Promise<void>((resolve) => setImmediate(resolve))
+  assert.equal(controller.state.status, 'cancelled')
+})
+
+test('only actual byte progress extends the download deadline', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  const download = deferred<string[]>()
+  const controller = new UpdateCoordinator(
+    {
+      checkForUpdates: async () => ({
+        isUpdateAvailable: true,
+        updateInfo: { version: '0.4.22' },
+        cancellationToken: {
+          cancel() {
+            download.reject(new Error('cancelled'))
+          }
+        }
+      }),
+      downloadUpdate: () => download.promise
+    },
+    '0.4.21',
+    true,
+    () => {},
+    100
+  )
+  await controller.check()
+  t.mock.timers.tick(90)
+  controller.progress({ percent: 10, transferred: 100 })
+  t.mock.timers.tick(90)
+  assert.equal(controller.state.status, 'downloading')
+  controller.progress({ percent: 10, transferred: 100 })
+  t.mock.timers.tick(11)
+  assert.equal(controller.state.status, 'error')
+  await new Promise<void>((resolve) => setImmediate(resolve))
+})
+
+test('a timed-out metadata request cannot overwrite a newer check', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  const old = deferred<{ isUpdateAvailable: boolean; updateInfo: { version: string } }>()
+  let calls = 0
+  const controller = new UpdateCoordinator(
+    {
+      checkForUpdates: () =>
+        ++calls === 1
+          ? old.promise
+          : Promise.resolve({ isUpdateAvailable: false, updateInfo: { version: '0.4.21' } }),
+      downloadUpdate: async () => []
+    },
+    '0.4.21',
+    true,
+    () => {},
+    100
+  )
+  const checking = controller.check()
+  t.mock.timers.tick(101)
+  await checking
+  assert.equal(controller.state.status, 'error')
+  await controller.check()
+  old.resolve({ isUpdateAvailable: true, updateInfo: { version: '0.4.22' } })
+  await new Promise<void>((resolve) => setImmediate(resolve))
+  assert.equal(controller.state.status, 'up-to-date')
+  assert.equal(controller.state.latestVersion, undefined)
+})

--- a/apps/desktop/src/main/update-coordinator.test.ts
+++ b/apps/desktop/src/main/update-coordinator.test.ts
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { UpdateCoordinator } from './update-coordinator'
 
-function deferred<T>() {
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: Error) => void
+} {
   let resolve!: (value: T) => void
   let reject!: (error: Error) => void
   const promise = new Promise<T>((yes, no) => {
@@ -54,7 +58,11 @@ test('cancelled downloads ignore late progress and completion', async () => {
       checkForUpdates: async () => ({
         isUpdateAvailable: true,
         updateInfo: { version: '0.4.22' },
-        cancellationToken: { cancel() {} }
+        cancellationToken: {
+          cancel() {
+            /* Simulate a transport that finishes after cancellation. */
+          }
+        }
       }),
       downloadUpdate: () => download.promise
     },

--- a/apps/desktop/src/main/update-coordinator.ts
+++ b/apps/desktop/src/main/update-coordinator.ts
@@ -1,0 +1,120 @@
+import type { UpdateState } from '../shared/update-api'
+
+interface CheckResult<T> {
+  isUpdateAvailable?: boolean
+  updateInfo: { version: string }
+  cancellationToken?: T
+}
+
+export interface UpdateTransport<T extends { cancel(): void }> {
+  checkForUpdates(): Promise<CheckResult<T> | null>
+  downloadUpdate(token?: T): Promise<string[]>
+}
+
+/** Bounds checks and download inactivity; stale completions cannot reset newer UI state. */
+export class UpdateCoordinator<T extends { cancel(): void }> {
+  state: UpdateState
+  private generation = 0
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private download: Promise<void> | null = null
+  private cancelDownload: (() => void) | null = null
+  private transferred = 0
+
+  constructor(
+    private readonly updater: UpdateTransport<T>,
+    currentVersion: string,
+    supported: boolean,
+    private readonly changed: (state: UpdateState) => void,
+    private readonly timeoutMs = 90_000
+  ) {
+    this.state = { currentVersion, supported, status: 'idle' }
+  }
+
+  private set(patch: Partial<UpdateState>): void {
+    this.state = { ...this.state, ...patch }
+    this.changed(this.state)
+  }
+
+  private clearTimer(): void {
+    if (this.timer) clearTimeout(this.timer)
+    this.timer = null
+  }
+
+  async check(): Promise<UpdateState> {
+    if (
+      !this.state.supported ||
+      this.state.status === 'checking' ||
+      this.download ||
+      this.state.status === 'downloaded'
+    )
+      return this.state
+    const generation = ++this.generation
+    this.set({ status: 'checking', error: undefined, percent: undefined, latestVersion: undefined })
+    try {
+      const result = await Promise.race([
+        this.updater.checkForUpdates(),
+        new Promise<never>((_, reject) => {
+          this.timer = setTimeout(() => reject(new Error('timeout')), this.timeoutMs)
+        })
+      ])
+      if (generation !== this.generation) return this.state
+      this.clearTimer()
+      if (!result?.isUpdateAvailable) {
+        this.set({ status: 'up-to-date' })
+        return this.state
+      }
+      this.transferred = 0
+      this.cancelDownload = () => result.cancellationToken?.cancel()
+      this.set({ status: 'downloading', latestVersion: result.updateInfo.version, percent: 0 })
+      this.armDownloadTimeout()
+      this.download = this.updater
+        .downloadUpdate(result.cancellationToken)
+        .then(() => {
+          if (generation !== this.generation) return
+          this.clearTimer()
+          this.set({ status: 'downloaded', percent: 100, error: undefined })
+        })
+        .catch(() => {
+          if (generation !== this.generation) return
+          this.clearTimer()
+          this.set({ status: 'error', error: 'Could not download the update. Please try again.' })
+        })
+        .finally(() => {
+          this.download = null
+          this.cancelDownload = null
+        })
+    } catch {
+      if (generation !== this.generation) return this.state
+      this.clearTimer()
+      this.set({
+        status: 'error',
+        error: 'Could not check for updates. Check your connection and try again.'
+      })
+    }
+    return this.state
+  }
+
+  private armDownloadTimeout(): void {
+    this.clearTimer()
+    this.timer = setTimeout(() => {
+      this.cancel('error', 'The update download stopped responding. Please try again.')
+    }, this.timeoutMs)
+  }
+
+  progress(progress: { percent: number; transferred: number }): void {
+    if (this.state.status !== 'downloading') return
+    if (progress.transferred > this.transferred) {
+      this.transferred = progress.transferred
+      this.armDownloadTimeout()
+    }
+    this.set({ percent: Math.max(0, Math.min(100, Math.round(progress.percent))) })
+  }
+
+  cancel(status: 'cancelled' | 'error' = 'cancelled', error?: string): void {
+    if (this.state.status !== 'downloading') return
+    this.generation++
+    this.clearTimer()
+    this.cancelDownload?.()
+    this.set({ status, error, percent: undefined })
+  }
+}

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -2,22 +2,18 @@ import { app, ipcMain, Notification } from 'electron'
 import updaterPkg from 'electron-updater'
 import {
   UPDATE_CHECK_CHANNEL,
+  UPDATE_CANCEL_CHANNEL,
   UPDATE_GET_STATE_CHANNEL,
   UPDATE_INSTALL_CHANNEL,
-  UPDATE_STATE_EVENT_CHANNEL,
-  type UpdateState
+  UPDATE_STATE_EVENT_CHANNEL
 } from '../shared/update-api'
-import { applyUpdatePolicy, publicUpdateErrorMessage } from './update-policy'
+import { applyUpdatePolicy } from './update-policy'
+import { UpdateCoordinator } from './update-coordinator'
 
 const { autoUpdater } = updaterPkg
 
 const CHECK_INTERVAL_MS = 6 * 60 * 60_000
 
-let state: UpdateState = {
-  currentVersion: app.getVersion(),
-  supported: app.isPackaged,
-  status: 'idle'
-}
 let quittingForUpdate = false
 
 /**
@@ -42,12 +38,29 @@ export function initAutoUpdater(
    *  normal teardown (the llama addon SIGABRTs if a model is loaded). */
   beforeInstall?: () => Promise<void>
 ): void {
-  const setState = (patch: Partial<UpdateState>): void => {
-    state = { ...state, ...patch }
-    broadcast(UPDATE_STATE_EVENT_CHANNEL, state)
-  }
+  const coordinator = new UpdateCoordinator(
+    autoUpdater,
+    app.getVersion(),
+    app.isPackaged,
+    (state) => {
+      broadcast(UPDATE_STATE_EVENT_CHANNEL, state)
+      if (state.status !== 'downloaded') return
+      try {
+        if (!Notification.isSupported()) return
+        const notification = new Notification({
+          title: `DoodleNote ${state.latestVersion} is ready`,
+          body: 'Click to restart and update now.'
+        })
+        notification.on('click', () => void installNow())
+        notification.show()
+      } catch {
+        // Settings still offers Restart to update.
+      }
+    }
+  )
 
   const installNow = async (): Promise<void> => {
+    if (coordinator.state.status !== 'downloaded' || quittingForUpdate) return
     quittingForUpdate = true
     // The update quit must be a NORMAL quit (the installer takes over after
     // it), so the hard-exit workaround doesn't protect this path — unload
@@ -60,58 +73,27 @@ export function initAutoUpdater(
     autoUpdater.quitAndInstall()
   }
 
-  ipcMain.handle(UPDATE_GET_STATE_CHANNEL, () => state)
-  ipcMain.handle(UPDATE_CHECK_CHANNEL, async () => {
-    if (!app.isPackaged) return state
-    try {
-      await autoUpdater.checkForUpdates()
-    } catch {
-      // the error event already updated state
-    }
-    return state
-  })
+  ipcMain.handle(UPDATE_GET_STATE_CHANNEL, () => coordinator.state)
+  ipcMain.handle(UPDATE_CHECK_CHANNEL, () => coordinator.check())
+  ipcMain.handle(UPDATE_CANCEL_CHANNEL, () => coordinator.cancel())
   ipcMain.handle(UPDATE_INSTALL_CHANNEL, () => {
-    if (state.status !== 'downloaded') return
     void installNow()
   })
 
   if (!app.isPackaged) return
 
   applyUpdatePolicy(autoUpdater)
-  autoUpdater.autoDownload = true
-  autoUpdater.autoInstallOnAppQuit = true
+  autoUpdater.autoDownload = false
+  // Installation must use installNow so native models are unloaded first.
+  autoUpdater.autoInstallOnAppQuit = false
 
-  autoUpdater.on('checking-for-update', () => setState({ status: 'checking', error: undefined }))
-  autoUpdater.on('update-not-available', () => setState({ status: 'up-to-date' }))
-  autoUpdater.on('update-available', (info) =>
-    setState({ status: 'downloading', latestVersion: info.version, percent: 0 })
-  )
-  autoUpdater.on('download-progress', (progress) =>
-    setState({ status: 'downloading', percent: Math.round(progress.percent) })
-  )
-  autoUpdater.on('update-downloaded', (info) => {
-    setState({ status: 'downloaded', latestVersion: info.version, percent: 100 })
-    try {
-      if (!Notification.isSupported()) return
-      const notification = new Notification({
-        title: `DoodleNote ${info.version} is ready`,
-        body: 'Click to restart and update now.'
-      })
-      notification.on('click', () => {
-        void installNow()
-      })
-      notification.show()
-    } catch {
-      // Settings still offers Restart to update.
-    }
-  })
+  autoUpdater.on('download-progress', (progress) => coordinator.progress(progress))
   autoUpdater.on('error', (error) => {
     console.error('[updater]', error.message)
-    setState({ status: 'error', error: publicUpdateErrorMessage() })
   })
 
-  void autoUpdater.checkForUpdates().catch(() => {})
+  void coordinator.check()
   setInterval(() => {
-    void autoUpdater.checkForUpdates().catch(() => {})
+    void coordinator.check()
   }, CHECK_INTERVAL_MS).unref()
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -110,6 +110,7 @@ import {
 } from '../shared/integrations-api'
 import {
   UPDATE_CHECK_CHANNEL,
+  UPDATE_CANCEL_CHANNEL,
   UPDATE_GET_STATE_CHANNEL,
   UPDATE_INSTALL_CHANNEL,
   UPDATE_STATE_EVENT_CHANNEL,
@@ -459,6 +460,10 @@ const updateApi: UpdateApi = {
 
   check(): Promise<UpdateState> {
     return ipcRenderer.invoke(UPDATE_CHECK_CHANNEL) as Promise<UpdateState>
+  },
+
+  cancel(): Promise<void> {
+    return ipcRenderer.invoke(UPDATE_CANCEL_CHANNEL) as Promise<void>
   },
 
   install(): Promise<void> {

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -341,6 +341,8 @@ export default function ModelsView({
         return `v${u.latestVersion} is ready to install`
       case 'up-to-date':
         return 'You are on the latest version'
+      case 'cancelled':
+        return 'Download cancelled. You can try again.'
       case 'error':
         return u.error ?? 'Update check failed'
       default:
@@ -997,6 +999,14 @@ export default function ModelsView({
                       >
                         Restart to update
                       </button>
+                    ) : update?.status === 'downloading' ? (
+                      <button
+                        type="button"
+                        className="pill-btn"
+                        onClick={() => void window.updates.cancel()}
+                      >
+                        Cancel download
+                      </button>
                     ) : (
                       <button
                         type="button"
@@ -1004,12 +1014,13 @@ export default function ModelsView({
                         disabled={
                           checkPending ||
                           update?.supported === false ||
-                          update?.status === 'checking' ||
-                          update?.status === 'downloading'
+                          update?.status === 'checking'
                         }
                         onClick={() => void checkForUpdates()}
                       >
-                        Check for updates
+                        {update?.status === 'error' || update?.status === 'cancelled'
+                          ? 'Retry update'
+                          : 'Check for updates'}
                       </button>
                     )}
                   </div>

--- a/apps/desktop/src/shared/update-api.ts
+++ b/apps/desktop/src/shared/update-api.ts
@@ -1,6 +1,7 @@
 export const UPDATE_GET_STATE_CHANNEL = 'update:get-state'
 export const UPDATE_CHECK_CHANNEL = 'update:check'
 export const UPDATE_INSTALL_CHANNEL = 'update:install'
+export const UPDATE_CANCEL_CHANNEL = 'update:cancel'
 export const UPDATE_STATE_EVENT_CHANNEL = 'update:state-event'
 
 export interface UpdateState {
@@ -8,7 +9,7 @@ export interface UpdateState {
   currentVersion: string
   /** False in dev builds — the feed only serves packaged apps. */
   supported: boolean
-  status: 'idle' | 'checking' | 'up-to-date' | 'downloading' | 'downloaded' | 'error'
+  status: 'idle' | 'checking' | 'up-to-date' | 'downloading' | 'downloaded' | 'cancelled' | 'error'
   /** Version on the feed when newer than current. */
   latestVersion?: string
   /** Download progress 0-100 while status is "downloading". */
@@ -20,6 +21,7 @@ export interface UpdateApi {
   getState(): Promise<UpdateState>
   /** Manual "Check for updates". Resolves with the post-check state. */
   check(): Promise<UpdateState>
+  cancel(): Promise<void>
   /** Quit and install the downloaded update (status must be "downloaded"). */
   install(): Promise<void>
   onState(cb: (state: UpdateState) => void): () => void

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,15 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.22",
+    date: "September 5, 2026",
+    highlights: [
+      "Fix Windows recording finalization so the local transcript refinement pass can finish",
+      "Protect recordings started immediately after launch and preserve system-audio speaker labels",
+      "Cancel stalled update downloads and retry from Settings without exposing internal errors",
+    ],
+  },
+  {
     version: "0.4.21",
     date: "September 4, 2026",
     highlights: [

--- a/docs/WINDOWS-RELEASE-QA.md
+++ b/docs/WINDOWS-RELEASE-QA.md
@@ -1,0 +1,66 @@
+# Windows release acceptance
+
+The current delivery target is a Windows x64 beta. A working short transcript
+does not establish production readiness. Keep ONY-231 open until the installed
+candidate has passed the physical checks below.
+
+## Automated recording smoke
+
+Run recorder regressions with the actual Electron runtime:
+
+```sh
+node apps/desktop/scripts/test-electron-runtime.cjs apps/desktop/release/win-unpacked/DoodleNote.exe
+```
+
+For end-to-end capture, install Playwright 1.62.1 separately and set
+`DOODLE_PLAYWRIGHT_MODULE` to its module directory if it is not resolvable.
+Prepare a synthetic speech WAV and a model cache containing the live Zipformer
+and final Whisper models. Use only synthetic or explicitly approved fixtures.
+
+```sh
+node apps/desktop/scripts/smoke-windows-refinement.cjs <packaged-exe> <models-directory> <synthetic.wav> <expected-phrase>
+```
+
+The script creates an isolated temporary profile, injects synthetic microphone
+audio, verifies live captions, saved audio, refinement, replacement and session
+persistence, and terminates only its own application process tree. The source
+profile and the user's installed app are not modified. The expected phrase is
+a flow check; score the entire final transcript separately for accuracy.
+
+## Physical acceptance
+
+- Test both a built-in microphone and a USB/Bluetooth headset on supported
+  Windows devices. Record exact OS, CPU, app version and microphone model.
+- Say “The final confirmation number is seven four nine,” then immediately
+  click Stop. Do not speak the testing instruction. Confirm the final transcript
+  contains “final confirmation number” and the complete number.
+- Record varied names, dates, numbers, pauses, accents and speaking speeds.
+  Compare saved audio with both provisional and final transcripts. Record word
+  substitutions, omissions and additions; do not accept a model based on one
+  successful sentence.
+- Capture microphone only, system audio only, and both together. Verify labels,
+  chronology, playback seeking and final words. Start a recording immediately
+  after app launch to exercise startup recovery.
+- Test a 30–60 minute meeting, Stop/Resume, several recording parts, microphone
+  switching, sleep/wake, and disconnect/reconnect. Confirm no lost or duplicated
+  speech, runaway memory, or indefinitely pending finalization.
+- Verify fresh-profile model setup, interrupted download and retry, offline use
+  after setup, and closing the app during refinement. Preserve usable live text
+  and saved audio when refinement fails.
+- Reopen the app and confirm transcript persistence, re-transcription, notes,
+  export and configured sync. Keep personal recordings out of issues and logs.
+- Upgrade an existing beta through Settings: discovery, download, progress,
+  cancellation, retry, explicit Restart to update and the resulting version.
+  Interrupt the network during a download: after 90 seconds without new bytes,
+  Settings should show a short error and offer Retry update.
+
+## Production gate
+
+Record candidate commit, installer hash, observed checks, skipped environments
+and remaining failures. Require a valid Windows Authenticode signature before
+production publication through `release:win`. An unsigned beta is suitable for
+authorized testing only; do not promote it by replacing `latest.yml`.
+
+The initial repaired capture/refinement smoke still misrecognized one synthetic
+access-code digit with Whisper tiny.en. The flow is verified; the representative
+accuracy acceptance remains open and may require a stronger local model.


### PR DESCRIPTION
Update checks and downloads could leave Settings waiting indefinitely. Add bounded metadata checks, a 90-second download inactivity timeout, cancellation, readable failure messages, and Retry update. Ignore stale completions after cancellation. Installation uses the explicit Restart to update action so native model shutdown runs before installer handoff. These updater controls are shared by desktop platforms; automatic install-on-quit is replaced by explicit restart.

Stacked on #122. Prepare Windows beta 0.4.22 with the recording finalization fixes, changelog, and installed QA checklist. The production signing gate and production feed remain unchanged.

Validation: desktop typecheck passed; 160 tests passed, five skipped, including four timeout/cancel/retry regressions. Corrected two lint findings in the new test; targeted lint now passes. Final packaged smoke and GitHub CI are in progress.

Windows production readiness still requires signing and representative physical accuracy testing. A synthetic refinement test still misrecognized one digit, so this beta does not claim full transcription accuracy acceptance.