### PR TITLE
[ONY-240] Adopt the fresh native mobile foundation and PR #124

### DIFF
--- a/.github/workflows/mobile-native.yml
+++ b/.github/workflows/mobile-native.yml
@@ -1,0 +1,62 @@
+name: Native mobile
+
+on:
+  pull_request:
+    paths:
+      - 'apps/mobile-native/**'
+      - '.github/workflows/mobile-native.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mobile-native/**'
+      - '.github/workflows/mobile-native.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-mobile-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  simulator:
+    runs-on: macos-26
+    timeout-minutes: 30
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Prepare native project
+        run: |
+          brew install xcodegen
+          xcodegen generate --spec apps/mobile-native/project.yml
+      - name: Select an available iPhone simulator
+        run: |
+          xcrun simctl list devices available --json > "$RUNNER_TEMP/simulators.json"
+          python3 - <<'PY'
+          import json, os
+          with open(os.path.join(os.environ['RUNNER_TEMP'], 'simulators.json')) as f:
+              runtimes = json.load(f)['devices']
+          phones = [d for runtime, devices in runtimes.items() if 'iOS-26-' in runtime
+                    for d in devices if d['name'].startswith('iPhone') and d['isAvailable']]
+          if not phones:
+              raise SystemExit('No iOS 26 iPhone simulator is available')
+          with open(os.environ['GITHUB_ENV'], 'a') as f:
+              f.write('DOODLENOTE_SIMULATOR=' + phones[0]['udid'] + '\n')
+          PY
+      - name: Native unit and UI tests
+        run: |
+          xcodebuild -project apps/mobile-native/DoodleNoteNative.xcodeproj \
+            -scheme DoodleNoteNative \
+            -destination "platform=iOS Simulator,id=$DOODLENOTE_SIMULATOR" \
+            -derivedDataPath "$RUNNER_TEMP/DoodleNoteDerivedData" \
+            -resultBundlePath "$RUNNER_TEMP/DoodleNoteNative.xcresult" \
+            CODE_SIGNING_ALLOWED=NO test
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: native-mobile-test-results
+          path: ${{ runner.temp }}/DoodleNoteNative.xcresult
+          if-no-files-found: ignore
+          retention-days: 7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ The web app starts with a local PGlite database and no cloud credentials:
 pnpm --filter web dev
 ```
 
-See the component READMEs for [desktop](apps/desktop/README.md), [iOS](apps/ios/README.md), [web](apps/web/README.md), the [transcription engine](engine/README.md), and the [local MCP server](packages/doodle-note-mcp/README.md).
+See the component READMEs for [desktop](apps/desktop/README.md), [native iPhone/iPad](apps/mobile-native/README.md), [web](apps/web/README.md), the [transcription engine](engine/README.md), and the [local MCP server](packages/doodle-note-mcp/README.md).
 
 ## Making a change
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
   <p>
     <a href="https://github.com/Onyx-Dev-Labs/doodle-note/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/Onyx-Dev-Labs/doodle-note/actions/workflows/ci.yml/badge.svg"></a>
-    <a href="https://github.com/Onyx-Dev-Labs/doodle-note/actions/workflows/ios.yml"><img alt="iOS" src="https://github.com/Onyx-Dev-Labs/doodle-note/actions/workflows/ios.yml/badge.svg"></a>
+    <a href="https://github.com/Onyx-Dev-Labs/doodle-note/actions/workflows/mobile-native.yml"><img alt="iOS" src="https://github.com/Onyx-Dev-Labs/doodle-note/actions/workflows/mobile-native.yml/badge.svg"></a>
     <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-506941.svg"></a>
     <a href="https://www.doodlenote.ai"><img alt="Website" src="https://img.shields.io/badge/doodlenote.ai-506941"></a>
   </p>
@@ -84,7 +84,7 @@ meeting limits. Hosted Sync is optional and costs $10 per user per month.
 | --------------- | -------------- | --------------------------------------------------------------------------------------------------------------------- |
 | macOS desktop   | Supported      | Apple Silicon, macOS 14 or later; official releases distributed through [doodlenote.ai](https://www.doodlenote.ai) are signed and notarized. |
 | Windows desktop | Beta           | Windows 10/11, 64-bit; packaging and native-module smoke checks run in CI. The current checked-in configuration is unsigned, so SmartScreen warns. |
-| iPhone          | In development | Native SwiftUI app targeting iOS 26; full recording verification requires a physical device.                          |
+| iPhone          | In development | Fresh iPhone/iPad app in apps/mobile-native; iOS 26 prototype, with physical-device and release gates open.                          |
 | Web workspace   | In development | Next.js app for account linking, sync, sharing, workspaces, and hosted agent access.                                  |
 
 Public release history is available in [GitHub Releases](https://github.com/Onyx-Dev-Labs/doodle-note/releases) and the [DoodleNote changelog](https://www.doodlenote.ai/changelog). Maintainer release procedures are documented in [docs/RELEASING.md](docs/RELEASING.md).
@@ -95,7 +95,8 @@ Public release history is available in [GitHub Releases](https://github.com/Onyx
 .github/                 CI, CodeQL, iOS, and release workflows and community configuration
 apps/
   desktop/                Electron + React desktop application
-  ios/                    Native SwiftUI iPhone application
+  mobile-native/          Fresh SwiftUI iPhone/iPad implementation
+  ios/                    Historical iOS implementation; not used for fresh mobile work
   web/                    Next.js cloud workspace and public site
 docs/                    Brand, open-source, release, and screenshot documentation
 engine/                   Swift audio capture and on-device ASR sidecar
@@ -137,7 +138,7 @@ For a durable production deployment of the Sync server, follow
 explicit authentication secret and must either configure Stripe or declare
 themselves self-hosted.
 
-For native iPhone setup, see [apps/ios/README.md](apps/ios/README.md). For the engine protocol and commands, see [engine/README.md](engine/README.md).
+For fresh iPhone/iPad setup, see [apps/mobile-native/README.md](apps/mobile-native/README.md). For the engine protocol and commands, see [engine/README.md](engine/README.md).
 
 ## Verification
 

--- a/apps/mobile-native/.gitignore
+++ b/apps/mobile-native/.gitignore
@@ -1,0 +1,4 @@
+DerivedData/
+.build/
+.xcodebuildmcp/
+*.xcresult

--- a/apps/mobile-native/Config/Info.plist
+++ b/apps/mobile-native/Config/Info.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>DoodleNote</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Record conversations you choose to capture and save the audio on this device.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Create a transcript of your recording using speech models on this device.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~iphone</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/apps/mobile-native/README.md
+++ b/apps/mobile-native/README.md
@@ -4,17 +4,18 @@ This is the fresh iPhone/iPad implementation approved on September 6, 2026. It w
 
 ## Current checkpoint
 
-This is the first foundation checkpoint within the native feasibility stage. It is not a completed feasibility study or a beta release.
+This checkpoint includes the native foundation, journaled audio recovery, and an experimental on-device speaker pipeline within the native feasibility stage. It is not a completed feasibility study or a beta release.
 
 - Native SwiftUI library, standalone notes, text search, and dedicated compact/regular-width editing layouts.
 - Atomic local note documents containing typed text, PencilKit drawings, transcript passages, and capture state. Unreadable/future-format documents remain untouched. A previously active recording is marked interrupted when reopening.
 - Microphone pipeline with a bounded writer queue and rolling PCM CAF files. Closed chunks remain independently readable; normal stopping drains the queue and closes the final chunk. Disk/backlog errors stop capture visibly. Live speech failure leaves audio capture running.
-- Local playback across saved chunks and passage timestamp navigation.
-- Apple's SpeechAnalyzer/SpeechTranscriber integration with runtime device/locale/installed-asset checks, explicit model download, bounded input, audio conversion, provisional/final results, and bounded finalization. No network transcription fallback.
+- Local playback across saved chunks and passage timestamp navigation. Journaled open PCM tails are repaired into separate validated copies on startup; originals remain untouched.
+- Optional streaming speaker labels using a pinned FluidAudio/Sortformer model, explicit checksum-verified download, four speaker slots, provisional labels, and manually confirmed names scoped to each recording session. Speaker processing has a separate bounded queue so a slow model cannot silently drop saved audio.
+- Apple's SpeechAnalyzer/SpeechTranscriber integration with runtime device/locale/installed-asset checks, explicit model download, bounded input, audio conversion, provisional/final results, and cancellation requested after a finalization timeout. No network transcription fallback.
 - English, Danish, Spanish, French, and German are selectable **spoken-language candidates**. This does not establish recognition availability or accuracy for all five on real hardware. This foundation's interface is still English; the accepted five-language UI remains required work.
 - PencilKit canvas with a tool picker, drawing persistence, zoom, and ordinary system text entry. Physical Pencil, Scribble, pressure/latency, and accessibility acceptance are still open.
 
-The app has no sync, calendar, external AI, or voice-profile connections yet. Microphone audio never enters those services in this checkpoint. Speech model acquisition uses Apple's asset service when the user requests a download.
+The app has no sync, calendar, external AI, or voice-profile connections yet. Microphone audio never enters those services in this checkpoint. Speech model acquisition uses Apple's asset service when requested. The optional speaker model download retrieves four pinned public files from Hugging Face (240,139,774 bytes); inference runs locally. Model assets are outside note storage and excluded from operating-system backup.
 
 ## Build and test
 
@@ -37,15 +38,15 @@ Tests cover local text/ink/transcript round trips, crash-state recovery without 
 
 Application Support contains one UUID directory per note. `note.json` is atomically replaced and protected until first device unlock; `audio/` contains rolling recordings. This is an internal prototype schema, not the future cloud protocol or backup archive format. No data migration from the old iOS app is attempted.
 
-Recording metadata is persisted before the engine starts. Audio is closed roughly every five seconds and on a normal stop; abrupt process termination may damage the open tail chunk. This checkpoint has **not** proved complete crash-tail recovery. Files are retained for investigation and later recovery work. PCM storage is intentionally straightforward for measurement, but needs storage-budget, low-space, and two-hour tests before release decisions.
+Recording metadata is persisted before the engine starts. Audio is closed roughly every five seconds and on a normal stop. The writer journals each open chunk; startup repairs supported PCM headers and incomplete final frames into a separate copy, validates its frame count, and selects that copy for playback without duplicating the original. Synthetic torn-tail tests pass. Actual process-kill, power-loss, and low-storage behavior still require device testing; bytes never flushed to storage cannot be recovered. PCM storage is intentionally straightforward for measurement, but needs storage-budget, low-space, and two-hour tests before release decisions.
 
 Note writes currently encode the complete document. Transcript UI is lazy, but indexing, incremental persistence, large-ink performance, and long-session memory behavior still need evaluation. A write failure keeps edits visible and shows an error. The app has no Trash or permanent-delete action yet.
 
 ## Next implementation gates
 
-1. Integrate a pinned, license-verified streaming diarization candidate for three to four speakers, optional device-local voice references, name correction, and final/live identity reconciliation. Until then every passage explicitly remains unassigned. Do not infer a speaker from transcription or calendar membership.
+1. Evaluate the integrated streaming diarization candidate with real three/four-speaker material. Add optional device-local voice references and final/live identity reconciliation. Current names are manually confirmed per session, not automatic recognition of known people. Resolve model redistribution notices before release; see [speaker evaluation](docs/speaker-evaluation.md).
 2. Run the integrated mic/transcript/speaker/Pencil path on physical iPhone and iPad, using authorized test material. Measure five-language recognition, attribution, latency, thermals, memory, storage, interruption/route behavior, screen lock, restart, and complete two-hour preservation. Simulator success cannot satisfy this gate.
-3. Add audio import, interrupted-tail repair/retry, model management and readiness UX, and all five interface languages. Preserve the full approved scope if the first engine candidate fails.
+3. Add audio import, recovery/retry controls for unsupported damaged recordings, complete model management and readiness UX, and all five interface languages. Preserve the full approved scope if the first engine candidate fails.
 4. Implement local summary versions and six meeting formats, source-grounded meeting/library Q&A, full-history retrieval, and optional explicitly enabled text AI providers.
 5. Implement direct Google/Microsoft calendars, optional existing cloud sync with private ink/conflict/Trash extensions, encrypted archive restore, PDF/Markdown exports, and account isolation. Production migration and OAuth configuration need their own reviewed rollout.
 6. Complete device/accessibility/Pencil/localization acceptance and reviewed TestFlight/App Store preparation. No source checkpoint implies release approval.

--- a/apps/mobile-native/README.md
+++ b/apps/mobile-native/README.md
@@ -1,0 +1,55 @@
+# DoodleNote native mobile foundation
+
+This is the fresh iPhone/iPad implementation approved on September 6, 2026. It was created independently of `apps/ios`; no implementation or project setup was copied from that directory. The [approved specification](docs/discovery/doodlenote_Specification_v1.md) governs the complete first release.
+
+## Current checkpoint
+
+This is the first foundation checkpoint within the native feasibility stage. It is not a completed feasibility study or a beta release.
+
+- Native SwiftUI library, standalone notes, text search, and dedicated compact/regular-width editing layouts.
+- Atomic local note documents containing typed text, PencilKit drawings, transcript passages, and capture state. Unreadable/future-format documents remain untouched. A previously active recording is marked interrupted when reopening.
+- Microphone pipeline with a bounded writer queue and rolling PCM CAF files. Closed chunks remain independently readable; normal stopping drains the queue and closes the final chunk. Disk/backlog errors stop capture visibly. Live speech failure leaves audio capture running.
+- Local playback across saved chunks and passage timestamp navigation.
+- Apple's SpeechAnalyzer/SpeechTranscriber integration with runtime device/locale/installed-asset checks, explicit model download, bounded input, audio conversion, provisional/final results, and bounded finalization. No network transcription fallback.
+- English, Danish, Spanish, French, and German are selectable **spoken-language candidates**. This does not establish recognition availability or accuracy for all five on real hardware. This foundation's interface is still English; the accepted five-language UI remains required work.
+- PencilKit canvas with a tool picker, drawing persistence, zoom, and ordinary system text entry. Physical Pencil, Scribble, pressure/latency, and accessibility acceptance are still open.
+
+The app has no sync, calendar, external AI, or voice-profile connections yet. Microphone audio never enters those services in this checkpoint. Speech model acquisition uses Apple's asset service when the user requests a download.
+
+## Build and test
+
+Prerequisites: Xcode 26 with the iOS 26 SDK and XcodeGen. The initial local verification used Xcode 26.6 (17F113), iOS 26.5 simulators, and XcodeGen 2.45.4. iOS 26 is a **prototype API requirement**, not the finalized release device floor.
+
+From this directory:
+
+```sh
+xcodegen generate
+xcodebuild -project DoodleNoteNative.xcodeproj -scheme DoodleNoteNative \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' \
+  -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO test
+```
+
+Use any installed compatible simulator name/OS. The Xcode project is generated and excluded by the repository's existing ignore rules. `project.yml` and `Config/Info.plist` are the reproducible project sources. No legacy iOS project is required. The prototype bundle ID is `ai.doodlenote.native.prototype`; physical installation needs a development team and provisioning. Production signing and store configuration are not included.
+
+Tests cover local text/ink/transcript round trips, crash-state recovery without deleting audio, corrupt/future documents, provisional transcript replacement, chunk frame preservation, source-format preservation during speech conversion, and UI note persistence after terminating/relaunching the app. The UI test uses a separate app storage directory and generates synthetic text. Audio tests use synthetic PCM buffers and do not activate a microphone.
+
+## Storage and failure behavior
+
+Application Support contains one UUID directory per note. `note.json` is atomically replaced and protected until first device unlock; `audio/` contains rolling recordings. This is an internal prototype schema, not the future cloud protocol or backup archive format. No data migration from the old iOS app is attempted.
+
+Recording metadata is persisted before the engine starts. Audio is closed roughly every five seconds and on a normal stop; abrupt process termination may damage the open tail chunk. This checkpoint has **not** proved complete crash-tail recovery. Files are retained for investigation and later recovery work. PCM storage is intentionally straightforward for measurement, but needs storage-budget, low-space, and two-hour tests before release decisions.
+
+Note writes currently encode the complete document. Transcript UI is lazy, but indexing, incremental persistence, large-ink performance, and long-session memory behavior still need evaluation. A write failure keeps edits visible and shows an error. The app has no Trash or permanent-delete action yet.
+
+## Next implementation gates
+
+1. Integrate a pinned, license-verified streaming diarization candidate for three to four speakers, optional device-local voice references, name correction, and final/live identity reconciliation. Until then every passage explicitly remains unassigned. Do not infer a speaker from transcription or calendar membership.
+2. Run the integrated mic/transcript/speaker/Pencil path on physical iPhone and iPad, using authorized test material. Measure five-language recognition, attribution, latency, thermals, memory, storage, interruption/route behavior, screen lock, restart, and complete two-hour preservation. Simulator success cannot satisfy this gate.
+3. Add audio import, interrupted-tail repair/retry, model management and readiness UX, and all five interface languages. Preserve the full approved scope if the first engine candidate fails.
+4. Implement local summary versions and six meeting formats, source-grounded meeting/library Q&A, full-history retrieval, and optional explicitly enabled text AI providers.
+5. Implement direct Google/Microsoft calendars, optional existing cloud sync with private ink/conflict/Trash extensions, encrypted archive restore, PDF/Markdown exports, and account isolation. Production migration and OAuth configuration need their own reviewed rollout.
+6. Complete device/accessibility/Pencil/localization acceptance and reviewed TestFlight/App Store preparation. No source checkpoint implies release approval.
+
+## Evidence
+
+See [validation notes](docs/validation.md) for completed checks and remaining limits. The current installed Speech SDK was inspected for the exact APIs used here. Apple's [SpeechAnalyzer documentation](https://developer.apple.com/documentation/speech/speechanalyzer) and [sample](https://developer.apple.com/documentation/speech/bringing-advanced-speech-to-text-capabilities-to-your-app) describe compatible audio conversion and streaming analysis; those documents do not prove this app's accuracy or speaker support.

--- a/apps/mobile-native/Sources/AudioChunkWriter.swift
+++ b/apps/mobile-native/Sources/AudioChunkWriter.swift
@@ -24,13 +24,14 @@ private final class ConverterSupply: @unchecked Sendable {
 }
 
 enum CaptureError: LocalizedError {
-    case microphone, format, backlog, conversion
+    case microphone, format, backlog, conversion, speakerBacklog
     var errorDescription: String? {
         switch self {
         case .microphone: "Microphone access is needed to record. Enable it in Settings."
         case .format: "The microphone audio format is unavailable."
         case .backlog: "Audio capture could not keep up. Recording stopped to avoid an unreported gap."
         case .conversion: "Live transcription could not process the audio format. Audio is still being saved."
+        case .speakerBacklog: "Speaker processing could not keep up. Speaker labels stopped."
         }
     }
 }
@@ -53,6 +54,7 @@ final class AudioChunkWriter: @unchecked Sendable {
     private let speechFormat: AVAudioFormat?
     private var speechInput: AsyncStream<AnalyzerInput>.Continuation?
     private var speakerInput: AsyncStream<SpeakerAudio>.Continuation?
+    private let speakerConverter = SpeakerPCMConverter()
     private let onCaptureError: @Sendable (String) -> Void
     private let onSpeechError: @Sendable (String) -> Void
     private let onSpeakerError: @Sendable (String) -> Void
@@ -111,6 +113,10 @@ final class AudioChunkWriter: @unchecked Sendable {
             queue.async { [self] in
                 do { try closeChunk() } catch { onCaptureError(error.localizedDescription) }
                 flushSpeech()
+                if speakerInput != nil {
+                    do { try yieldSpeakers(speakerConverter.finish()) }
+                    catch { onSpeakerError("Speaker finalization failed. Saved audio is preserved. \(error.localizedDescription)") }
+                }
                 speechInput?.finish()
                 speechInput = nil
                 speakerInput?.finish()
@@ -165,28 +171,22 @@ final class AudioChunkWriter: @unchecked Sendable {
     }
 
     private func feedSpeakers(_ buffer: AVAudioPCMBuffer) {
-        guard let speakerInput else { return }
-        guard let channels = buffer.floatChannelData else {
-            speakerInput.finish()
+        guard speakerInput != nil else { return }
+        do { try yieldSpeakers(speakerConverter.convert(buffer)) }
+        catch {
+            speakerInput?.finish()
             self.speakerInput = nil
-            onSpeakerError("Speaker labels stopped because the microphone format changed. Audio is preserved.")
-            return
+            onSpeakerError("Speaker processing stopped. Audio and transcription continue. \(error.localizedDescription)")
         }
-        let count = Int(buffer.format.channelCount)
-        var mono = [Float](repeating: 0, count: Int(buffer.frameLength))
-        for frame in mono.indices {
-            for channel in 0..<count {
-                mono[frame] += buffer.format.isInterleaved ? channels[0][frame * count + channel] : channels[channel][frame]
-            }
-            mono[frame] /= Float(count)
-        }
-        switch speakerInput.yield(SpeakerAudio(samples: mono, sampleRate: buffer.format.sampleRate)) {
+    }
+
+    private func yieldSpeakers(_ samples: [Float]) throws {
+        guard let speakerInput, !samples.isEmpty else { return }
+        switch speakerInput.yield(SpeakerAudio(samples: samples, sampleRate: 16_000)) {
         case .dropped, .terminated:
-            speakerInput.finish()
-            self.speakerInput = nil
-            onSpeakerError("Speaker processing could not keep up. Labels stopped; audio and transcription continue.")
+            throw CaptureError.speakerBacklog
         case .enqueued: break
-        @unknown default: break
+        @unknown default: throw CaptureError.conversion
         }
     }
 

--- a/apps/mobile-native/Sources/AudioChunkWriter.swift
+++ b/apps/mobile-native/Sources/AudioChunkWriter.swift
@@ -45,25 +45,32 @@ final class AudioChunkWriter: @unchecked Sendable {
     private let directory: URL
     private let prefix: String
     private var file: AVAudioFile?
+    private var openFileURL: URL?
     private var index = 0
     private var writeFailed = false
     private var framesInChunk: AVAudioFramePosition = 0
     private var converter: AVAudioConverter?
     private let speechFormat: AVAudioFormat?
     private var speechInput: AsyncStream<AnalyzerInput>.Continuation?
+    private var speakerInput: AsyncStream<SpeakerAudio>.Continuation?
     private let onCaptureError: @Sendable (String) -> Void
     private let onSpeechError: @Sendable (String) -> Void
+    private let onSpeakerError: @Sendable (String) -> Void
 
     init(directory: URL, speechFormat: AVAudioFormat? = nil,
          speechInput: AsyncStream<AnalyzerInput>.Continuation? = nil,
+         speakerInput: AsyncStream<SpeakerAudio>.Continuation? = nil,
          onCaptureError: @escaping @Sendable (String) -> Void,
-         onSpeechError: @escaping @Sendable (String) -> Void) {
+         onSpeechError: @escaping @Sendable (String) -> Void,
+         onSpeakerError: @escaping @Sendable (String) -> Void = { _ in }) {
         self.directory = directory
         self.prefix = String(format: "%020.0f", Date().timeIntervalSince1970 * 1_000_000)
         self.speechFormat = speechFormat
         self.speechInput = speechInput
+        self.speakerInput = speakerInput
         self.onCaptureError = onCaptureError
         self.onSpeechError = onSpeechError
+        self.onSpeakerError = onSpeakerError
     }
 
     func append(_ input: AVAudioPCMBuffer) {
@@ -102,10 +109,12 @@ final class AudioChunkWriter: @unchecked Sendable {
             lock.lock()
             accepting = false
             queue.async { [self] in
-                file = nil
+                do { try closeChunk() } catch { onCaptureError(error.localizedDescription) }
                 flushSpeech()
                 speechInput?.finish()
                 speechInput = nil
+                speakerInput?.finish()
+                speakerInput = nil
                 continuation.resume()
             }
             lock.unlock()
@@ -115,6 +124,8 @@ final class AudioChunkWriter: @unchecked Sendable {
     private func write(_ buffer: AVAudioPCMBuffer) throws {
         if file == nil {
             let url = directory.appendingPathComponent("\(prefix)-\(String(format: "%06d", index)).caf")
+            try AudioRecovery.begin(file: url, format: buffer.format)
+            openFileURL = url
             file = try AVAudioFile(forWriting: url, settings: [
                 AVFormatIDKey: kAudioFormatLinearPCM,
                 AVSampleRateKey: buffer.format.sampleRate,
@@ -129,24 +140,61 @@ final class AudioChunkWriter: @unchecked Sendable {
         try file?.write(from: buffer)
         framesInChunk += AVAudioFramePosition(buffer.frameLength)
         if Double(framesInChunk) >= buffer.format.sampleRate * 5 {
-            file = nil
+            try closeChunk()
             framesInChunk = 0
             index += 1
         }
 
+        feedSpeakers(buffer)
         // Speech has a separate failure path. Saved audio remains available for later processing.
         guard let speechInput, let speechFormat else { return }
         do {
             let converted = try convert(buffer, to: speechFormat)
             guard converted.frameLength > 0 else { return }
-            if case .dropped = speechInput.yield(AnalyzerInput(buffer: converted)) {
+            switch speechInput.yield(AnalyzerInput(buffer: converted)) {
+            case .dropped, .terminated:
                 throw CaptureError.conversion
+            case .enqueued: break
+            @unknown default: throw CaptureError.conversion
             }
         } catch {
             speechInput.finish()
             self.speechInput = nil
             onSpeechError(error.localizedDescription)
         }
+    }
+
+    private func feedSpeakers(_ buffer: AVAudioPCMBuffer) {
+        guard let speakerInput else { return }
+        guard let channels = buffer.floatChannelData else {
+            speakerInput.finish()
+            self.speakerInput = nil
+            onSpeakerError("Speaker labels stopped because the microphone format changed. Audio is preserved.")
+            return
+        }
+        let count = Int(buffer.format.channelCount)
+        var mono = [Float](repeating: 0, count: Int(buffer.frameLength))
+        for frame in mono.indices {
+            for channel in 0..<count {
+                mono[frame] += buffer.format.isInterleaved ? channels[0][frame * count + channel] : channels[channel][frame]
+            }
+            mono[frame] /= Float(count)
+        }
+        switch speakerInput.yield(SpeakerAudio(samples: mono, sampleRate: buffer.format.sampleRate)) {
+        case .dropped, .terminated:
+            speakerInput.finish()
+            self.speakerInput = nil
+            onSpeakerError("Speaker processing could not keep up. Labels stopped; audio and transcription continue.")
+        case .enqueued: break
+        @unknown default: break
+        }
+    }
+
+    private func closeChunk() throws {
+        file = nil
+        guard let url = openFileURL else { return }
+        if !writeFailed { try AudioRecovery.complete(file: url) }
+        openFileURL = nil
     }
 
     private func convert(_ input: AVAudioPCMBuffer, to format: AVAudioFormat) throws -> AVAudioPCMBuffer {

--- a/apps/mobile-native/Sources/AudioChunkWriter.swift
+++ b/apps/mobile-native/Sources/AudioChunkWriter.swift
@@ -1,0 +1,195 @@
+import AVFoundation
+import Speech
+
+/// The owned buffer is immutable after construction and used by one writer queue.
+private final class OwnedPCM: @unchecked Sendable {
+    let buffer: AVAudioPCMBuffer
+    init(_ buffer: AVAudioPCMBuffer) { self.buffer = buffer }
+}
+
+/// AVAudioConverter invokes this supplier synchronously; the lock also makes repeated calls safe.
+private final class ConverterSupply: @unchecked Sendable {
+    let buffer: AVAudioPCMBuffer
+    private let lock = NSLock()
+    private var supplied = false
+    init(_ buffer: AVAudioPCMBuffer) { self.buffer = buffer }
+    func take(_ status: UnsafeMutablePointer<AVAudioConverterInputStatus>) -> AVAudioBuffer? {
+        lock.withLock {
+            if supplied { status.pointee = .noDataNow; return nil }
+            supplied = true
+            status.pointee = .haveData
+            return buffer
+        }
+    }
+}
+
+enum CaptureError: LocalizedError {
+    case microphone, format, backlog, conversion
+    var errorDescription: String? {
+        switch self {
+        case .microphone: "Microphone access is needed to record. Enable it in Settings."
+        case .format: "The microphone audio format is unavailable."
+        case .backlog: "Audio capture could not keep up. Recording stopped to avoid an unreported gap."
+        case .conversion: "Live transcription could not process the audio format. Audio is still being saved."
+        }
+    }
+}
+
+/// All file/converter access belongs to `queue`. The lock protects admission and bounded queue depth.
+/// The tap owns its input only for the callback, so accepted buffers are copied before enqueueing.
+final class AudioChunkWriter: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "ai.doodlenote.audio-writer", qos: .userInitiated)
+    private let lock = NSLock()
+    private var accepting = true
+    private var pending = 0
+    private let directory: URL
+    private let prefix: String
+    private var file: AVAudioFile?
+    private var index = 0
+    private var writeFailed = false
+    private var framesInChunk: AVAudioFramePosition = 0
+    private var converter: AVAudioConverter?
+    private let speechFormat: AVAudioFormat?
+    private var speechInput: AsyncStream<AnalyzerInput>.Continuation?
+    private let onCaptureError: @Sendable (String) -> Void
+    private let onSpeechError: @Sendable (String) -> Void
+
+    init(directory: URL, speechFormat: AVAudioFormat? = nil,
+         speechInput: AsyncStream<AnalyzerInput>.Continuation? = nil,
+         onCaptureError: @escaping @Sendable (String) -> Void,
+         onSpeechError: @escaping @Sendable (String) -> Void) {
+        self.directory = directory
+        self.prefix = String(format: "%020.0f", Date().timeIntervalSince1970 * 1_000_000)
+        self.speechFormat = speechFormat
+        self.speechInput = speechInput
+        self.onCaptureError = onCaptureError
+        self.onSpeechError = onSpeechError
+    }
+
+    func append(_ input: AVAudioPCMBuffer) {
+        lock.lock()
+        guard accepting else { lock.unlock(); return }
+        guard pending < 128,
+              let owned = AVAudioPCMBuffer(pcmFormat: input.format, frameCapacity: input.frameLength) else {
+            accepting = false
+            lock.unlock()
+            onCaptureError(CaptureError.backlog.localizedDescription)
+            return
+        }
+        owned.frameLength = input.frameLength
+        let source = UnsafeMutableAudioBufferListPointer(input.mutableAudioBufferList)
+        let target = UnsafeMutableAudioBufferListPointer(owned.mutableAudioBufferList)
+        for (src, dst) in zip(source, target) {
+            if let s = src.mData, let d = dst.mData { memcpy(d, s, Int(src.mDataByteSize)) }
+        }
+        pending += 1
+        let packet = OwnedPCM(owned)
+        queue.async { [self] in
+            defer { lock.withLock { pending -= 1 } }
+            guard !writeFailed else { return }
+            do { try write(packet.buffer) }
+            catch {
+                writeFailed = true
+                lock.withLock { accepting = false }
+                onCaptureError(error.localizedDescription)
+            }
+        }
+        lock.unlock()
+    }
+
+    func finish() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            accepting = false
+            queue.async { [self] in
+                file = nil
+                flushSpeech()
+                speechInput?.finish()
+                speechInput = nil
+                continuation.resume()
+            }
+            lock.unlock()
+        }
+    }
+
+    private func write(_ buffer: AVAudioPCMBuffer) throws {
+        if file == nil {
+            let url = directory.appendingPathComponent("\(prefix)-\(String(format: "%06d", index)).caf")
+            file = try AVAudioFile(forWriting: url, settings: [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: buffer.format.sampleRate,
+                AVNumberOfChannelsKey: buffer.format.channelCount,
+                AVLinearPCMBitDepthKey: 16,
+                AVLinearPCMIsFloatKey: false,
+                AVLinearPCMIsBigEndianKey: false
+            ], commonFormat: buffer.format.commonFormat, interleaved: buffer.format.isInterleaved)
+            try FileManager.default.setAttributes(
+                [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication], ofItemAtPath: url.path)
+        }
+        try file?.write(from: buffer)
+        framesInChunk += AVAudioFramePosition(buffer.frameLength)
+        if Double(framesInChunk) >= buffer.format.sampleRate * 5 {
+            file = nil
+            framesInChunk = 0
+            index += 1
+        }
+
+        // Speech has a separate failure path. Saved audio remains available for later processing.
+        guard let speechInput, let speechFormat else { return }
+        do {
+            let converted = try convert(buffer, to: speechFormat)
+            guard converted.frameLength > 0 else { return }
+            if case .dropped = speechInput.yield(AnalyzerInput(buffer: converted)) {
+                throw CaptureError.conversion
+            }
+        } catch {
+            speechInput.finish()
+            self.speechInput = nil
+            onSpeechError(error.localizedDescription)
+        }
+    }
+
+    private func convert(_ input: AVAudioPCMBuffer, to format: AVAudioFormat) throws -> AVAudioPCMBuffer {
+        if input.format == format { return input }
+        if converter == nil {
+            converter = AVAudioConverter(from: input.format, to: format)
+            converter?.primeMethod = .none
+        }
+        guard let converter,
+              let output = AVAudioPCMBuffer(pcmFormat: format,
+                  frameCapacity: AVAudioFrameCount(ceil(Double(input.frameLength) * format.sampleRate / input.format.sampleRate)) + 32)
+        else { throw CaptureError.conversion }
+        let supply = ConverterSupply(input)
+        var error: NSError?
+        let status = converter.convert(to: output, error: &error) { _, inputStatus in
+            supply.take(inputStatus)
+        }
+        if let error { throw error }
+        guard status != .error else { throw CaptureError.conversion }
+        return output
+    }
+
+    private func flushSpeech() {
+        guard let converter, let speechFormat, let speechInput else { return }
+        defer { self.converter = nil }
+        do {
+            while true {
+                guard let output = AVAudioPCMBuffer(pcmFormat: speechFormat, frameCapacity: 4096) else {
+                    throw CaptureError.conversion
+                }
+                var error: NSError?
+                let status = converter.convert(to: output, error: &error) { _, inputStatus in
+                    inputStatus.pointee = .endOfStream
+                    return nil
+                }
+                if let error { throw error }
+                guard status != .error else { throw CaptureError.conversion }
+                if output.frameLength > 0,
+                   case .dropped = speechInput.yield(AnalyzerInput(buffer: output)) {
+                    throw CaptureError.conversion
+                }
+                if status == .endOfStream || output.frameLength == 0 { break }
+            }
+        } catch { onSpeechError(error.localizedDescription) }
+    }
+}

--- a/apps/mobile-native/Sources/AudioRecovery.swift
+++ b/apps/mobile-native/Sources/AudioRecovery.swift
@@ -1,0 +1,114 @@
+import AVFoundation
+
+/// Only repairs journaled PCM files created by this app. Originals are never rewritten.
+enum AudioRecovery {
+    struct OpenChunk: Codable {
+        var version = 1
+        let filename: String
+        let sampleRate: Double
+        let channels: UInt32
+    }
+    struct Report { var recovered = 0; var unreadable: [String] = [] }
+    enum Failure: Error { case unsupported, malformed, empty, validation }
+
+    static func journalURL(for file: URL) -> URL { file.appendingPathExtension("open.json") }
+    static func recoveredURL(for file: URL) -> URL {
+        file.deletingPathExtension().appendingPathExtension("recovered.caf")
+    }
+    static func begin(file: URL, format: AVAudioFormat) throws {
+        let journal = OpenChunk(filename: file.lastPathComponent,
+                                sampleRate: format.sampleRate, channels: format.channelCount)
+        try JSONEncoder().encode(journal).write(to: journalURL(for: file),
+            options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+    }
+    static func complete(file: URL) throws { try FileManager.default.removeItem(at: journalURL(for: file)) }
+
+    static func recover(directory: URL) -> Report {
+        var report = Report()
+        let files = (try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)) ?? []
+        for journalURL in files where journalURL.lastPathComponent.hasSuffix(".caf.open.json") {
+            do {
+                let journal = try JSONDecoder().decode(OpenChunk.self, from: Data(contentsOf: journalURL))
+                guard journal.version == 1, journal.channels > 0, journal.channels <= 32,
+                      journal.sampleRate.isFinite, journal.sampleRate > 0,
+                      URL(fileURLWithPath: journal.filename).lastPathComponent == journal.filename,
+                      journal.filename.hasSuffix(".caf"), !journal.filename.hasPrefix("."),
+                      journalURL.lastPathComponent == journal.filename + ".open.json"
+                else { throw Failure.malformed }
+                let original = directory.appendingPathComponent(journal.filename)
+                let recovered = recoveredURL(for: original)
+                if !FileManager.default.fileExists(atPath: recovered.path) {
+                    try repair(original: original, recovered: recovered, journal: journal)
+                }
+                guard try AVAudioFile(forReading: recovered).length > 0 else { throw Failure.empty }
+                report.recovered += 1
+            } catch { report.unreadable.append(journalURL.lastPathComponent) }
+        }
+        return report
+    }
+
+    private static func repair(original: URL, recovered: URL, journal: OpenChunk) throws {
+        let source = try FileHandle(forReadingFrom: original)
+        defer { try? source.close() }
+        let size = try source.seekToEnd()
+        try source.seek(toOffset: 0)
+        guard try source.read(upToCount: 8) == Data([0x63, 0x61, 0x66, 0x66, 0, 1, 0, 0]) else {
+            throw Failure.unsupported
+        }
+        var offset: UInt64 = 8
+        var bytesPerFrame: UInt64?
+        var dataHeader: UInt64?
+        var dataStart: UInt64?
+        while offset + 12 <= size, offset <= 1_048_576 {
+            try source.seek(toOffset: offset)
+            guard let header = try source.read(upToCount: 12), header.count == 12 else { throw Failure.malformed }
+            let kind = String(decoding: header.prefix(4), as: UTF8.self)
+            let count = readBE(header, at: 4, count: 8)
+            if kind == "data" {
+                guard bytesPerFrame != nil, size >= offset + 16 else { throw Failure.malformed }
+                dataHeader = offset
+                dataStart = offset + 16
+                break
+            }
+            guard count <= size - offset - 12 else { throw Failure.malformed }
+            if kind == "desc" {
+                guard offset == 8, count == 32,
+                      let description = try source.read(upToCount: 32), description.count == 32,
+                      String(decoding: description[8..<12], as: UTF8.self) == "lpcm",
+                      readBE(description, at: 12, count: 4) == 2,
+                      readBE(description, at: 20, count: 4) == 1,
+                      readBE(description, at: 24, count: 4) == UInt64(journal.channels),
+                      readBE(description, at: 28, count: 4) == 16,
+                      Double(bitPattern: readBE(description, at: 0, count: 8)) == journal.sampleRate
+                else { throw Failure.unsupported }
+                let frameBytes = readBE(description, at: 16, count: 4)
+                guard frameBytes == UInt64(journal.channels) * 2 else { throw Failure.unsupported }
+                bytesPerFrame = frameBytes
+            } else if kind != "free" && kind != "chan" { throw Failure.unsupported }
+            offset += 12 + count
+        }
+        guard let bytesPerFrame, let dataHeader, let dataStart else { throw Failure.malformed }
+        let completeBytes = ((size - dataStart) / bytesPerFrame) * bytesPerFrame
+        guard completeBytes > 0 else { throw Failure.empty }
+        // The journal identifies our data-last writer format. Trim a torn frame only in the copy.
+        let temporary = recovered.appendingPathExtension(UUID().uuidString + ".tmp")
+        defer { try? FileManager.default.removeItem(at: temporary) }
+        try FileManager.default.copyItem(at: original, to: temporary)
+        let destination = try FileHandle(forWritingTo: temporary)
+        do {
+            try destination.seek(toOffset: dataHeader + 4)
+            var dataLength = (completeBytes + 4).bigEndian
+            try withUnsafeBytes(of: &dataLength) { try destination.write(contentsOf: Data($0)) }
+            try destination.truncate(atOffset: dataStart + completeBytes)
+            try destination.synchronize()
+            try destination.close()
+        } catch { try? destination.close(); throw error }
+        let test = try AVAudioFile(forReading: temporary)
+        guard test.length == AVAudioFramePosition(completeBytes / bytesPerFrame) else { throw Failure.validation }
+        try FileManager.default.moveItem(at: temporary, to: recovered)
+    }
+
+    private static func readBE(_ data: Data, at start: Int, count: Int) -> UInt64 {
+        data[start..<(start + count)].reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+    }
+}

--- a/apps/mobile-native/Sources/DoodleNoteApp.swift
+++ b/apps/mobile-native/Sources/DoodleNoteApp.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+@main
+struct DoodleNoteApp: App {
+    @State private var library: NoteLibrary
+    @State private var recording = RecordingSession()
+
+    init() {
+        let base = URL.applicationSupportDirectory.appendingPathComponent("DoodleNoteNative", isDirectory: true)
+        #if DEBUG
+        let root = ProcessInfo.processInfo.arguments.contains("--ui-testing")
+            ? URL.applicationSupportDirectory.appendingPathComponent("DoodleNoteUITests", isDirectory: true) : base
+        #else
+        let root = base
+        #endif
+        _library = State(initialValue: NoteLibrary(root: root))
+    }
+
+    var body: some Scene {
+        WindowGroup { LibraryView(library: library, recording: recording) }
+    }
+}
+
+struct LibraryView: View {
+    @Bindable var library: NoteLibrary
+    @Bindable var recording: RecordingSession
+    @State private var selection: UUID?
+    @State private var search = ""
+
+    private var visibleNotes: [NoteRecord] {
+        library.notes.filter { note in
+            search.isEmpty || ([note.title, note.text] + note.passages.map(\.text))
+                .contains { $0.localizedCaseInsensitiveContains(search) }
+        }.sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: $selection) {
+                Section {
+                    Label("Only on this device", systemImage: "iphone")
+                        .font(.subheadline).foregroundStyle(.secondary)
+                }
+                Section("Notes") {
+                    ForEach(visibleNotes) { note in
+                        NavigationLink(value: note.id) {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text(note.title.isEmpty ? String(localized: "Untitled note") : note.title)
+                                    .font(.headline).lineLimit(1)
+                                Text(note.text.isEmpty ? String(localized: "Personal notes and recordings") : note.text)
+                                    .font(.subheadline).foregroundStyle(.secondary).lineLimit(2)
+                                Text(note.updatedAt, style: .date).font(.caption).foregroundStyle(.secondary)
+                            }.padding(.vertical, 4)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("DoodleNote")
+            .searchable(text: $search, prompt: "Search notes and transcripts")
+            .overlay {
+                if library.notes.isEmpty {
+                    ContentUnavailableView("Your notes start here", systemImage: "note.text",
+                        description: Text("Create a note to write, draw, or record a conversation."))
+                        .allowsHitTesting(false)
+                }
+            }
+            .toolbar {
+                Button("New note", systemImage: "square.and.pencil") { selection = library.create() }
+                    .disabled(library.disk == nil).accessibilityIdentifier("newNote")
+            }
+        } detail: {
+            if let selection, library.note(selection) != nil {
+                NoteEditor(id: selection, library: library, recording: recording).id(selection)
+            } else {
+                ContentUnavailableView("Choose a note", systemImage: "note.text",
+                    description: Text("Your notes stay on this device. No account is required."))
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            if let problem = library.problem ?? recording.problem {
+                Text(problem).font(.callout).foregroundStyle(.red)
+                    .padding().frame(maxWidth: .infinity).background(.regularMaterial)
+                    .accessibilityIdentifier("storageProblem")
+            }
+            if let active = recording.noteID, active != selection {
+                Button("Open active recording", systemImage: "record.circle") { selection = active }
+                    .padding().frame(maxWidth: .infinity).background(.regularMaterial)
+            }
+        }
+    }
+}

--- a/apps/mobile-native/Sources/LocalPlayback.swift
+++ b/apps/mobile-native/Sources/LocalPlayback.swift
@@ -1,0 +1,48 @@
+import AVFoundation
+import Observation
+
+@MainActor @Observable
+final class LocalPlayback: NSObject, AVAudioPlayerDelegate {
+    private(set) var isPlaying = false
+    var problem: String?
+    private var player: AVAudioPlayer?
+    private var remaining: [URL] = []
+
+    func play(files: [URL], at seconds: TimeInterval = 0) {
+        stop()
+        problem = nil
+        var offset = max(0, seconds)
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback)
+            try AVAudioSession.sharedInstance().setActive(true)
+            for (index, url) in files.enumerated() {
+                let candidate = try AVAudioPlayer(contentsOf: url)
+                if offset >= candidate.duration { offset -= candidate.duration; continue }
+                remaining = Array(files.dropFirst(index + 1))
+                player = candidate
+                candidate.delegate = self
+                candidate.currentTime = offset
+                isPlaying = candidate.play()
+                if !isPlaying { problem = "The saved audio could not be played." }
+                return
+            }
+            stop()
+        } catch { problem = "Playback failed. The audio files are preserved. \(error.localizedDescription)"; stop() }
+    }
+
+    func stop() {
+        player?.stop()
+        player = nil
+        remaining = []
+        isPlaying = false
+    }
+
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        let finishedID = ObjectIdentifier(player)
+        Task { @MainActor in
+            guard let current = self.player, ObjectIdentifier(current) == finishedID else { return }
+            if flag && !remaining.isEmpty { play(files: remaining) }
+            else { stop() }
+        }
+    }
+}

--- a/apps/mobile-native/Sources/LocalSpeech.swift
+++ b/apps/mobile-native/Sources/LocalSpeech.swift
@@ -1,0 +1,109 @@
+import AVFoundation
+import Observation
+import Speech
+
+@MainActor @Observable
+final class LocalSpeech {
+    enum Readiness: Equatable { case checking, unavailable, downloadNeeded, ready, downloading, running, failed }
+    private(set) var readiness = Readiness.checking
+    private(set) var detail = "Checking on-device speech…"
+    private var analyzer: SpeechAnalyzer?
+    private var resultTask: Task<Void, Never>?
+    private var selectedLocale: Locale?
+    private var generation = UUID()
+    private var downloading = false
+
+    func check(_ language: SpokenLanguage) async {
+        guard analyzer == nil, !downloading else { return }
+        let request = UUID()
+        generation = request
+        readiness = .checking
+        let locale = await SpeechTranscriber.supportedLocale(equivalentTo: Locale(identifier: language.rawValue))
+        guard request == generation else { return }
+        guard SpeechTranscriber.isAvailable, let locale else {
+            selectedLocale = nil
+            readiness = .unavailable
+            detail = "On-device speech is unavailable here for this language. You can still record and write notes."
+            return
+        }
+        selectedLocale = locale
+        let module = SpeechTranscriber(locale: locale, preset: .timeIndexedProgressiveTranscription)
+        let status = await AssetInventory.status(forModules: [module])
+        guard request == generation else { return }
+        readiness = status == .installed ? .ready : .downloadNeeded
+        detail = status == .installed ? "Speech model ready on this device." : "Download the speech model before recording with live text."
+    }
+
+    func download(_ language: SpokenLanguage) async {
+        guard let selectedLocale, readiness == .downloadNeeded else { return }
+        downloading = true
+        readiness = .downloading
+        detail = "Downloading the speech model…"
+        do {
+            let module = SpeechTranscriber(locale: selectedLocale, preset: .timeIndexedProgressiveTranscription)
+            if let request = try await AssetInventory.assetInstallationRequest(supporting: [module]) {
+                try await request.downloadAndInstall()
+            }
+            downloading = false
+            await check(language)
+        } catch { downloading = false; fail("Speech model download failed. \(error.localizedDescription)") }
+    }
+
+    func start(language: SpokenLanguage, offset: TimeInterval,
+               onPassage: @escaping @MainActor (TranscriptPassage) -> Void) async
+        -> (AVAudioFormat, AsyncStream<AnalyzerInput>.Continuation)? {
+        await check(language)
+        guard readiness == .ready, let selectedLocale else { return nil }
+        let module = SpeechTranscriber(locale: selectedLocale, preset: .timeIndexedProgressiveTranscription)
+        let analyzer = SpeechAnalyzer(modules: [module])
+        let (stream, continuation) = AsyncStream<AnalyzerInput>.makeStream(bufferingPolicy: .bufferingOldest(128))
+        guard let format = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [module]) else {
+            fail("A compatible speech audio format is unavailable.")
+            return nil
+        }
+        self.analyzer = analyzer
+        do {
+            try await analyzer.prepareToAnalyze(in: format)
+            resultTask = Task { [weak self] in
+                do {
+                    for try await result in module.results {
+                        guard !Task.isCancelled else { return }
+                        onPassage(TranscriptPassage(start: offset + result.range.start.seconds,
+                            end: offset + CMTimeRangeGetEnd(result.range).seconds,
+                            text: String(result.text.characters), isFinal: result.isFinal))
+                    }
+                } catch { self?.fail("Live transcription stopped. Audio is preserved. \(error.localizedDescription)") }
+            }
+            try await analyzer.start(inputSequence: stream)
+            readiness = .running
+            detail = "Transcribing on this device. Speaker identification is not connected yet."
+            return (format, continuation)
+        } catch {
+            continuation.finish()
+            await analyzer.cancelAndFinishNow()
+            resultTask?.cancel()
+            self.analyzer = nil
+            fail("Live transcription could not start. Audio can still be recorded. \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    func finish() async {
+        if let analyzer {
+            let timeout = Task { [weak self] in
+                do { try await Task.sleep(for: .seconds(20)) } catch { return }
+                self?.fail("Transcription finalization timed out. Saved audio and text are retained.")
+                await analyzer.cancelAndFinishNow()
+            }
+            defer { timeout.cancel() }
+            do { try await analyzer.finalizeAndFinishThroughEndOfInput() }
+            catch { fail("Transcription finalization failed. The saved audio is retained. \(error.localizedDescription)") }
+        }
+        await resultTask?.value
+        resultTask = nil
+        analyzer = nil
+        if readiness == .running { readiness = .ready; detail = "Speech model ready on this device." }
+    }
+
+    func fail(_ message: String) { readiness = .failed; detail = message }
+}

--- a/apps/mobile-native/Sources/LocalSpeech.swift
+++ b/apps/mobile-native/Sources/LocalSpeech.swift
@@ -12,30 +12,45 @@ final class LocalSpeech {
     private var selectedLocale: Locale?
     private var generation = UUID()
     private var downloading = false
+    private var preparing = false
+    struct Availability {
+        let locale: Locale
+        let installed: Bool
+    }
+    private let availability: @MainActor (SpokenLanguage) async -> Availability?
+
+    init(availability: @escaping @MainActor (SpokenLanguage) async -> Availability? = { language in
+        guard SpeechTranscriber.isAvailable,
+              let locale = await SpeechTranscriber.supportedLocale(equivalentTo: Locale(identifier: language.rawValue))
+        else { return nil }
+        let module = SpeechTranscriber(locale: locale, preset: .timeIndexedProgressiveTranscription)
+        return Availability(locale: locale, installed: await AssetInventory.status(forModules: [module]) == .installed)
+    }) { self.availability = availability }
 
     func check(_ language: SpokenLanguage) async {
-        guard analyzer == nil, !downloading else { return }
+        guard analyzer == nil, !downloading, !preparing else { return }
+        await refreshAvailability(language)
+    }
+
+    private func refreshAvailability(_ language: SpokenLanguage) async {
         let request = UUID()
         generation = request
         readiness = .checking
-        let locale = await SpeechTranscriber.supportedLocale(equivalentTo: Locale(identifier: language.rawValue))
+        let result = await availability(language)
         guard request == generation else { return }
-        guard SpeechTranscriber.isAvailable, let locale else {
+        guard let result else {
             selectedLocale = nil
             readiness = .unavailable
             detail = "On-device speech is unavailable here for this language. You can still record and write notes."
             return
         }
-        selectedLocale = locale
-        let module = SpeechTranscriber(locale: locale, preset: .timeIndexedProgressiveTranscription)
-        let status = await AssetInventory.status(forModules: [module])
-        guard request == generation else { return }
-        readiness = status == .installed ? .ready : .downloadNeeded
-        detail = status == .installed ? "Speech model ready on this device." : "Download the speech model before recording with live text."
+        selectedLocale = result.locale
+        readiness = result.installed ? .ready : .downloadNeeded
+        detail = result.installed ? "Speech model ready on this device." : "Download the speech model before recording with live text."
     }
 
     func download(_ language: SpokenLanguage) async {
-        guard let selectedLocale, readiness == .downloadNeeded else { return }
+        guard !preparing, analyzer == nil, let selectedLocale, readiness == .downloadNeeded else { return }
         downloading = true
         readiness = .downloading
         detail = "Downloading the speech model…"
@@ -52,7 +67,10 @@ final class LocalSpeech {
     func start(language: SpokenLanguage, offset: TimeInterval,
                onPassage: @escaping @MainActor (TranscriptPassage) -> Void) async
         -> (AVAudioFormat, AsyncStream<AnalyzerInput>.Continuation)? {
-        await check(language)
+        guard analyzer == nil, !preparing, !downloading else { return nil }
+        preparing = true
+        defer { preparing = false }
+        await refreshAvailability(language)
         guard readiness == .ready, let selectedLocale else { return nil }
         let module = SpeechTranscriber(locale: selectedLocale, preset: .timeIndexedProgressiveTranscription)
         let analyzer = SpeechAnalyzer(modules: [module])

--- a/apps/mobile-native/Sources/LocalSpeech.swift
+++ b/apps/mobile-native/Sources/LocalSpeech.swift
@@ -76,7 +76,7 @@ final class LocalSpeech {
             }
             try await analyzer.start(inputSequence: stream)
             readiness = .running
-            detail = "Transcribing on this device. Speaker identification is not connected yet."
+            detail = "Transcribing on this device."
             return (format, continuation)
         } catch {
             continuation.finish()

--- a/apps/mobile-native/Sources/NoteEditor.swift
+++ b/apps/mobile-native/Sources/NoteEditor.swift
@@ -14,6 +14,11 @@ struct NoteEditor: View {
     private var isActive: Bool { recording.noteID == id }
     private var audio: [URL] { library.disk?.audioFiles(for: id) ?? [] }
 
+    private func play(at seconds: TimeInterval = 0) {
+        guard recording.permitsPlayback else { return }
+        player.play(files: audio, at: seconds)
+    }
+
     private func binding<Value>(_ keyPath: WritableKeyPath<NoteRecord, Value>) -> Binding<Value> {
         Binding(get: { note[keyPath: keyPath] }, set: { value in library.update(id) { $0[keyPath: keyPath] = value } })
     }
@@ -57,11 +62,14 @@ struct NoteEditor: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .task(id: note.language) {
-            if recording.noteID == nil { await recording.speech.check(note.language) }
-            await recording.speakers.check()
+            if recording.noteID == nil && !recording.busy {
+                await recording.speech.check(note.language)
+                await recording.speakers.check()
+            }
         }
         .onDisappear { player.stop() }
         .onChange(of: recording.noteID) { _, value in if value != nil { player.stop() } }
+        .onChange(of: recording.busy) { _, value in if value { player.stop() } }
     }
 
     private var notePicker: some View {
@@ -106,11 +114,11 @@ struct NoteEditor: View {
                                 .font(.caption.bold())
                             Spacer()
                             Button {
-                                player.play(files: audio, at: passage.start)
+                                play(at: passage.start)
                             } label: {
                                 Text(Duration.seconds(passage.start), format: .time(pattern: .minuteSecond))
                                     .monospacedDigit().font(.caption)
-                            }.disabled(audio.isEmpty || recording.noteID != nil)
+                            }.disabled(audio.isEmpty || !recording.permitsPlayback)
                                 .accessibilityLabel("Play passage")
                         }
                         Text(passage.text).foregroundStyle(passage.isFinal ? .primary : .secondary)
@@ -137,8 +145,8 @@ struct NoteEditor: View {
                 if !audio.isEmpty && recording.noteID == nil {
                     Button(player.isPlaying ? "Stop playback" : "Play recording",
                            systemImage: player.isPlaying ? "stop.fill" : "play.fill") {
-                        if player.isPlaying { player.stop() } else { player.play(files: audio) }
-                    }.buttonStyle(.bordered)
+                        if player.isPlaying { player.stop() } else { play() }
+                    }.buttonStyle(.bordered).disabled(!recording.permitsPlayback)
                 }
                 Spacer()
                 Button(isActive ? "Stop recording" : "Record", systemImage: isActive ? "stop.fill" : "mic.fill") {

--- a/apps/mobile-native/Sources/NoteEditor.swift
+++ b/apps/mobile-native/Sources/NoteEditor.swift
@@ -1,0 +1,197 @@
+import SwiftUI
+import PencilKit
+
+struct NoteEditor: View {
+    let id: UUID
+    @Bindable var library: NoteLibrary
+    @Bindable var recording: RecordingSession
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    @State private var pane = 0
+    @State private var player = LocalPlayback()
+
+    private var note: NoteRecord { library.note(id) ?? NoteRecord(id: id) }
+    private var isActive: Bool { recording.noteID == id }
+    private var audio: [URL] { library.disk?.audioFiles(for: id) ?? [] }
+
+    private func binding<Value>(_ keyPath: WritableKeyPath<NoteRecord, Value>) -> Binding<Value> {
+        Binding(get: { note[keyPath: keyPath] }, set: { value in library.update(id) { $0[keyPath: keyPath] = value } })
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TextField("Untitled note", text: binding(\.title), axis: .vertical)
+                .font(.largeTitle.bold()).padding().accessibilityIdentifier("noteTitle")
+            if note.captureState == .interrupted {
+                Label("Recording interrupted. Saved audio and notes are retained. Start again when ready.", systemImage: "pause.circle")
+                    .font(.callout).foregroundStyle(.orange).padding(.horizontal)
+            }
+            HStack {
+                Picker("Spoken language", selection: binding(\.language)) {
+                    ForEach(SpokenLanguage.allCases) { Text($0.name).tag($0) }
+                }
+                .disabled(recording.noteID != nil || recording.busy || recording.speech.readiness == .downloading)
+                Spacer()
+                if let started = recording.startedAt, isActive {
+                    Label { Text(started, style: .timer).monospacedDigit() } icon: { Image(systemName: "record.circle.fill") }
+                        .foregroundStyle(.red)
+                }
+            }.padding(.horizontal)
+            // Keep recording controls clear of PencilKit's floating tool palette.
+            captureControls
+            if sizeClass == .regular {
+                HStack(spacing: 0) {
+                    VStack(spacing: 0) { notePicker; notePane }.frame(maxWidth: .infinity)
+                    Divider()
+                    transcript.frame(maxWidth: .infinity)
+                }
+            } else {
+                Picker("Content", selection: $pane) {
+                    Text("Notes").tag(0)
+                    Text("Ink").tag(1)
+                    Text("Transcript").tag(2)
+                }.pickerStyle(.segmented).padding()
+                if pane == 2 { transcript } else { notePane }
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .task(id: note.language) {
+            if recording.noteID == nil { await recording.speech.check(note.language) }
+        }
+        .onDisappear { player.stop() }
+        .onChange(of: recording.noteID) { _, value in if value != nil { player.stop() } }
+    }
+
+    private var notePicker: some View {
+        Picker("Content", selection: $pane) { Text("Notes").tag(0); Text("Ink").tag(1) }
+            .pickerStyle(.segmented).padding()
+    }
+
+    @ViewBuilder private var notePane: some View {
+        if pane == 1 {
+            if note.ink.isEmpty || (try? PKDrawing(data: note.ink)) != nil {
+                InkCanvas(data: binding(\.ink)).accessibilityLabel("Drawing canvas")
+            } else {
+                ContentUnavailableView("Drawing could not be opened", systemImage: "pencil.tip.crop.circle.badge.exclamationmark",
+                    description: Text("The original drawing is preserved."))
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Your personal notes").font(.caption).foregroundStyle(.secondary).padding(.horizontal)
+                TextEditor(text: binding(\.text)).padding(.horizontal, 8)
+                    .accessibilityLabel("Personal notes").accessibilityIdentifier("personalNotes")
+            }
+        }
+    }
+
+    private var transcript: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 16) {
+                Text("Transcript").font(.title2.bold())
+                Text(recording.speech.detail).font(.callout).foregroundStyle(.secondary)
+                if recording.noteID == nil && recording.speech.readiness == .downloadNeeded {
+                    Button("Download speech model", systemImage: "arrow.down.circle") {
+                        Task { await recording.speech.download(note.language) }
+                    }.disabled(recording.busy)
+                }
+                if recording.noteID == nil && recording.speech.readiness == .failed {
+                    Button("Check speech availability") { Task { await recording.speech.check(note.language) } }
+                }
+                ForEach(note.passages) { passage in
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Text(passage.speakerName ?? String(localized: "Unassigned speaker")).font(.caption.bold())
+                            Spacer()
+                            Button {
+                                player.play(files: audio, at: passage.start)
+                            } label: {
+                                Text(Duration.seconds(passage.start), format: .time(pattern: .minuteSecond))
+                                    .monospacedDigit().font(.caption)
+                            }.disabled(audio.isEmpty || recording.noteID != nil)
+                                .accessibilityLabel("Play passage")
+                        }
+                        Text(passage.text).foregroundStyle(passage.isFinal ? .primary : .secondary)
+                        if !passage.isFinal { Text("Draft transcription").font(.caption).foregroundStyle(.secondary) }
+                    }
+                }
+                if note.passages.isEmpty {
+                    Text("Live text will appear here when the speech model is ready.")
+                        .foregroundStyle(.secondary).padding(.vertical)
+                }
+            }.frame(maxWidth: .infinity, alignment: .leading).padding()
+        }
+    }
+
+    private var captureControls: some View {
+        VStack(spacing: 8) {
+            if let problem = player.problem { Text(problem).font(.caption).foregroundStyle(.red) }
+            HStack {
+                if !audio.isEmpty && recording.noteID == nil {
+                    Button(player.isPlaying ? "Stop playback" : "Play recording",
+                           systemImage: player.isPlaying ? "stop.fill" : "play.fill") {
+                        if player.isPlaying { player.stop() } else { player.play(files: audio) }
+                    }.buttonStyle(.bordered)
+                }
+                Spacer()
+                Button(isActive ? "Stop recording" : "Record", systemImage: isActive ? "stop.fill" : "mic.fill") {
+                    player.stop()
+                    Task {
+                        if isActive { await recording.stop(library: library) }
+                        else { await recording.start(id, library: library) }
+                    }
+                }.buttonStyle(.borderedProminent).tint(isActive ? .red : .accentColor)
+                    .disabled(recording.busy || (recording.noteID != nil && !isActive) || recording.speech.readiness == .downloading)
+                    .accessibilityIdentifier("recordButton")
+            }
+            if recording.busy { ProgressView("Preparing or finalizing recording…").font(.caption) }
+        }.padding().background(.bar)
+    }
+}
+
+struct InkCanvas: UIViewRepresentable {
+    @Binding var data: Data
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+    func makeUIView(context: Context) -> PKCanvasView {
+        let canvas = DrawingCanvasView()
+        canvas.picker = context.coordinator.picker
+        canvas.drawingPolicy = .anyInput
+        canvas.alwaysBounceVertical = true
+        canvas.contentSize = CGSize(width: 1200, height: 1800)
+        canvas.minimumZoomScale = 0.25
+        canvas.maximumZoomScale = 4
+        canvas.tool = PKInkingTool(.pen, color: .label, width: 3)
+        canvas.delegate = context.coordinator
+        context.coordinator.picker.addObserver(canvas)
+        return canvas
+    }
+    func updateUIView(_ canvas: PKCanvasView, context: Context) {
+        context.coordinator.parent = self
+        if context.coordinator.lastData != data {
+            context.coordinator.lastData = data
+            canvas.drawing = (try? PKDrawing(data: data)) ?? PKDrawing()
+        }
+        context.coordinator.picker.setVisible(true, forFirstResponder: canvas)
+    }
+    final class Coordinator: NSObject, PKCanvasViewDelegate {
+        var parent: InkCanvas
+        var lastData = Data()
+        let picker = PKToolPicker()
+        init(_ parent: InkCanvas) { self.parent = parent }
+        func canvasViewDrawingDidChange(_ canvasView: PKCanvasView) {
+            let data = canvasView.drawing.dataRepresentation()
+            guard data != lastData else { return }
+            lastData = data
+            parent.data = data
+        }
+    }
+}
+
+final class DrawingCanvasView: PKCanvasView {
+    var picker: PKToolPicker?
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        guard window != nil else { return }
+        becomeFirstResponder()
+        picker?.setVisible(true, forFirstResponder: self)
+    }
+}

--- a/apps/mobile-native/Sources/NoteEditor.swift
+++ b/apps/mobile-native/Sources/NoteEditor.swift
@@ -8,6 +8,7 @@ struct NoteEditor: View {
     @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var pane = 0
     @State private var player = LocalPlayback()
+    @State private var showSpeakers = false
 
     private var note: NoteRecord { library.note(id) ?? NoteRecord(id: id) }
     private var isActive: Bool { recording.noteID == id }
@@ -38,6 +39,7 @@ struct NoteEditor: View {
             }.padding(.horizontal)
             // Keep recording controls clear of PencilKit's floating tool palette.
             captureControls
+            if showSpeakers { speakerSettings }
             if sizeClass == .regular {
                 HStack(spacing: 0) {
                     VStack(spacing: 0) { notePicker; notePane }.frame(maxWidth: .infinity)
@@ -56,6 +58,7 @@ struct NoteEditor: View {
         .navigationBarTitleDisplayMode(.inline)
         .task(id: note.language) {
             if recording.noteID == nil { await recording.speech.check(note.language) }
+            await recording.speakers.check()
         }
         .onDisappear { player.stop() }
         .onChange(of: recording.noteID) { _, value in if value != nil { player.stop() } }
@@ -99,7 +102,8 @@ struct NoteEditor: View {
                 ForEach(note.passages) { passage in
                     VStack(alignment: .leading, spacing: 6) {
                         HStack {
-                            Text(passage.speakerName ?? String(localized: "Unassigned speaker")).font(.caption.bold())
+                            Text(passage.speakerName ?? note.speakerAnnotations?.label(for: passage) ?? String(localized: "Unassigned speaker"))
+                                .font(.caption.bold())
                             Spacer()
                             Button {
                                 player.play(files: audio, at: passage.start)
@@ -124,7 +128,12 @@ struct NoteEditor: View {
     private var captureControls: some View {
         VStack(spacing: 8) {
             if let problem = player.problem { Text(problem).font(.caption).foregroundStyle(.red) }
+            if recording.speakers.state == .failed {
+                Text(recording.speakers.detail).font(.caption).foregroundStyle(.orange)
+            }
             HStack {
+                Button("Speakers", systemImage: "person.2") { showSpeakers.toggle() }
+                    .accessibilityIdentifier("speakerSettings")
                 if !audio.isEmpty && recording.noteID == nil {
                     Button(player.isPlaying ? "Stop playback" : "Play recording",
                            systemImage: player.isPlaying ? "stop.fill" : "play.fill") {
@@ -139,11 +148,42 @@ struct NoteEditor: View {
                         else { await recording.start(id, library: library) }
                     }
                 }.buttonStyle(.borderedProminent).tint(isActive ? .red : .accentColor)
-                    .disabled(recording.busy || (recording.noteID != nil && !isActive) || recording.speech.readiness == .downloading)
+                    .disabled(recording.busy || (recording.noteID != nil && !isActive) || recording.speech.readiness == .downloading || recording.speakers.preparing)
                     .accessibilityIdentifier("recordButton")
             }
             if recording.busy { ProgressView("Preparing or finalizing recording…").font(.caption) }
         }.padding().background(.bar)
+    }
+
+    private var speakerSettings: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+                Toggle("Live speaker labels", isOn: Binding(get: { recording.speakers.enabled }, set: { recording.speakers.enabled = $0 }))
+                    .disabled(recording.noteID != nil || recording.busy || recording.speakers.preparing)
+                Text(recording.speakers.detail).font(.caption).foregroundStyle(.secondary)
+                if recording.noteID == nil && !recording.busy {
+                    if recording.speakers.state == .downloading {
+                        Button("Cancel model download") { recording.speakers.cancelDownload() }
+                    } else if recording.speakers.state == .missing || recording.speakers.state == .failed {
+                        Button("Download speaker model") { recording.speakers.download() }
+                    }
+                }
+                if let annotations = note.speakerAnnotations {
+                    ForEach(annotations.speakerKeys, id: \.self) { key in
+                        TextField(annotations.name(for: key), text: Binding(
+                            get: { library.note(id)?.speakerAnnotations?.names[key] ?? "" },
+                            set: { name in library.update(id) { $0.speakerAnnotations?.names[key] = name.trimmingCharacters(in: .whitespacesAndNewlines) } }))
+                            .textFieldStyle(.roundedBorder)
+                    }
+                }
+                Text("Names apply to this recording session. Remembering voices across meetings is still being built.")
+                    .font(.caption).foregroundStyle(.secondary)
+                HStack {
+                    Link("Model source", destination: URL(string: "https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml")!)
+                    Link("Model license", destination: URL(string: "https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/")!)
+                }.font(.caption)
+            }.padding()
+        }.frame(maxHeight: 240).background(.quaternary.opacity(0.3))
     }
 }
 

--- a/apps/mobile-native/Sources/NoteRecord.swift
+++ b/apps/mobile-native/Sources/NoteRecord.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+enum SpokenLanguage: String, Codable, CaseIterable, Identifiable {
+    case english = "en-US", danish = "da-DK", spanish = "es-ES"
+    case french = "fr-FR", german = "de-DE"
+
+    var id: String { rawValue }
+    var name: String {
+        switch self {
+        case .english: "English"
+        case .danish: "Dansk"
+        case .spanish: "Español"
+        case .french: "Français"
+        case .german: "Deutsch"
+        }
+    }
+}
+
+struct TranscriptPassage: Codable, Identifiable, Equatable {
+    var id = UUID()
+    var start: TimeInterval
+    var end: TimeInterval
+    var text: String
+    var isFinal: Bool
+    // A missing identity is deliberate. Transcription alone does not identify a speaker.
+    var speakerName: String? = nil
+}
+
+struct NoteRecord: Codable, Identifiable, Equatable {
+    enum CaptureState: String, Codable { case idle, recording, finished, interrupted }
+    var schemaVersion = 1
+    var id = UUID()
+    var createdAt = Date()
+    var updatedAt = Date()
+    var title = ""
+    var text = ""
+    var ink = Data()
+    var language = SpokenLanguage.english
+    var passages: [TranscriptPassage] = []
+    var captureState = CaptureState.idle
+
+    mutating func apply(_ passage: TranscriptPassage) {
+        // Volatile hypotheses replace only their overlapping interval. Finalized text is immutable here.
+        passages.removeAll { !$0.isFinal && $0.start < passage.end && $0.end > passage.start }
+        if let index = passages.firstIndex(where: {
+            abs($0.start - passage.start) < 0.001 && abs($0.end - passage.end) < 0.001
+        }) {
+            if !passages[index].isFinal { passages[index] = passage }
+        } else {
+            passages.append(passage)
+        }
+        passages.sort { $0.start < $1.start }
+    }
+}

--- a/apps/mobile-native/Sources/NoteRecord.swift
+++ b/apps/mobile-native/Sources/NoteRecord.swift
@@ -38,6 +38,7 @@ struct NoteRecord: Codable, Identifiable, Equatable {
     var language = SpokenLanguage.english
     var passages: [TranscriptPassage] = []
     var captureState = CaptureState.idle
+    var speakerAnnotations: SpeakerAnnotations? = nil
 
     mutating func apply(_ passage: TranscriptPassage) {
         // Volatile hypotheses replace only their overlapping interval. Finalized text is immutable here.

--- a/apps/mobile-native/Sources/NoteStore.swift
+++ b/apps/mobile-native/Sources/NoteStore.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Observation
+
+struct NoteDiskStore {
+    let root: URL
+
+    init(root: URL) throws {
+        self.root = root
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication])
+    }
+
+    func directory(for id: UUID) -> URL { root.appendingPathComponent(id.uuidString, isDirectory: true) }
+
+    func audioDirectory(for id: UUID) throws -> URL {
+        let url = directory(for: id).appendingPathComponent("audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication])
+        return url
+    }
+
+    func save(_ note: NoteRecord) throws {
+        let dir = directory(for: note.id)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(note)
+        try data.write(to: dir.appendingPathComponent("note.json"),
+                       options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+    }
+
+    func load() throws -> (notes: [NoteRecord], unreadable: [String]) {
+        let dirs = try FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: nil)
+        var notes: [NoteRecord] = []
+        var unreadable: [String] = []
+        for dir in dirs where UUID(uuidString: dir.lastPathComponent) != nil {
+            do {
+                var note = try JSONDecoder().decode(NoteRecord.self,
+                    from: Data(contentsOf: dir.appendingPathComponent("note.json")))
+                guard note.schemaVersion == 1, note.id.uuidString == dir.lastPathComponent else {
+                    unreadable.append(dir.lastPathComponent)
+                    continue
+                }
+                if note.captureState == .recording {
+                    note.captureState = .interrupted
+                    try save(note)
+                }
+                notes.append(note)
+            } catch { unreadable.append(dir.lastPathComponent) }
+        }
+        return (notes.sorted { $0.updatedAt > $1.updatedAt }, unreadable)
+    }
+
+    func audioFiles(for id: UUID) -> [URL] {
+        let dir = directory(for: id).appendingPathComponent("audio", isDirectory: true)
+        return ((try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? [])
+            .filter { $0.pathExtension == "caf" }.sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+}
+
+@MainActor @Observable
+final class NoteLibrary {
+    private(set) var notes: [NoteRecord] = []
+    var problem: String?
+    private(set) var disk: NoteDiskStore?
+
+    init(root: URL) {
+        do {
+            let disk = try NoteDiskStore(root: root)
+            self.disk = disk
+            let result = try disk.load()
+            notes = result.notes
+            if !result.unreadable.isEmpty {
+                problem = "Some saved notes could not be opened. Their files have been preserved."
+            }
+        } catch { problem = "Local storage could not be opened. \(error.localizedDescription)" }
+    }
+
+    @discardableResult func create() -> UUID? {
+        let note = NoteRecord()
+        guard persist(note) else { return nil }
+        notes.insert(note, at: 0)
+        return note.id
+    }
+
+    func note(_ id: UUID) -> NoteRecord? { notes.first { $0.id == id } }
+
+    @discardableResult func update(_ id: UUID, _ change: (inout NoteRecord) -> Void) -> Bool {
+        guard let i = notes.firstIndex(where: { $0.id == id }) else { return false }
+        var note = notes[i]
+        change(&note)
+        note.updatedAt = Date()
+        // Keep unsaved edits visible if storage fails. Never display a false saved status.
+        notes[i] = note
+        return persist(note)
+    }
+
+    private func persist(_ note: NoteRecord) -> Bool {
+        do {
+            guard let disk else { return false }
+            try disk.save(note)
+            return true
+        } catch {
+            problem = "Changes could not be saved. Keep the app open and free device storage. \(error.localizedDescription)"
+            return false
+        }
+    }
+}

--- a/apps/mobile-native/Sources/NoteStore.swift
+++ b/apps/mobile-native/Sources/NoteStore.swift
@@ -27,10 +27,11 @@ struct NoteDiskStore {
                        options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
     }
 
-    func load() throws -> (notes: [NoteRecord], unreadable: [String]) {
+    func load() throws -> (notes: [NoteRecord], unreadable: [String], audioProblems: [String]) {
         let dirs = try FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: nil)
         var notes: [NoteRecord] = []
         var unreadable: [String] = []
+        var audioProblems: [String] = []
         for dir in dirs where UUID(uuidString: dir.lastPathComponent) != nil {
             do {
                 var note = try JSONDecoder().decode(NoteRecord.self,
@@ -39,6 +40,8 @@ struct NoteDiskStore {
                     unreadable.append(dir.lastPathComponent)
                     continue
                 }
+                let recovery = AudioRecovery.recover(directory: dir.appendingPathComponent("audio"))
+                audioProblems.append(contentsOf: recovery.unreadable)
                 if note.captureState == .recording {
                     note.captureState = .interrupted
                     try save(note)
@@ -46,13 +49,18 @@ struct NoteDiskStore {
                 notes.append(note)
             } catch { unreadable.append(dir.lastPathComponent) }
         }
-        return (notes.sorted { $0.updatedAt > $1.updatedAt }, unreadable)
+        return (notes.sorted { $0.updatedAt > $1.updatedAt }, unreadable, audioProblems)
     }
 
     func audioFiles(for id: UUID) -> [URL] {
         let dir = directory(for: id).appendingPathComponent("audio", isDirectory: true)
-        return ((try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? [])
-            .filter { $0.pathExtension == "caf" }.sorted { $0.lastPathComponent < $1.lastPathComponent }
+        let files = (try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []
+        return files.filter { $0.pathExtension == "caf" && !$0.lastPathComponent.hasSuffix(".recovered.caf") }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+            .map { original in
+                let recovered = AudioRecovery.recoveredURL(for: original)
+                return FileManager.default.fileExists(atPath: recovered.path) ? recovered : original
+            }
     }
 }
 
@@ -70,6 +78,8 @@ final class NoteLibrary {
             notes = result.notes
             if !result.unreadable.isEmpty {
                 problem = "Some saved notes could not be opened. Their files have been preserved."
+            } else if !result.audioProblems.isEmpty {
+                problem = "Some interrupted audio needs recovery. Original files and notes are preserved."
             }
         } catch { problem = "Local storage could not be opened. \(error.localizedDescription)" }
     }

--- a/apps/mobile-native/Sources/NoteStore.swift
+++ b/apps/mobile-native/Sources/NoteStore.swift
@@ -27,11 +27,13 @@ struct NoteDiskStore {
                        options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
     }
 
-    func load() throws -> (notes: [NoteRecord], unreadable: [String], audioProblems: [String]) {
+    func load(persistRecovery: ((NoteRecord) throws -> Void)? = nil) throws
+        -> (notes: [NoteRecord], unreadable: [String], audioProblems: [String], recoveryWriteProblems: [String]) {
         let dirs = try FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: nil)
         var notes: [NoteRecord] = []
         var unreadable: [String] = []
         var audioProblems: [String] = []
+        var recoveryWriteProblems: [String] = []
         for dir in dirs where UUID(uuidString: dir.lastPathComponent) != nil {
             do {
                 var note = try JSONDecoder().decode(NoteRecord.self,
@@ -44,12 +46,15 @@ struct NoteDiskStore {
                 audioProblems.append(contentsOf: recovery.unreadable)
                 if note.captureState == .recording {
                     note.captureState = .interrupted
-                    try save(note)
+                    do {
+                        if let persistRecovery { try persistRecovery(note) }
+                        else { try save(note) }
+                    } catch { recoveryWriteProblems.append(dir.lastPathComponent) }
                 }
                 notes.append(note)
             } catch { unreadable.append(dir.lastPathComponent) }
         }
-        return (notes.sorted { $0.updatedAt > $1.updatedAt }, unreadable, audioProblems)
+        return (notes.sorted { $0.updatedAt > $1.updatedAt }, unreadable, audioProblems, recoveryWriteProblems)
     }
 
     func audioFiles(for id: UUID) -> [URL] {
@@ -80,6 +85,8 @@ final class NoteLibrary {
                 problem = "Some saved notes could not be opened. Their files have been preserved."
             } else if !result.audioProblems.isEmpty {
                 problem = "Some interrupted audio needs recovery. Original files and notes are preserved."
+            } else if !result.recoveryWriteProblems.isEmpty {
+                problem = "Recovered notes are available, but recovery status could not be saved. Free device storage before continuing."
             }
         } catch { problem = "Local storage could not be opened. \(error.localizedDescription)" }
     }

--- a/apps/mobile-native/Sources/RecordingSession.swift
+++ b/apps/mobile-native/Sources/RecordingSession.swift
@@ -14,13 +14,19 @@ final class RecordingSession {
     private var captureFailed = false
     private var interruptionObserver: NSObjectProtocol?
     private var routeObserver: NSObjectProtocol?
+    private let recordPermission: @MainActor () async -> Bool
+    var permitsPlayback: Bool { noteID == nil && !busy }
+
+    init(recordPermission: @escaping @MainActor () async -> Bool = {
+        await AVAudioApplication.requestRecordPermission()
+    }) { self.recordPermission = recordPermission }
 
     func start(_ id: UUID, library: NoteLibrary) async {
         guard noteID == nil, !busy, let note = library.note(id), let disk = library.disk else { return }
         busy = true
         captureFailed = false
         defer { busy = false }
-        guard await AVAudioApplication.requestRecordPermission() else {
+        guard await recordPermission() else {
             problem = CaptureError.microphone.localizedDescription
             return
         }

--- a/apps/mobile-native/Sources/RecordingSession.swift
+++ b/apps/mobile-native/Sources/RecordingSession.swift
@@ -1,0 +1,101 @@
+import AVFoundation
+import Observation
+
+@MainActor @Observable
+final class RecordingSession {
+    private(set) var noteID: UUID?
+    private(set) var busy = false
+    private(set) var startedAt: Date?
+    var problem: String?
+    let speech = LocalSpeech()
+    private var engine: AVAudioEngine?
+    private var writer: AudioChunkWriter?
+    private var interruptionObserver: NSObjectProtocol?
+    private var routeObserver: NSObjectProtocol?
+
+    func start(_ id: UUID, library: NoteLibrary) async {
+        guard noteID == nil, !busy, let note = library.note(id), let disk = library.disk else { return }
+        busy = true
+        defer { busy = false }
+        guard await AVAudioApplication.requestRecordPermission() else {
+            problem = CaptureError.microphone.localizedDescription
+            return
+        }
+        do {
+            let directory = try disk.audioDirectory(for: id)
+            let audioSession = AVAudioSession.sharedInstance()
+            try audioSession.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker, .allowBluetoothHFP])
+            try audioSession.setActive(true)
+            let engine = AVAudioEngine()
+            let input = engine.inputNode
+            let format = input.outputFormat(forBus: 0)
+            guard format.sampleRate > 0, format.channelCount > 0 else { throw CaptureError.format }
+            let offset = disk.audioFiles(for: id).reduce(0.0) { total, url in
+                guard let file = try? AVAudioFile(forReading: url) else { return total }
+                return total + Double(file.length) / file.processingFormat.sampleRate
+            }
+            let speechFeed = await speech.start(language: note.language, offset: offset) { passage in
+                library.update(id) { $0.apply(passage) }
+            }
+            guard library.update(id, { $0.captureState = .recording }) else {
+                speechFeed?.1.finish()
+                await speech.finish()
+                try? audioSession.setActive(false)
+                return
+            }
+            let writer = AudioChunkWriter(directory: directory,
+                speechFormat: speechFeed?.0, speechInput: speechFeed?.1,
+                onCaptureError: { [weak self] message in
+                    Task { @MainActor in
+                        guard let self, self.noteID == id else { return }
+                        self.problem = message
+                        await self.stop(library: library, interrupted: true)
+                    }
+                }, onSpeechError: { [weak self] message in
+                    Task { @MainActor in self?.speech.fail(message) }
+                })
+            self.writer = writer
+            self.engine = engine
+            self.noteID = id
+            input.installTap(onBus: 0, bufferSize: 4096, format: format) { buffer, _ in writer.append(buffer) }
+            engine.prepare()
+            try engine.start()
+            startedAt = Date()
+            interruptionObserver = NotificationCenter.default.addObserver(
+                forName: AVAudioSession.interruptionNotification, object: nil, queue: .main) { [weak self] event in
+                    guard let raw = event.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+                          raw == AVAudioSession.InterruptionType.began.rawValue else { return }
+                    Task { @MainActor in await self?.stop(library: library, interrupted: true) }
+                }
+            routeObserver = NotificationCenter.default.addObserver(
+                forName: .AVAudioEngineConfigurationChange, object: engine, queue: .main) { [weak self] _ in
+                    Task { @MainActor in await self?.stop(library: library, interrupted: true) }
+                }
+        } catch {
+            problem = "Recording could not start. \(error.localizedDescription)"
+            busy = false
+            if noteID != nil { await stop(library: library, interrupted: true) }
+            else { try? AVAudioSession.sharedInstance().setActive(false) }
+        }
+    }
+
+    func stop(library: NoteLibrary, interrupted: Bool = false) async {
+        guard let id = noteID, !busy else { return }
+        busy = true
+        if let interruptionObserver { NotificationCenter.default.removeObserver(interruptionObserver) }
+        if let routeObserver { NotificationCenter.default.removeObserver(routeObserver) }
+        interruptionObserver = nil
+        routeObserver = nil
+        engine?.inputNode.removeTap(onBus: 0)
+        engine?.stop()
+        engine = nil
+        await writer?.finish()
+        writer = nil
+        library.update(id) { $0.captureState = interrupted ? .interrupted : .finished }
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        await speech.finish()
+        noteID = nil
+        startedAt = nil
+        busy = false
+    }
+}

--- a/apps/mobile-native/Sources/RecordingSession.swift
+++ b/apps/mobile-native/Sources/RecordingSession.swift
@@ -8,14 +8,17 @@ final class RecordingSession {
     private(set) var startedAt: Date?
     var problem: String?
     let speech = LocalSpeech()
+    let speakers = StreamingSpeakers()
     private var engine: AVAudioEngine?
     private var writer: AudioChunkWriter?
+    private var captureFailed = false
     private var interruptionObserver: NSObjectProtocol?
     private var routeObserver: NSObjectProtocol?
 
     func start(_ id: UUID, library: NoteLibrary) async {
         guard noteID == nil, !busy, let note = library.note(id), let disk = library.disk else { return }
         busy = true
+        captureFailed = false
         defer { busy = false }
         guard await AVAudioApplication.requestRecordPermission() else {
             problem = CaptureError.microphone.localizedDescription
@@ -30,29 +33,41 @@ final class RecordingSession {
             let input = engine.inputNode
             let format = input.outputFormat(forBus: 0)
             guard format.sampleRate > 0, format.channelCount > 0 else { throw CaptureError.format }
-            let offset = disk.audioFiles(for: id).reduce(0.0) { total, url in
-                guard let file = try? AVAudioFile(forReading: url) else { return total }
+            let offset = try disk.audioFiles(for: id).reduce(0.0) { total, url in
+                let file = try AVAudioFile(forReading: url)
                 return total + Double(file.length) / file.processingFormat.sampleRate
             }
             let speechFeed = await speech.start(language: note.language, offset: offset) { passage in
                 library.update(id) { $0.apply(passage) }
             }
+            let speakerFeed = await speakers.start(offset: offset) { sessionID, turns in
+                library.update(id) { note in
+                    var annotations = note.speakerAnnotations ?? SpeakerAnnotations()
+                    annotations.replace(sessionID: sessionID, with: turns)
+                    note.speakerAnnotations = annotations
+                }
+            }
             guard library.update(id, { $0.captureState = .recording }) else {
                 speechFeed?.1.finish()
+                speakerFeed?.finish()
                 await speech.finish()
+                await speakers.finish()
                 try? audioSession.setActive(false)
                 return
             }
             let writer = AudioChunkWriter(directory: directory,
-                speechFormat: speechFeed?.0, speechInput: speechFeed?.1,
+                speechFormat: speechFeed?.0, speechInput: speechFeed?.1, speakerInput: speakerFeed,
                 onCaptureError: { [weak self] message in
                     Task { @MainActor in
                         guard let self, self.noteID == id else { return }
                         self.problem = message
+                        self.captureFailed = true
                         await self.stop(library: library, interrupted: true)
                     }
                 }, onSpeechError: { [weak self] message in
                     Task { @MainActor in self?.speech.fail(message) }
+                }, onSpeakerError: { [weak self] message in
+                    Task { @MainActor in self?.speakers.fail(message) }
                 })
             self.writer = writer
             self.engine = engine
@@ -91,9 +106,10 @@ final class RecordingSession {
         engine = nil
         await writer?.finish()
         writer = nil
-        library.update(id) { $0.captureState = interrupted ? .interrupted : .finished }
+        library.update(id) { $0.captureState = (interrupted || captureFailed) ? .interrupted : .finished }
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
         await speech.finish()
+        await speakers.finish()
         noteID = nil
         startedAt = nil
         busy = false

--- a/apps/mobile-native/Sources/Resources/SpeakerModel/manifest.json
+++ b/apps/mobile-native/Sources/Resources/SpeakerModel/manifest.json
@@ -1,0 +1,27 @@
+{
+  "repository": "FluidInference/diar-streaming-sortformer-coreml",
+  "revision": "ae9a27ab45dc0aa3abede7d2d6bad2b7a69aa6d1",
+  "package": "Sortformer_v2.1.mlpackage",
+  "files": [
+    {
+      "path": "Manifest.json",
+      "size": 617,
+      "sha256": "216380ef6d639d64dbd84236de641cf98b5350ccf1e6103156502a240b07fd91"
+    },
+    {
+      "path": "Data/com.apple.CoreML/model.mlmodel",
+      "size": 762389,
+      "sha256": "4bcf2064983710d51ad167aeeacec76c9cba93043924986218a1da9dde316750"
+    },
+    {
+      "path": "Data/com.apple.CoreML/weights/0-weight.bin",
+      "size": 8948544,
+      "sha256": "88a98803e35186b1dfb41d7f748f7cee5093bb6efeb117f56953c17549792fa4"
+    },
+    {
+      "path": "Data/com.apple.CoreML/weights/1-weight.bin",
+      "size": 230428224,
+      "sha256": "4c85926af77684bce762b355a2b162df557d832444fbeb79ee195113a4bbf1db"
+    }
+  ]
+}

--- a/apps/mobile-native/Sources/Resources/ThirdParty/FluidAudio-LICENSE.txt
+++ b/apps/mobile-native/Sources/Resources/ThirdParty/FluidAudio-LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/mobile-native/Sources/Resources/ThirdParty/Model-NOTICE.txt
+++ b/apps/mobile-native/Sources/Resources/ThirdParty/Model-NOTICE.txt
@@ -1,0 +1,19 @@
+Experimental speaker model
+
+NVIDIA Sortformer v2.1, converted to Core ML by FluidInference.
+Model repository: https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml
+Pinned revision: ae9a27ab45dc0aa3abede7d2d6bad2b7a69aa6d1
+Upstream model: https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2.1
+
+Licensed by NVIDIA Corporation under the NVIDIA Open Model License.
+https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/
+
+The conversion model card also declares Creative Commons Attribution 4.0:
+https://creativecommons.org/licenses/by/4.0/
+The converted artifact is used as published, without changing its weights.
+The relationship between these notices and release redistribution remains a release review item.
+Model weights are not included in this source repository or app bundle.
+
+FluidAudio is Apache-2.0; its license accompanies this notice.
+The pinned package also includes separately licensed clustering and text-processing components.
+Their notices must be included in the final distribution license inventory.

--- a/apps/mobile-native/Sources/SpeakerAnnotations.swift
+++ b/apps/mobile-native/Sources/SpeakerAnnotations.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+struct SpeakerTurn: Codable, Equatable, Sendable {
+    var sessionID: UUID
+    var slot: Int
+    var start: TimeInterval
+    var end: TimeInterval
+    var isFinal: Bool
+    var key: String { "\(sessionID.uuidString):\(slot)" }
+}
+
+struct SpeakerAnnotations: Codable, Equatable {
+    var turns: [SpeakerTurn] = []
+    var names: [String: String] = [:]
+    var order: [String]? = nil
+
+    mutating func replace(sessionID: UUID, with incoming: [SpeakerTurn]) {
+        turns.removeAll { $0.sessionID == sessionID }
+        let valid = incoming.filter {
+            $0.sessionID == sessionID && (0..<4).contains($0.slot)
+                && $0.start.isFinite && $0.end.isFinite && $0.start >= 0 && $0.end > $0.start
+        }
+        var known = order ?? speakerKeys
+        for turn in valid.sorted(by: { $0.slot < $1.slot }) where !known.contains(turn.key) { known.append(turn.key) }
+        order = known
+        turns += valid
+        turns.sort { $0.start < $1.start }
+    }
+
+    var speakerKeys: [String] {
+        if let order {
+            let present = Set(turns.map(\.key))
+            return order.filter { present.contains($0) }
+        }
+        var seen = Set<String>()
+        return turns.compactMap { seen.insert($0.key).inserted ? $0.key : nil }
+    }
+
+    func name(for key: String) -> String {
+        if let name = names[key], !name.isEmpty { return name }
+        let index = ((order ?? speakerKeys).firstIndex(of: key) ?? 0) + 1
+        return "Speaker \(index)"
+    }
+
+    func label(for passage: TranscriptPassage) -> String {
+        let duration = passage.end - passage.start
+        guard duration > 0 else { return "Unassigned speaker" }
+        let relevant = turns.filter { min($0.end, passage.end) > max($0.start, passage.start) }
+        let grouped = Dictionary(grouping: relevant, by: \.key)
+        // Union each speaker's intervals so a finalized/draft overlap cannot inflate coverage.
+        let coverage = grouped.mapValues { turns -> Double in
+            let intervals = turns.map { (max($0.start, passage.start), min($0.end, passage.end)) }.sorted { $0.0 < $1.0 }
+            var end = passage.start
+            return intervals.reduce(0) { total, item in
+                let contribution = max(0, item.1 - max(end, item.0))
+                end = max(end, item.1)
+                return total + contribution
+            }
+        }
+        let active = coverage.filter { $0.value / duration >= 0.1 }
+        if active.count > 1 { return "Multiple speakers" }
+        guard let (key, covered) = active.first, covered / duration >= 0.65 else { return "Unassigned speaker" }
+        let tentative = relevant.contains { $0.key == key && !$0.isFinal }
+        return name(for: key) + (tentative ? " (provisional)" : "")
+    }
+}

--- a/apps/mobile-native/Sources/SpeakerModelStore.swift
+++ b/apps/mobile-native/Sources/SpeakerModelStore.swift
@@ -1,0 +1,94 @@
+import CryptoKit
+import Foundation
+
+struct SpeakerModelManifest: Codable, Sendable {
+    struct Asset: Codable, Sendable { let path: String; let size: Int; let sha256: String }
+    let repository: String
+    let revision: String
+    let package: String
+    let files: [Asset]
+}
+
+enum SpeakerModelError: LocalizedError {
+    case manifest, missing, integrity, response
+    var errorDescription: String? {
+        switch self {
+        case .manifest: "The speaker model manifest is unavailable."
+        case .missing: "Download the speaker model to enable labels."
+        case .integrity: "The speaker model failed its integrity check. Download it again."
+        case .response: "The speaker model download failed. Please try again."
+        }
+    }
+}
+
+actor SpeakerModelStore {
+    private let root: URL
+    init(root: URL = URL.applicationSupportDirectory.appendingPathComponent("DoodleNoteSpeakerModels")) {
+        self.root = root
+    }
+
+    static func manifest() throws -> SpeakerModelManifest {
+        guard let url = Bundle.main.url(forResource: "manifest", withExtension: "json") else { throw SpeakerModelError.manifest }
+        return try JSONDecoder().decode(SpeakerModelManifest.self, from: Data(contentsOf: url))
+    }
+
+    func installed() -> Bool {
+        guard let manifest = try? Self.manifest() else { return false }
+        return FileManager.default.fileExists(atPath: root.appendingPathComponent(manifest.revision)
+            .appendingPathComponent("verified.json").path)
+    }
+
+    func modelURL() throws -> URL {
+        let manifest = try Self.manifest()
+        let directory = root.appendingPathComponent(manifest.revision).appendingPathComponent(manifest.package)
+        for asset in manifest.files { try Self.verify(directory.appendingPathComponent(asset.path), asset: asset) }
+        return directory
+    }
+
+    func download() async throws {
+        let manifest = try Self.manifest()
+        let staging = root.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let package = staging.appendingPathComponent(manifest.package, isDirectory: true)
+        try FileManager.default.createDirectory(at: package, withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication])
+        var modelRoot = root
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try modelRoot.setResourceValues(values)
+        defer { try? FileManager.default.removeItem(at: staging) }
+        for asset in manifest.files {
+            try Task.checkCancellation()
+            guard !asset.path.hasPrefix("/"), !asset.path.split(separator: "/").contains(".."),
+                  let remote = URL(string: "https://huggingface.co/\(manifest.repository)/resolve/\(manifest.revision)/\(manifest.package)/\(asset.path)")
+            else { throw SpeakerModelError.manifest }
+            let (temporary, response) = try await URLSession.shared.download(from: remote)
+            defer { try? FileManager.default.removeItem(at: temporary) }
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { throw SpeakerModelError.response }
+            try Self.verify(temporary, asset: asset)
+            let destination = package.appendingPathComponent(asset.path)
+            try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try FileManager.default.moveItem(at: temporary, to: destination)
+        }
+        try Task.checkCancellation()
+        try JSONEncoder().encode(manifest).write(to: staging.appendingPathComponent("verified.json"), options: .atomic)
+        let destination = root.appendingPathComponent(manifest.revision)
+        if FileManager.default.fileExists(atPath: destination.path) {
+            // Replacing model assets does not modify notes, audio, or voice profiles.
+            _ = try FileManager.default.replaceItemAt(destination, withItemAt: staging)
+        } else { try FileManager.default.moveItem(at: staging, to: destination) }
+    }
+
+    static func verify(_ file: URL, asset: SpeakerModelManifest.Asset) throws {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: file.path),
+              let size = attributes[.size] as? NSNumber, size.intValue == asset.size else { throw SpeakerModelError.integrity }
+        let handle = try FileHandle(forReadingFrom: file)
+        defer { try? handle.close() }
+        var digest = SHA256()
+        while let bytes = try handle.read(upToCount: 1_048_576), !bytes.isEmpty {
+            try Task.checkCancellation()
+            digest.update(data: bytes)
+        }
+        let value = digest.finalize().map { String(format: "%02x", $0) }.joined()
+        guard value == asset.sha256 else { throw SpeakerModelError.integrity }
+    }
+}

--- a/apps/mobile-native/Sources/SpeakerPCMConverter.swift
+++ b/apps/mobile-native/Sources/SpeakerPCMConverter.swift
@@ -1,0 +1,77 @@
+import AVFoundation
+
+/// Confined to the audio writer queue. Preserve resampling state across tap callbacks.
+final class SpeakerPCMConverter {
+    private var converter: AVAudioConverter?
+    private var sourceFormat: AVAudioFormat?
+    private var sourceFrames: Int64 = 0
+    private var emittedFrames = 0
+    private let outputFormat = AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1)!
+
+    func convert(_ input: AVAudioPCMBuffer) throws -> [Float] {
+        if sourceFormat == nil {
+            sourceFormat = input.format
+            sourceFrames = 0
+            emittedFrames = 0
+            converter = AVAudioConverter(from: input.format, to: outputFormat)
+            converter?.primeMethod = .none
+            converter?.downmix = true
+        }
+        guard sourceFormat == input.format, let converter else { throw CaptureError.format }
+        sourceFrames += Int64(input.frameLength)
+        let capacity = AVAudioFrameCount(ceil(Double(input.frameLength) * 16_000 / input.format.sampleRate)) + 32
+        guard let output = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: capacity) else {
+            throw CaptureError.conversion
+        }
+        let supply = Supply(input)
+        var error: NSError?
+        let status = converter.convert(to: output, error: &error) { _, state in supply.take(state) }
+        if let error { throw error }
+        guard status != .error else { throw CaptureError.conversion }
+        return samples(output)
+    }
+
+    func finish() throws -> [Float] {
+        guard let converter else { return [] }
+        defer { self.converter = nil; sourceFormat = nil }
+        var result: [Float] = []
+        while true {
+            guard let output = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: 4096) else {
+                throw CaptureError.conversion
+            }
+            var error: NSError?
+            let status = converter.convert(to: output, error: &error) { _, state in
+                state.pointee = .endOfStream
+                return nil
+            }
+            if let error { throw error }
+            guard status != .error else { throw CaptureError.conversion }
+            result += samples(output)
+            if status == .endOfStream || output.frameLength == 0 { return result }
+        }
+    }
+
+    private func samples(_ buffer: AVAudioPCMBuffer) -> [Float] {
+        guard buffer.frameLength > 0, let channel = buffer.floatChannelData?[0], let sourceFormat else { return [] }
+        // AVAudioConverter can emit filter padding at end-of-stream. It must not extend the recording clock.
+        let expected = Int((Double(sourceFrames) * 16_000 / sourceFormat.sampleRate).rounded(.down))
+        let count = min(Int(buffer.frameLength), max(0, expected - emittedFrames))
+        emittedFrames += count
+        return Array(UnsafeBufferPointer(start: channel, count: count))
+    }
+
+    private final class Supply: @unchecked Sendable {
+        let buffer: AVAudioPCMBuffer
+        private var supplied = false
+        private let lock = NSLock()
+        init(_ buffer: AVAudioPCMBuffer) { self.buffer = buffer }
+        func take(_ status: UnsafeMutablePointer<AVAudioConverterInputStatus>) -> AVAudioBuffer? {
+            lock.withLock {
+                guard !supplied else { status.pointee = .noDataNow; return nil }
+                supplied = true
+                status.pointee = .haveData
+                return buffer
+            }
+        }
+    }
+}

--- a/apps/mobile-native/Sources/StreamingSpeakers.swift
+++ b/apps/mobile-native/Sources/StreamingSpeakers.swift
@@ -1,0 +1,142 @@
+import FluidAudio
+import Foundation
+import Observation
+
+struct SpeakerAudio: Sendable {
+    let samples: [Float]
+    let sampleRate: Double
+}
+
+/// Heavy Core ML work is isolated from capture and the UI. The input stream is bounded separately.
+actor SpeakerWorker {
+    private var diarizer: SortformerDiarizer?
+    private var sessionID = UUID()
+    private var offset = 0.0
+
+    func prepare(modelURL: URL, sessionID: UUID, offset: Double) async throws {
+        self.sessionID = sessionID
+        self.offset = offset
+        if let diarizer { diarizer.reset(); return }
+        let config = SortformerConfig.fastV2_1
+        var timeline = DiarizerTimelineConfig.sortformerDefault
+        timeline.maxStoredFrames = 750
+        let engine = SortformerDiarizer(config: config, timelineConfig: timeline)
+        let models = try await SortformerModels.load(config: config, mainModelPath: modelURL)
+        guard let embedded = models.embeddedConfig,
+              embedded.chunkLen == config.chunkLen,
+              embedded.chunkLeftContext == config.chunkLeftContext,
+              embedded.chunkRightContext == config.chunkRightContext,
+              embedded.fifoLen == config.fifoLen,
+              embedded.spkcacheLen == config.spkcacheLen else { throw SpeakerModelError.integrity }
+        engine.initialize(models: models)
+        diarizer = engine
+    }
+
+    func consume(_ audio: SpeakerAudio) throws -> [SpeakerTurn]? {
+        guard let diarizer else { throw SpeakerModelError.missing }
+        try Task.checkCancellation()
+        guard try diarizer.process(samples: audio.samples, sourceSampleRate: audio.sampleRate) != nil else { return nil }
+        return snapshot(diarizer)
+    }
+
+    func finish() throws -> [SpeakerTurn] {
+        guard let diarizer else { return [] }
+        try diarizer.finalizeSession()
+        return snapshot(diarizer)
+    }
+
+    func processedFrames() -> Int { diarizer?.numFramesProcessed ?? 0 }
+
+    private func snapshot(_ engine: SortformerDiarizer) -> [SpeakerTurn] {
+        engine.timeline.speakers.values.flatMap { speaker in
+            (speaker.finalizedSegments + speaker.tentativeSegments).map { segment in
+                SpeakerTurn(sessionID: sessionID, slot: segment.speakerIndex,
+                    start: offset + Double(segment.startTime), end: offset + Double(segment.endTime),
+                    isFinal: segment.isFinalized)
+            }
+        }
+    }
+}
+
+@MainActor @Observable
+final class StreamingSpeakers {
+    enum State { case missing, downloading, ready, preparing, running, failed }
+    var enabled = UserDefaults.standard.bool(forKey: "speakerLabelsEnabled") {
+        didSet { UserDefaults.standard.set(enabled, forKey: "speakerLabelsEnabled") }
+    }
+    private(set) var state = State.missing
+    private(set) var detail = "Download the speaker model to enable on-device labels."
+    private let store = SpeakerModelStore()
+    private let worker = SpeakerWorker()
+    private var downloadTask: Task<Void, Never>?
+    private var task: Task<Void, Never>?
+    private var sessionID: UUID?
+
+    var preparing: Bool { state == .downloading || state == .preparing }
+
+    func check() async {
+        guard task == nil, !preparing else { return }
+        if await store.installed() { state = .ready; detail = "Speaker model available on this device." }
+    }
+
+    func download() {
+        guard !preparing, task == nil else { return }
+        state = .downloading
+        detail = "Downloading the speaker model (240 MB)…"
+        downloadTask = Task {
+            do {
+                try await store.download()
+                state = .ready
+                enabled = true
+                detail = "Speaker model downloaded. Labels will be checked when recording starts."
+            } catch is CancellationError { state = .missing; detail = "Speaker model download canceled." }
+            catch { fail(error.localizedDescription) }
+            downloadTask = nil
+        }
+    }
+
+    func cancelDownload() { downloadTask?.cancel() }
+
+    func start(offset: Double, onUpdate: @escaping @MainActor (UUID, [SpeakerTurn]) -> Void) async
+        -> AsyncStream<SpeakerAudio>.Continuation? {
+        guard enabled, !preparing, task == nil else { return nil }
+        let sessionID = UUID()
+        self.sessionID = sessionID
+        state = .preparing
+        detail = "Preparing speaker labels…"
+        do {
+            let url = try await store.modelURL()
+            try await worker.prepare(modelURL: url, sessionID: sessionID, offset: offset)
+        } catch { fail("Speaker labels are unavailable. Audio and transcription can continue. \(error.localizedDescription)"); return nil }
+        let (stream, input) = AsyncStream<SpeakerAudio>.makeStream(bufferingPolicy: .bufferingOldest(128))
+        state = .running
+        detail = "Live speaker labels are provisional. Confirm names only when you know who spoke."
+        task = Task { [weak self, worker] in
+            do {
+                for await packet in stream {
+                    try Task.checkCancellation()
+                    if let turns = try await worker.consume(packet) { onUpdate(sessionID, turns) }
+                }
+                if !Task.isCancelled { onUpdate(sessionID, try await worker.finish()) }
+            } catch is CancellationError { }
+            catch { self?.fail("Speaker processing stopped. Audio and transcription are preserved. \(error.localizedDescription)") }
+        }
+        return input
+    }
+
+    func finish() async {
+        let active = task
+        let timeout = Task { [weak self] in
+            do { try await Task.sleep(for: .seconds(20)) } catch { return }
+            self?.task?.cancel()
+            self?.fail("Speaker finalization took too long. Saved audio and existing labels are retained.")
+        }
+        await active?.value
+        timeout.cancel()
+        task = nil
+        sessionID = nil
+        if state == .running { state = .ready; detail = "Speaker labels saved on this device." }
+    }
+
+    func fail(_ message: String) { state = .failed; detail = message }
+}

--- a/apps/mobile-native/Tests/AudioRecoveryTests.swift
+++ b/apps/mobile-native/Tests/AudioRecoveryTests.swift
@@ -1,0 +1,65 @@
+import AVFoundation
+import XCTest
+@testable import DoodleNoteNative
+
+final class AudioRecoveryTests: XCTestCase {
+    func fixture() throws -> (NoteDiskStore, UUID, URL, AVAudioFormat) {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        let store = try NoteDiskStore(root: root)
+        var note = NoteRecord()
+        note.captureState = .recording
+        try store.save(note)
+        let url = try store.audioDirectory(for: note.id).appendingPathComponent("capture-000001.caf")
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 2))
+        var file: AVAudioFile? = try AVAudioFile(forWriting: url, settings: [
+            AVFormatIDKey: kAudioFormatLinearPCM, AVSampleRateKey: 16_000,
+            AVNumberOfChannelsKey: 2, AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false, AVLinearPCMIsBigEndianKey: false
+        ])
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 16_000))
+        buffer.frameLength = 16_000
+        for channel in 0..<2 {
+            for frame in 0..<16_000 { buffer.floatChannelData![channel][frame] = channel == 0 ? 0.25 : -0.25 }
+        }
+        try file?.write(from: buffer)
+        file = nil
+        return (store, note.id, url, format)
+    }
+
+    func testStaleHeaderAndPartialFrameRecoverWithoutChangingOriginal() throws {
+        let (store, id, original, format) = try fixture()
+        try AudioRecovery.begin(file: original, format: format)
+        var bytes = try Data(contentsOf: original)
+        let marker = try XCTUnwrap(bytes.range(of: Data("data".utf8)))
+        bytes.replaceSubrange((marker.lowerBound + 4)..<(marker.lowerBound + 12), with: Data(repeating: 0xff, count: 8))
+        bytes.append(contentsOf: [0xaa, 0xbb])
+        try bytes.write(to: original)
+        let result = try store.load()
+        XCTAssertEqual(result.notes.first?.captureState, .interrupted)
+        XCTAssertTrue(result.audioProblems.isEmpty)
+        XCTAssertEqual(try Data(contentsOf: original), bytes)
+        let selected = try XCTUnwrap(store.audioFiles(for: id).first)
+        XCTAssertEqual(selected, AudioRecovery.recoveredURL(for: original))
+        let recovered = try AVAudioFile(forReading: selected)
+        XCTAssertEqual(recovered.length, 16_000)
+        let read = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: recovered.processingFormat, frameCapacity: 16_000))
+        try recovered.read(into: read)
+        XCTAssertEqual(read.floatChannelData![0][15_999], 0.25, accuracy: 0.001)
+        XCTAssertEqual(read.floatChannelData![1][15_999], -0.25, accuracy: 0.001)
+        _ = try store.load()
+        XCTAssertEqual(store.audioFiles(for: id), [selected])
+    }
+
+    func testMalformedAudioIsReportedAndPreserved() throws {
+        let (store, id, original, format) = try fixture()
+        try AudioRecovery.begin(file: original, format: format)
+        let bytes = Data("incomplete audio header".utf8)
+        try bytes.write(to: original)
+        let result = try store.load()
+        XCTAssertEqual(result.audioProblems.count, 1)
+        XCTAssertEqual(try Data(contentsOf: original), bytes)
+        XCTAssertEqual(store.audioFiles(for: id), [original])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: AudioRecovery.recoveredURL(for: original).path))
+    }
+}

--- a/apps/mobile-native/Tests/LocalDataTests.swift
+++ b/apps/mobile-native/Tests/LocalDataTests.swift
@@ -1,0 +1,116 @@
+import AVFoundation
+import PencilKit
+import Speech
+import XCTest
+@testable import DoodleNoteNative
+
+final class LocalDataTests: XCTestCase {
+    func temporaryStore() throws -> NoteDiskStore {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return try NoteDiskStore(root: url)
+    }
+
+    func testTextInkAndTranscriptSurviveReopen() throws {
+        let store = try temporaryStore()
+        var note = NoteRecord()
+        note.title = "Discovery"
+        note.text = "A personal detail not in the transcript"
+        note.ink = PKDrawing().dataRepresentation()
+        note.language = .danish
+        note.apply(TranscriptPassage(start: 0, end: 2, text: "Godmorgen", isFinal: true))
+        try store.save(note)
+        let result = try NoteDiskStore(root: store.root).load()
+        XCTAssertEqual(result.notes, [note])
+        XCTAssertTrue(result.unreadable.isEmpty)
+    }
+
+    func testInterruptedCaptureIsRecoveredWithoutLosingAudio() throws {
+        let store = try temporaryStore()
+        var note = NoteRecord()
+        note.captureState = .recording
+        try store.save(note)
+        let audio = try store.audioDirectory(for: note.id).appendingPathComponent("original.caf")
+        let bytes = Data([1, 2, 3])
+        try bytes.write(to: audio)
+        let recovered = try store.load()
+        XCTAssertEqual(recovered.notes.first?.captureState, .interrupted)
+        XCTAssertEqual(try Data(contentsOf: audio), bytes)
+        XCTAssertEqual(try store.load().notes.first?.captureState, .interrupted)
+    }
+
+    func testCorruptAndFutureNotesRemainUntouchedWhileHealthyNotesLoad() throws {
+        let store = try temporaryStore()
+        let good = NoteRecord()
+        var future = NoteRecord()
+        future.schemaVersion = 100
+        try store.save(good)
+        try store.save(future)
+        let badID = UUID()
+        let badDir = store.directory(for: badID)
+        try FileManager.default.createDirectory(at: badDir, withIntermediateDirectories: true)
+        let bytes = Data("incomplete json".utf8)
+        let file = badDir.appendingPathComponent("note.json")
+        try bytes.write(to: file)
+        let result = try store.load()
+        XCTAssertEqual(result.notes, [good])
+        XCTAssertEqual(Set(result.unreadable), Set([badID.uuidString, future.id.uuidString]))
+        XCTAssertEqual(try Data(contentsOf: file), bytes)
+    }
+
+    func testSpeechRevisionsReplaceDraftsWithoutDuplicatingFinalText() {
+        var note = NoteRecord()
+        note.apply(TranscriptPassage(start: 0, end: 1, text: "Hel", isFinal: false))
+        note.apply(TranscriptPassage(start: 0, end: 2, text: "Hello there", isFinal: false))
+        note.apply(TranscriptPassage(start: 0, end: 2, text: "Hello there.", isFinal: true))
+        note.apply(TranscriptPassage(start: 0, end: 2, text: "Incorrect draft", isFinal: false))
+        note.apply(TranscriptPassage(start: 2, end: 3, text: "Next", isFinal: true))
+        XCTAssertEqual(note.passages.map(\.text), ["Hello there.", "Next"])
+        XCTAssertTrue(note.passages.allSatisfy { $0.isFinal && $0.speakerName == nil })
+    }
+
+    func testChunkWriterPreservesEveryFrameAndClosesOnFinish() async throws {
+        let store = try temporaryStore()
+        let id = UUID()
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 16_000))
+        buffer.frameLength = 16_000
+        memset(buffer.floatChannelData![0], 0, 16_000 * MemoryLayout<Float>.size)
+        let writer = AudioChunkWriter(directory: try store.audioDirectory(for: id),
+                                      onCaptureError: { _ in }, onSpeechError: { _ in })
+        for _ in 0..<12 { writer.append(buffer) }
+        await writer.finish()
+        writer.append(buffer)
+        await writer.finish()
+        let files = store.audioFiles(for: id)
+        XCTAssertEqual(files.count, 3)
+        let frames = try files.reduce(Int64(0)) { total, url in total + (try AVAudioFile(forReading: url).length) }
+        XCTAssertEqual(frames, 192_000)
+    }
+
+    func testSpeechConversionDoesNotChangeSavedSourceAudio() async throws {
+        let store = try temporaryStore()
+        let id = UUID()
+        let sourceFormat = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 2))
+        let speechFormat = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: sourceFormat, frameCapacity: 4_800))
+        buffer.frameLength = 4_800
+        for channel in 0..<2 { memset(buffer.floatChannelData![channel], 0, 4_800 * MemoryLayout<Float>.size) }
+        let (stream, input) = AsyncStream<AnalyzerInput>.makeStream(bufferingPolicy: .bufferingOldest(128))
+        let writer = AudioChunkWriter(directory: try store.audioDirectory(for: id),
+            speechFormat: speechFormat, speechInput: input, onCaptureError: { _ in }, onSpeechError: { _ in })
+        for _ in 0..<20 { writer.append(buffer) }
+        await writer.finish()
+        var convertedFrames = 0
+        for await item in stream {
+            XCTAssertEqual(item.buffer.format.sampleRate, 16_000)
+            XCTAssertEqual(item.buffer.format.channelCount, 1)
+            convertedFrames += Int(item.buffer.frameLength)
+        }
+        XCTAssertEqual(convertedFrames, 32_000, accuracy: 32)
+        let file = try AVAudioFile(forReading: XCTUnwrap(store.audioFiles(for: id).first))
+        XCTAssertEqual(file.length, 96_000)
+        XCTAssertEqual(file.processingFormat.channelCount, 2)
+        XCTAssertEqual(file.processingFormat.sampleRate, 48_000)
+    }
+}

--- a/apps/mobile-native/Tests/LocalDataTests.swift
+++ b/apps/mobile-native/Tests/LocalDataTests.swift
@@ -16,13 +16,19 @@ final class LocalDataTests: XCTestCase {
         var note = NoteRecord()
         note.title = "Discovery"
         note.text = "A personal detail not in the transcript"
-        note.ink = PKDrawing().dataRepresentation()
+        let points = [CGPoint(x: 10, y: 10), CGPoint(x: 80, y: 40)].enumerated().map { index, point in
+            PKStrokePoint(location: point, timeOffset: Double(index) * 0.1, size: CGSize(width: 3, height: 3),
+                          opacity: 1, force: 1, azimuth: 0, altitude: .pi / 2)
+        }
+        let path = PKStrokePath(controlPoints: points, creationDate: Date())
+        note.ink = PKDrawing(strokes: [PKStroke(ink: PKInk(.pen, color: .black), path: path)]).dataRepresentation()
         note.language = .danish
         note.apply(TranscriptPassage(start: 0, end: 2, text: "Godmorgen", isFinal: true))
         try store.save(note)
         let result = try NoteDiskStore(root: store.root).load()
         XCTAssertEqual(result.notes, [note])
         XCTAssertTrue(result.unreadable.isEmpty)
+        XCTAssertEqual(try PKDrawing(data: XCTUnwrap(result.notes.first).ink).strokes.count, 1)
     }
 
     func testInterruptedCaptureIsRecoveredWithoutLosingAudio() throws {

--- a/apps/mobile-native/Tests/LocalDataTests.swift
+++ b/apps/mobile-native/Tests/LocalDataTests.swift
@@ -64,6 +64,25 @@ final class LocalDataTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: file), bytes)
     }
 
+    func testRecoveryWriteFailureStillExposesReadableNotes() throws {
+        let store = try temporaryStore()
+        var note = NoteRecord()
+        note.text = "Keep this readable even when storage is full"
+        note.ink = Data([1, 2, 3])
+        note.apply(TranscriptPassage(start: 0, end: 1, text: "Saved speech", isFinal: true))
+        note.captureState = .recording
+        try store.save(note)
+        let url = store.directory(for: note.id).appendingPathComponent("note.json")
+        let original = try Data(contentsOf: url)
+        let result = try store.load(persistRecovery: { _ in throw CocoaError(.fileWriteOutOfSpace) })
+        note.captureState = .interrupted
+        XCTAssertEqual(result.notes, [note])
+        XCTAssertTrue(result.unreadable.isEmpty)
+        XCTAssertEqual(result.recoveryWriteProblems, [note.id.uuidString])
+        XCTAssertEqual(try Data(contentsOf: url), original)
+        XCTAssertEqual(try store.load().notes.first?.captureState, .interrupted)
+    }
+
     func testSpeechRevisionsReplaceDraftsWithoutDuplicatingFinalText() {
         var note = NoteRecord()
         note.apply(TranscriptPassage(start: 0, end: 1, text: "Hel", isFinal: false))

--- a/apps/mobile-native/Tests/PreparationTests.swift
+++ b/apps/mobile-native/Tests/PreparationTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import DoodleNoteNative
+
+@MainActor final class PreparationTests: XCTestCase {
+    func testNavigationCannotReplaceThePreparingSpeechLanguage() async {
+        var requested: [SpokenLanguage] = []
+        var pending: CheckedContinuation<LocalSpeech.Availability?, Never>?
+        let entered = expectation(description: "Capture language probe entered")
+        let speech = LocalSpeech(availability: { language in
+            requested.append(language)
+            return await withCheckedContinuation { pending = $0; entered.fulfill() }
+        })
+        let start = Task { await speech.start(language: .english, offset: 0, onPassage: { _ in }) }
+        await fulfillment(of: [entered], timeout: 2)
+        await speech.check(.spanish)
+        XCTAssertEqual(requested, [.english])
+        pending?.resume(returning: nil)
+        let feed = await start.value
+        XCTAssertNil(feed)
+        XCTAssertEqual(speech.readiness, .unavailable)
+    }
+
+    func testPlaybackIsExcludedWhileRecordPermissionIsPending() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let library = NoteLibrary(root: root)
+        let id = try XCTUnwrap(library.create())
+        var pending: CheckedContinuation<Bool, Never>?
+        let entered = expectation(description: "Permission request entered")
+        let recording = RecordingSession(recordPermission: {
+            await withCheckedContinuation { pending = $0; entered.fulfill() }
+        })
+        XCTAssertTrue(recording.permitsPlayback)
+        let start = Task { await recording.start(id, library: library) }
+        await fulfillment(of: [entered], timeout: 2)
+        XCTAssertTrue(recording.busy)
+        XCTAssertNil(recording.noteID)
+        XCTAssertFalse(recording.permitsPlayback)
+        pending?.resume(returning: false)
+        await start.value
+        XCTAssertTrue(recording.permitsPlayback)
+        XCTAssertNotNil(recording.problem)
+    }
+}

--- a/apps/mobile-native/Tests/SpeakerPCMConverterTests.swift
+++ b/apps/mobile-native/Tests/SpeakerPCMConverterTests.swift
@@ -1,0 +1,45 @@
+import AVFoundation
+import XCTest
+@testable import DoodleNoteNative
+
+final class SpeakerPCMConverterTests: XCTestCase {
+    func testSpeakerClockAndWaveformDoNotDependOnMicrophonePacketSize() throws {
+        for rate in [44_100.0, 48_000.0] {
+            let small = try converted(rate: rate, packetSize: 4096)
+            let large = try converted(rate: rate, packetSize: 16_384)
+            XCTAssertEqual(small.count, 32_000, accuracy: 2, "rate \(rate)")
+            XCTAssertEqual(small.count, large.count)
+            let largestDifference = zip(small, large).map { abs($0 - $1) }.max() ?? 0
+            XCTAssertLessThan(largestDifference, 0.001, "No packet-boundary padding or filter reset")
+        }
+    }
+
+    func testBothStereoChannelsReachTheSpeakerModel() throws {
+        let left = try converted(rate: 48_000, packetSize: 4096, activeChannel: 0)
+        let right = try converted(rate: 48_000, packetSize: 4096, activeChannel: 1)
+        XCTAssertGreaterThan(right.map { abs($0) }.max() ?? 0, 0.02)
+        XCTAssertEqual(left.count, right.count)
+        XCTAssertLessThan(zip(left, right).map { abs($0 - $1) }.max() ?? 0, 0.001)
+    }
+
+    private func converted(rate: Double, packetSize: Int, activeChannel: Int? = nil) throws -> [Float] {
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: rate, channels: 2))
+        let converter = SpeakerPCMConverter()
+        let count = Int(rate * 2)
+        var result: [Float] = []
+        for start in stride(from: 0, to: count, by: packetSize) {
+            let frames = min(packetSize, count - start)
+            let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frames)))
+            buffer.frameLength = AVAudioFrameCount(frames)
+            for index in 0..<frames {
+                let sample = Float(sin(Double(start + index) * 2 * .pi * 440 / rate)) * 0.25
+                buffer.floatChannelData![0][index] = activeChannel == 1 ? 0 : sample
+                buffer.floatChannelData![1][index] = activeChannel == 0 ? 0 : sample
+            }
+            result += try converter.convert(buffer)
+        }
+        result += try converter.finish()
+        XCTAssertTrue(try converter.finish().isEmpty)
+        return result
+    }
+}

--- a/apps/mobile-native/Tests/SpeakerTests.swift
+++ b/apps/mobile-native/Tests/SpeakerTests.swift
@@ -1,0 +1,111 @@
+import AVFoundation
+import CryptoKit
+import XCTest
+@testable import DoodleNoteNative
+
+final class SpeakerTests: XCTestCase {
+    func testBundledManifestPinsOnlyTheIntendedFourAssets() throws {
+        let manifest = try SpeakerModelStore.manifest()
+        XCTAssertEqual(manifest.revision, "ae9a27ab45dc0aa3abede7d2d6bad2b7a69aa6d1")
+        XCTAssertEqual(manifest.files.count, 4)
+        XCTAssertEqual(manifest.files.reduce(0) { $0 + $1.size }, 240_139_774)
+    }
+    func testFourSpeakersAndOverlapsAreLabeledWithoutGuessingNames() {
+        let session = UUID()
+        var annotations = SpeakerAnnotations()
+        annotations.replace(sessionID: session, with: (0..<4).map {
+            SpeakerTurn(sessionID: session, slot: $0, start: Double($0 * 2), end: Double($0 * 2 + 2), isFinal: true)
+        })
+        for slot in 0..<4 {
+            XCTAssertEqual(annotations.label(for: TranscriptPassage(start: Double(slot * 2), end: Double(slot * 2 + 2),
+                text: "A turn", isFinal: true)), "Speaker \(slot + 1)")
+        }
+        XCTAssertEqual(annotations.label(for: TranscriptPassage(start: 1, end: 3, text: "Crosses a turn", isFinal: true)), "Multiple speakers")
+        XCTAssertEqual(annotations.label(for: TranscriptPassage(start: 10, end: 12, text: "Unknown", isFinal: true)), "Unassigned speaker")
+    }
+
+    func testNameCorrectionSurvivesFinalizationButNotANewSessionSlot() throws {
+        let first = UUID(), second = UUID()
+        var annotations = SpeakerAnnotations()
+        let draft = SpeakerTurn(sessionID: first, slot: 0, start: 0, end: 2, isFinal: false)
+        let passage = TranscriptPassage(start: 0, end: 2, text: "Hello", isFinal: true)
+        annotations.replace(sessionID: first, with: [draft])
+        annotations.names[draft.key] = "Alex"
+        XCTAssertEqual(annotations.label(for: passage), "Alex (provisional)")
+        var final = draft
+        final.isFinal = true
+        annotations.replace(sessionID: first, with: [final])
+        XCTAssertEqual(annotations.label(for: passage), "Alex")
+        annotations.replace(sessionID: second, with: [SpeakerTurn(sessionID: second, slot: 0, start: 2, end: 4, isFinal: true)])
+        XCTAssertEqual(annotations.label(for: TranscriptPassage(start: 2, end: 4, text: "New session", isFinal: true)), "Speaker 2")
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = try NoteDiskStore(root: root)
+        var note = NoteRecord()
+        note.speakerAnnotations = annotations
+        try store.save(note)
+        XCTAssertEqual(try store.load().notes.first?.speakerAnnotations, annotations)
+    }
+
+    func testInsufficientOrDuplicatedCoverageStaysUnassigned() {
+        let session = UUID()
+        let turn = SpeakerTurn(sessionID: session, slot: 0, start: 0, end: 0.5, isFinal: true)
+        var annotations = SpeakerAnnotations()
+        annotations.replace(sessionID: session, with: [turn, turn, turn])
+        XCTAssertEqual(annotations.label(for: TranscriptPassage(start: 0, end: 2, text: "Not covered", isFinal: true)), "Unassigned speaker")
+    }
+
+    func testLegacyNoteWithoutSpeakerAnnotationsStillDecodes() throws {
+        let data = try JSONEncoder().encode(NoteRecord())
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object.removeValue(forKey: "speakerAnnotations")
+        let decoded = try JSONDecoder().decode(NoteRecord.self, from: JSONSerialization.data(withJSONObject: object))
+        XCTAssertNil(decoded.speakerAnnotations)
+    }
+
+    func testModelDigestRejectsCorruptionEvenWhenSizeMatches() throws {
+        let file = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: file) }
+        let good = Data("valid model".utf8)
+        let hash = SHA256.hash(data: good).map { String(format: "%02x", $0) }.joined()
+        let asset = SpeakerModelManifest.Asset(path: "weights.bin", size: good.count, sha256: hash)
+        try good.write(to: file)
+        XCTAssertNoThrow(try SpeakerModelStore.verify(file, asset: asset))
+        try Data(repeating: 0, count: good.count).write(to: file)
+        XCTAssertThrowsError(try SpeakerModelStore.verify(file, asset: asset))
+    }
+
+    func testSlowSpeakerConsumerDoesNotDiscardSavedAudio() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = try NoteDiskStore(root: root), id = UUID()
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 1_600))
+        buffer.frameLength = 1_600
+        memset(buffer.floatChannelData![0], 0, 1_600 * MemoryLayout<Float>.size)
+        let (stream, input) = AsyncStream<SpeakerAudio>.makeStream(bufferingPolicy: .bufferingOldest(1))
+        let failure = expectation(description: "Speaker backlog is visible")
+        let writer = AudioChunkWriter(directory: try store.audioDirectory(for: id), speakerInput: input,
+            onCaptureError: { _ in }, onSpeechError: { _ in }, onSpeakerError: { _ in failure.fulfill() })
+        for _ in 0..<5 { writer.append(buffer) }
+        await writer.finish()
+        var delivered = 0
+        for await _ in stream { delivered += 1 }
+        XCTAssertEqual(delivered, 1)
+        await fulfillment(of: [failure], timeout: 2)
+        let file = try AVAudioFile(forReading: XCTUnwrap(store.audioFiles(for: id).first))
+        XCTAssertEqual(file.length, 8_000)
+    }
+
+    func testPinnedModelProcessesSyntheticAudioWhenProvided() async throws {
+        guard let path = ProcessInfo.processInfo.environment["DOODLENOTE_SPEAKER_MODEL"] else {
+            throw XCTSkip("Opt-in Core ML check requires the pinned local evaluation model.")
+        }
+        let worker = SpeakerWorker()
+        try await worker.prepare(modelURL: URL(fileURLWithPath: path), sessionID: UUID(), offset: 0)
+        for _ in 0..<20 { _ = try await worker.consume(SpeakerAudio(samples: [Float](repeating: 0, count: 1_600), sampleRate: 16_000)) }
+        _ = try await worker.finish()
+        let frames = await worker.processedFrames()
+        XCTAssertGreaterThan(frames, 0)
+    }
+}

--- a/apps/mobile-native/UITests/NoteEditingTests.swift
+++ b/apps/mobile-native/UITests/NoteEditingTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+@MainActor final class NoteEditingTests: XCTestCase {
+    func testCreateEditAndRecoverAfterRelaunch() {
+        let app = XCUIApplication()
+        app.launchArguments = ["--ui-testing"]
+        app.launch()
+        let create = app.buttons["newNote"].firstMatch
+        XCTAssertTrue(create.waitForExistence(timeout: 10))
+        create.tap()
+        let title = app.textFields["noteTitle"].firstMatch
+        // A multiline TextField may be exposed as a text view on some OS versions.
+        let field = title.exists ? title : app.textViews["noteTitle"].firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: 5))
+        field.tap()
+        let uniqueTitle = "Saved note \(UUID().uuidString.prefix(6))"
+        field.typeText(uniqueTitle)
+        let notes = app.textViews["personalNotes"].firstMatch
+        notes.tap()
+        notes.typeText("Keep this personal note after relaunch.")
+        app.terminate()
+        app.launch()
+        let saved = app.staticTexts[uniqueTitle].firstMatch
+        XCTAssertTrue(saved.waitForExistence(timeout: 5))
+        saved.tap()
+        XCTAssertTrue(app.textViews["personalNotes"].waitForExistence(timeout: 5))
+        XCTAssertEqual(app.textViews["personalNotes"].value as? String,
+                       "Keep this personal note after relaunch.")
+        app.buttons["Ink"].tap()
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Native note and Pencil canvas"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/apps/mobile-native/UITests/NoteEditingTests.swift
+++ b/apps/mobile-native/UITests/NoteEditingTests.swift
@@ -1,6 +1,18 @@
 import XCTest
 
 @MainActor final class NoteEditingTests: XCTestCase {
+    func testSpeakerControlsAreAvailableWithoutDownloadingModels() {
+        let app = XCUIApplication()
+        app.launchArguments = ["--ui-testing"]
+        app.launch()
+        XCTAssertTrue(app.buttons["newNote"].waitForExistence(timeout: 10))
+        app.buttons["newNote"].tap()
+        XCTAssertTrue(app.buttons["speakerSettings"].waitForExistence(timeout: 5))
+        app.buttons["speakerSettings"].tap()
+        XCTAssertTrue(app.switches["Live speaker labels"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["Download speaker model"].exists)
+        XCTAssertTrue(app.buttons["recordButton"].isEnabled)
+    }
     func testCreateEditAndRecoverAfterRelaunch() {
         let app = XCUIApplication()
         app.launchArguments = ["--ui-testing"]

--- a/apps/mobile-native/docs/continuation.md
+++ b/apps/mobile-native/docs/continuation.md
@@ -1,0 +1,3 @@
+# Active implementation
+
+The external Codex SSD became unavailable during the September 6 continuation. Active work moved to an internal-drive checkout of the same PR branch. Uncommitted external-drive edits must be reconciled when that drive returns; do not overwrite them automatically.

--- a/apps/mobile-native/docs/discovery/CONTEXT.md
+++ b/apps/mobile-native/docs/discovery/CONTEXT.md
@@ -1,0 +1,85 @@
+# DoodleNote mobile product language
+
+Terms settled during discovery of the new iPhone and iPad app.
+
+## Language
+
+**Independent mobile app**:
+A DoodleNote app that is useful without installing or using desktop DoodleNote. Independence does not itself define account or internet requirements.
+_Avoid_: Desktop companion as a synonym for the whole mobile product
+
+**Cloud sync**:
+The existing optional DoodleNote service to which the mobile app can connect to synchronize notes and transcripts, with an extension for editable ink and readable previews. V1 recording audio stays on its recording device.
+
+**Personal notes**:
+Notes the user writes about a conversation, including while it is being recorded. They are distinct from the summary generated about that conversation.
+
+**Summary**:
+A condensed account of a recorded conversation intended to help the user understand its important content and next actions.
+
+**Standalone note**:
+A written note created without recording a conversation. It belongs in the same library as recorded conversations.
+_Avoid_: Meeting when referring to a note without a recorded conversation
+
+**Recording**:
+The captured or imported audio of a conversation. It is distinct from the transcript and summary derived from it.
+_Avoid_: Transcript as a synonym for audio
+
+**Transcript**:
+A searchable, timestamped text representation of a recording, linked to that recording for playback.
+_Avoid_: Summary as a synonym for the full text of a conversation
+
+**Next action**:
+A proposed follow-up arising from a conversation, represented as an editable checklist item within its note. An owner or due date must not be invented when none was established.
+
+**Ink**:
+Editable handwriting or sketches preserved in a note. Ink is distinct from typed text produced through handwriting-to-text entry.
+_Avoid_: Typed notes as a synonym for preserved handwriting
+
+**Live transcript**:
+The text representation of a conversation shown while it is being recorded. It is distinct from the summary produced about the conversation.
+
+**Local recording**:
+A recording retained on the device that captured or imported it. Synchronizing its notes and transcript does not make its audio available on another device.
+
+**Trash**:
+A recoverable state for a deleted note before permanent deletion, lasting 30 days. For synced notes, this state follows the note across devices.
+
+**Interface language**:
+The language selected for DoodleNote's screen text, including setup and normal app use. It is distinct from the spoken language of a recording and the language of generated notes.
+
+**Spoken language**:
+The primary language selected for a recording and its transcript. A v1 recording has one selected primary spoken language.
+
+**Output language**:
+The supported language chosen for generated notes, defaulting to the recording's selected spoken language. Choosing another output language does not replace the original-language transcript.
+
+**Meeting question**:
+A question answered using the current meeting's transcript and typed personal notes, with references to supporting passages.
+
+**Library question**:
+A question asked from the homepage across recording transcripts and notes in the selected library/workspace, with an explicit selector for additional authorized libraries. Trash is excluded; the scope is not limited to recent records.
+
+**Summary format**:
+A built-in structure for generated notes selected according to the meeting type. It changes how supported information is organized, not what facts the conversation contains.
+
+**Calendar event**:
+A scheduled occurrence from a connected Microsoft or Google calendar that can be linked to a DoodleNote meeting. An invitation does not itself establish who attended or spoke.
+
+**Local-only library**:
+A collection of notes kept on the device rather than included in ordinary DoodleNote cloud synchronization.
+
+**Generated version**:
+A newly generated summary kept separately from the user's edited version until the user chooses whether to replace it.
+
+**Suggested participant**:
+A person listed on a calendar invitation who can be offered as a candidate name for the meeting. The suggestion does not establish attendance or identify a voice.
+
+**Search scope**:
+The library or authorized set of libraries whose eligible content may be used to answer a library question. The user can see and deliberately change this scope.
+
+**Speaker**:
+A person whose speech appears in a recording. A speaker may remain unnamed until a name association is confirmed.
+
+**Speaker label**:
+The confirmed name or anonymous identifier attached to a speaker's transcript passages. It is distinct from a saved reference for recognizing a voice in future meetings.

--- a/apps/mobile-native/docs/discovery/docs/adr/0001-independent-mobile-with-existing-sync.md
+++ b/apps/mobile-native/docs/discovery/docs/adr/0001-independent-mobile-with-existing-sync.md
@@ -1,0 +1,11 @@
+---
+status: accepted
+---
+
+# Independent mobile use with optional existing DoodleNote cloud sync
+
+The iPhone and iPad product must serve users who do not use desktop DoodleNote while allowing them to connect to the existing cloud sync option for notes. Sean selected this boundary during the first discovery round instead of making mobile use depend on the desktop app or designing a separate cloud service.
+
+This establishes independent mobile product scope and an integration obligation to the existing sync service. It does not yet determine account requirements, offline processing, storage implementation, audio synchronization, or commercial terms.
+
+Later discovery decisions establish account-free local use, offline transcription/summaries/Q&A after model readiness, free core functionality with optional existing paid Sync, local-only recording audio, and extensions for ink/conflict/recovery behavior. See the current specification; the paragraph above records the original decision's scope rather than current unanswered questions.

--- a/apps/mobile-native/docs/discovery/docs/adr/0002-explicit-external-ai-and-local-audio.md
+++ b/apps/mobile-native/docs/discovery/docs/adr/0002-explicit-external-ai-and-local-audio.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+---
+
+# Explicit external AI choice and local recording audio
+
+The mobile app favors on-device processing where it meets requirements and may use external AI only after the user explicitly enables it. It must not silently upload content when local processing is unavailable. This preserves the user's processing choice at the cost of requiring explicit handling when local capabilities are insufficient.
+
+V1 cloud sync carries notes and transcripts while recording audio remains on its recording device until user removal. This avoids adding cloud audio storage and playback to the initial release, but a synced transcript on another device will not have playable audio. Later rounds accept extending sync for editable ink/previews, a complete user-directed archive backup including local audio, and free core functionality with optional existing paid Sync. Archive protection/restore details, device support, provider selection, credential handling, and the purchase flow remain separate implementation or final-review decisions.
+
+External AI processing consent is distinct from enabling cloud note synchronization. Keeping audio out of DoodleNote cloud sync does not itself decide whether an explicitly selected external transcription provider may receive audio.
+
+Round 4 selects user-supplied provider API keys for optional external AI. Provider charges remain separate from the DoodleNote sync subscription; there is no accepted mobile managed-inference billing service.

--- a/apps/mobile-native/docs/discovery/docs/adr/0003-extend-sync-for-ink-and-conflict-preservation.md
+++ b/apps/mobile-native/docs/discovery/docs/adr/0003-extend-sync-for-ink-and-conflict-preservation.md
@@ -1,0 +1,11 @@
+---
+status: accepted
+---
+
+# Extend existing sync for complete Pencil notes and preserved conflicts
+
+The first release must synchronize original editable Pencil ink with readable previews and preserve conflicting note versions when devices edit independently. The existing sync format cannot meet these requirements unchanged, so compatible cloud and viewer changes are part of the product scope.
+
+Keeping the existing format unchanged would leave handwritten content behind or allow competing edits to overwrite one another. Sean accepted extending the existing service to preserve complete notes and user work, with iPad ink editing and iPhone/desktop visibility; real-time collaboration remains outside v1.
+
+Private attachment storage, conflict/version representation, old-client compatibility, and deletion semantics remain architecture decisions to resolve. This record approves product direction, not production deployment or permission changes.

--- a/apps/mobile-native/docs/discovery/doodlenote_Discovery_v1.md
+++ b/apps/mobile-native/docs/discovery/doodlenote_Discovery_v1.md
@@ -1,0 +1,188 @@
+# DoodleNote iPhone and iPad product discovery
+
+Status: Interview in progress. This is a decision record, not an approved build specification.
+
+## Confirmed direction
+
+- Design and build a fresh DoodleNote app for iPhone and iPad.
+- Ignore the repository's existing iOS implementation and previous iOS design choices. They do not establish requirements for this effort.
+- Use grill-with-docs, combining grilling and domain modeling, to determine requirements through interview rounds.
+- Capture decisions as they are settled. Keep recommendations visibly separate from accepted requirements.
+- The first audience is professionals capturing meetings, client conversations, and follow-up work.
+- The anchor workflow is recording an in-person conversation, adding personal notes during it, and leaving with an accurate summary and clear next actions.
+- The app must be independently useful without the desktop app and optionally connect to the existing DoodleNote cloud sync service to synchronize notes.
+- Initial release scope is driven by reliable completion of the anchor workflow. No fixed launch date or budget amount has been supplied.
+- Include standalone written notes and audio-file import in v1. Video import is deferred.
+- Give iPad a dedicated notes/transcript layout and strong keyboard support. Apple Pencil in v1 includes editable handwriting/sketches within notes and handwriting-to-typed-text entry. Sync original editable ink as private attachments plus readable previews, editable on iPad and viewable on iPhone and desktop. This requires compatible sync/viewer extensions.
+- Finished meeting records include an editable summary with key points, decisions, and proposed next actions, plus a searchable timestamped transcript linked to audio. Do not invent missing owners or due dates.
+- Recording, writing notes, playback, and access to content already stored on the device must work offline. Live transcription, summaries, and meeting/library questions must also work offline on supported devices after required models and content are ready. Exact device eligibility and measured quality remain unverified.
+- Core local use requires no DoodleNote account. Sign-in is required when enabling cloud sync. Optional external AI uses the user's own provider API key, with its costs separate from the sync subscription; provider selection and mobile commercial terms remain open.
+- Live transcription and its accuracy are v1 priorities. It must not be deferred to a later release.
+- Prefer on-device processing where it meets requirements. External AI must be explicitly enabled by the user; never silently upload content as a fallback.
+- Recording continues through screen lock and app switching where the OS permits, preserves captured audio on interruption, and clearly offers resume when possible.
+- Keep audio on the recording device until the user removes it. V1 cloud sync covers notes and transcripts, without cross-device audio playback.
+- Next actions are editable checklists inside notes. Next-action reminders, external task integrations, and assignment workflows are deferred; calendar meeting reminders are included.
+- Use a recent-first library, optional folders, and search across typed notes, summaries, and transcripts.
+- Export selected notes and transcripts as PDF or Markdown through the system share sheet. Public sharing links are outside v1.
+- Preserve ink, but defer automatic handwriting recognition, ink search, and AI interpretation of ink. Summaries use the transcript and typed personal notes, including handwriting entered as typed text.
+- Automatic speaker separation is a desired v1 requirement subject to feasibility validation. Sean explicitly rejected treating it as deferred and wants live labels if identification can be made to work. The initial speaker-count target is three to four people. The requested explanation has been delivered; optional saved voice profiles and exact matching behavior remain proposed for final review.
+- Launch with English, Danish, Spanish, French, and German, including translated interface text. Generated notes default to the meeting's selected spoken language, with a separately selectable supported output language. Preserve the original-language transcript. Use one selected primary spoken language per recording in v1; automatic mixed-language switching is deferred pending separate validation.
+- Use two-hour live recordings and imports as the initial acceptance-test baseline, not a recording cutoff or a claim of measured performance. Never silently truncate longer content.
+- Preserve both conflicting note versions for user reconciliation. This requires improvements to existing sync behavior; real-time collaboration is outside v1.
+- Setup should let the user select a supported language and show the app's interface text in that language. English-only UI is a fallback to discuss if a concrete difficulty warrants it, not the accepted default. The five launch languages are confirmed; region variants and quality acceptance still require specification.
+- Deleted notes remain recoverable in Trash for 30 days, with synchronized Trash state for synced notes and explicit confirmation for immediate permanent deletion. Detailed audio/backup and offline-expiry semantics remain open.
+- Require offline generated summaries on supported devices after necessary models are ready, in the agreed languages. Device/model feasibility must validate this; preserve content for retry when unavailable.
+- Core local mobile functionality is free. The existing paid cloud sync service is optional; optional external-AI provider costs remain separate. App Store purchasing/review details remain to be resolved without changing prices or publishing.
+- Include offline questions about the current meeting's transcript and typed notes and homepage questions across all recordings and notes in the selected library/workspace. Offer an explicit selector to include other authorized libraries, exclude Trash, expose unavailable/unindexed content, and link answers to supporting passages. Do not inherit a recent-record-only retrieval limit.
+- Include six built-in formats: general meeting, client discovery, project/status update, one-to-one, interview, and training/workshop.
+- Include direct Microsoft 365/Office 365 Calendar and Google Calendar integrations in v1, with desktop calendar feature parity adapted to mobile. The recommendation to defer calendars was rejected.
+- Include a complete export/restore archive through Files, preserving notes, transcripts, ink, and local recording audio. Archive protection, profile inclusion, and restore conflict behavior remain design details.
+- Users explicitly choose a library/workspace for automatic note synchronization, with a clearly separate local-only library. Ordinary notes sync excludes recording audio and voice profiles.
+- Regenerating a summary preserves the edited version and creates a new generated version for review before replacement. It must not silently overwrite user work.
+- Support multiple Microsoft and Google calendar accounts with explicit account/calendar selection. Use invitation attendees as optional participant-name suggestions; require confirmed voice associations for speaker names.
+- V1 recording covers in-person conversations or meeting audio from another device. Same-device online-call audio capture is outside v1; opening a calendar meeting link does not add that capability.
+
+## Working method
+
+The round records below are historical. Later accepted answers supersede earlier open wording. The confirmed direction above and the consolidated specification describe current scope.
+
+Ask all currently answerable product decisions in each round. Research environment facts separately. Use current desktop, web, and shared-product evidence only to understand possible integration boundaries, not to impose mobile feature parity.
+
+Maintain a glossary when product terms are resolved. Record architecture decisions only when a meaningful trade-off, significant reversal cost, and non-obvious rationale warrant one. Keep this discovery's files under OUTPUTS/doodlenote-mobile-discovery, preserving existing repository work.
+
+The required about-me.md, working-style.md, and brand-voice.md were located and read under /Volumes/CodexSSD/Codex/Projects/AOA/CONTEXT/. They supplement the user-supplied global instructions; they do not establish DoodleNote mobile requirements.
+
+## Round 1: Settled foundation decisions
+
+1. First audience: Accepted the recommended professional audience.
+2. Anchor workflow: Accepted in-person recording, personal notes, accurate summary, and next actions.
+3. Relationship to desktop: Independent use, with optional integration into the existing cloud sync service. This does not yet settle sign-in requirements, processing location, offline guarantees, audio synchronization, or pricing.
+4. Launch constraints: Accepted reliability of the anchor workflow as the initial scope criterion. This does not authorize spending or establish a budget.
+
+## Round 2: Settled workflow decisions
+
+5. Notes without recording: Accepted standalone written notes in the same library as recorded conversations.
+6. Additional capture sources: Accepted audio-file import in v1 and deferred video import. No phone-call or other-app audio capture requirement has been accepted.
+7. iPad experience: Accepted a dedicated notes/transcript layout and strong keyboard support. Sean explicitly requires Apple Pencil capabilities in v1, overriding the recommendation to defer them. Exact ink, text-entry, recognition, and sync behavior is unresolved.
+8. Finished meeting record: Accepted editable summary, key points, decisions, proposed next actions, and searchable timestamped transcript linked to audio. Never invent missing owners or due dates.
+9. Offline minimum: Accepted recording, writing notes, playback, and access to content already stored on the device. Offline transcription and summarization remain separate decisions.
+10. Account requirement: Accepted core local use without a DoodleNote account and sign-in when enabling existing cloud sync. Processing-provider credentials and commercial entitlements remain separate decisions.
+
+## Round 3: Settled behavior decisions
+
+11. Pencil scope: Accepted editable handwriting/sketches within notes and handwriting-to-typed-text entry. Handwriting recognition for library search and AI input remains a separate branch.
+12. Processing privacy: Accepted on-device processing where it meets requirements, explicitly enabled external AI, and no silent external fallback. Device support, providers, credentials, cost, and long-meeting quality remain separate decisions.
+13. Transcript timing: Sean explicitly requires live transcription in v1 and prioritizes its accuracy, overriding the recommendation to defer live transcription. Finalization, corrections, failure behavior, and offline availability remain open.
+14. Recording lifecycle: Accepted recording through screen lock and app switching where the OS permits, preserving captured audio on interruption, and clearly offering resume when possible. Recording during calls and other-app audio capture are not promised.
+15. Audio retention and sync: Accepted local audio retention until user removal, with notes/transcripts sync in v1 and no cross-device audio playback. Backup, storage pressure, and deletion recovery remain separate decisions.
+16. Next actions: Accepted editable checklists within notes. Next-action reminders, external task integrations, and assignment workflows are deferred. Calendar reminders are separately included.
+17. Organization: Accepted recent-first library, optional folders, and search across typed notes, summaries, and transcripts. Pencil recognition/search remains a separate decision.
+18. Export: Accepted selected notes/transcripts as PDF or Markdown through the system share sheet. Public sharing links are outside v1. Rendering of Pencil ink and separate audio export need follow-up.
+
+## Round 4: Settled direction, with speaker feasibility and language details open
+
+19. Offline live transcription: Accepted offline live transcription on supported devices after speech-asset download, preserving recording if transcription fails. Exact device/OS eligibility remains open.
+20. External AI provision: Accepted user-supplied provider API keys in v1 and separate external-AI versus cloud-sync costs. Provider selection, secure credential storage, consent details, and commercial terms remain open. This does not authorize charges or set prices.
+21. Ink synchronization: Accepted original editable ink plus readable previews across devices, including iPhone and desktop visibility. The private-attachment and viewer design must extend the current sync contract; this is accepted product scope, not existing behavior.
+22. Handwriting in search and AI: Accepted preserved/displayed ink, with automatic ink recognition/search/AI interpretation deferred. Summaries use transcript and typed personal notes, including handwriting entered as typed text. Clearly distinguish what the AI processed.
+23. Speaker attribution: Sean wants automatic speaker identification/separation in v1 if feasible, including speakers in transcript and generated notes. The recommendation to defer automatic separation was rejected. On-device feasibility is under research; separation, actual names, timing of labels, and cross-meeting voice identity need clarification. Do not silently reduce this to manual-only labeling.
+24. Languages: Sean requires English plus multiple additional languages in the first release and reports multilingual desktop support is being added. The recommendation for English-only launch was rejected. Questions 30-33 subsequently settle the initial language list, content-language behavior, and translated interface scope.
+25. Meeting length: Accepted two-hour live recordings/imports as the initial acceptance-test target, not a recording cutoff. Include live accuracy, battery/heat, recovery, and complete summaries. Never silently truncate longer input. Behavior beyond that baseline and resource limits still need specification.
+26. Sync conflicts: Accepted preserving both conflicting versions for reconciliation. Do not silently overwrite edits or add real-time collaboration to v1. Existing cloud conflict handling requires compatible changes.
+
+## Round 5: Partly settled; speaker-identification explanation requested
+
+27. Speaker identity: Sean requests an explanation of what actual speaker identification would require and how it would look before deciding. Anonymous separation, confirmed meeting names, reference voice samples, and remembered profiles must be distinguished. The earlier recommendation to defer persistent profiles has not been accepted; the decision remains open.
+28. Timing of speaker labels: Sean wants labels during recording if question 27 can be made feasible. This is the desired live experience, not a demonstrated runtime capability. Precise confidence, tentative/final, and correction behavior remains to be agreed.
+29. Number of speakers: Sean selects three to four speakers if feasible, replacing the proposed six-speaker target. Preserve clear handling for uncertain and overlapping speech. This is an acceptance target, not measured capacity.
+30. Exact launch languages: Accepted English, Danish, Spanish, French, and German, including translated interface text. Validate each for live offline transcription and generated-note behavior. These are product requirements, not measured quality results.
+31. Generated-note language: Accepted the meeting's selected spoken language as the default, with a separately chosen supported summary output language when desired. Preserve the original-language transcript. Translation and generation must meet the chosen privacy requirements.
+32. Mixed-language recordings: Accepted one explicitly selected primary spoken language per recording in v1. Automatic mixed-language switching is a separate capability to validate later.
+33. Interface localization: Sean wants the language selected in setup to apply to screen text throughout the app. He is open to English initially if this proves too difficult and asks to be told why. Native localization is standard platform work, so retain translated UI as the intended v1 scope; do not silently take the fallback. Translation coverage and per-language QA remain required.
+34. Deletion recovery: Accepted recoverable Trash for 30 days, synchronized Trash state for synced notes, and explicit confirmation for immediate permanent deletion. Audio removal and backup remain separate decisions. This is product policy, not authorization to delete existing data.
+
+Sean subsequently explicitly accepted the recommendations for questions 30-32, resolving the earlier language ambiguity.
+
+Question 27 explanation and the proposed live recognition experience are captured in [doodlenote_Speaker-Identification_v1.md](./doodlenote_Speaker-Identification_v1.md). The main remaining decision is whether to include optional remembered voice references across meetings or confirm names per meeting. No saved-profile behavior is accepted yet; no runtime feasibility has been demonstrated.
+
+After the explanation, Sean acknowledged it and asked what comes next. Optional device-local saved profiles are carried forward as a proposed default in the [consolidated product brief](./doodlenote_Product-Brief_v1.md), for confirmation with the complete specification. This acknowledgment is not treated as permission to collect voice data or begin implementation. Questions 30-32 are now settled.
+
+## Round 6: Settled launch and ownership direction
+
+35. Offline generated notes: Accepted offline summaries on supported devices once necessary models are ready, in the agreed languages; retain content for retry when unavailable. The device/model feasibility phase must validate this and establish hardware support.
+36. Mobile commercial model: Accepted free core local functionality, optional existing paid cloud sync, and separate external-AI provider costs. App Store purchase/linking design, subscription terms, and review eligibility remain implementation/distribution work. No price changes or publishing are authorized.
+37. Questions: Sean requires both current-meeting questions over transcript/typed notes AND homepage questions across all recordings and notes. The recommendation to defer library-wide questions was rejected. Preserve supporting-passage links, processing/privacy choices, and the explicit exclusion of unrecognized ink. Library/workspace boundaries and offline Q&A need clarification.
+38. Summary formats: Sean requires selectable built-in formats based on meeting type. Question 47 subsequently confirms six presets; custom template creation has not been requested.
+39. Calendar integration: Sean explicitly requires calendar integration like desktop, starting with Office 365/Microsoft 365 and Google Calendar. The recommendation to defer it was rejected. Carry forward verified read-only calendar behaviors, with fresh native auth and mobile lifecycle handling; do not assume desktop loopback OAuth, polling, mic detection, or system-audio capture applies to iOS.
+40. Backup and restore: Accepted a complete export/restore archive through Files preserving notes, transcripts, ink, and local recordings. Protection, saved-profile inclusion, and restore collisions need explicit design. This is separate from cloud audio sync.
+41. Sync scope: Accepted explicit selection of a library/workspace for automatic note sync, with a separate local-only library. Ordinary notes sync excludes audio and voice profiles. Movement between libraries and account switching need ownership design.
+42. Regeneration: Accepted preserving the edited summary and creating a new generated version for review before replacement. Never silently overwrite user work. Versions and corrected speaker identities need a consistent sync contract.
+
+## Round 7: Settled calendar and question-answering details
+
+43. Calendar accounts: Accepted multiple work/personal Microsoft and Google accounts with clearly labelled account/calendar selection. Desktop's one-account-per-provider source baseline is not the mobile limit. Shared/delegated calendar guarantees are not implied by this decision.
+44. Calendar attendees: Accepted optional participant-name suggestions from invitees. Invitation membership does not establish attendance or voice identity; confirmed voice associations remain necessary. This expands the current normalized event data.
+45. Offline questions: Accepted meeting and homepage questions over locally available indexed content with required models ready. Show indexing/availability gaps; do not claim complete coverage while content is unavailable. External AI remains explicitly optional.
+46. Library-question scope: Accepted all records within the selected library/workspace by default, with a visible selector for deliberately including other authorized libraries. Exclude Trash and do not silently mix unrelated workspaces. Preserve full-history retrieval rather than newest-N truncation.
+47. Built-in formats: Accepted general meeting, client discovery, project/status update, one-to-one, interview, and training/workshop. Templates structure supported information without inventing missing facts.
+48. Same-device online calls: Accepted in-person or another-device meeting audio for v1. Calendar Join opens a meeting link but does not imply capturing that app's call audio. Same-device online-call capture is outside this first release.
+
+## Final-review frontier
+
+The feature decisions through question 48 are captured in [doodlenote_Specification_v1.md](./doodlenote_Specification_v1.md). The specification explicitly separates accepted requirements from proposed operational defaults D1-D6: optional device-local saved voice profiles; encrypted backups and local-only restore; account/sign-out/audio-retention handling; optional provider scope; initial distribution approach; and the native feasibility-first implementation approach. These defaults are awaiting confirmation as a package or corrections. They must not be represented as already accepted.
+
+Engine/model choice, exact hardware/OS support, calibrated accuracy/latency targets, model licensing, native OAuth registrations, and production compatibility remain evidence-dependent implementation/distribution gates. They are not silently assumed product capabilities. No application implementation has started.
+
+## Design tree
+
+- Audience + anchor workflow -> launch use cases, supported content, editing and retrieval, first-use experience, success criteria.
+- Anchor workflow -> capture sources, recording behavior, interruption recovery, transcript and generated-note needs, device limitations.
+- Ecosystem relationship -> identity, library ownership, sync, offline behavior, conflict resolution, migration needs.
+- Audience + workflows -> iPhone and iPad interaction models, Pencil and keyboard needs, accessibility.
+- Launch constraints + required workflows -> v1 scope, deferred features, commercial model, operating costs, distribution.
+- Content + identity + processing -> privacy, retention, export, deletion, consent, account lifecycle.
+- Settled requirements -> architecture alternatives, platform support, acceptance scenarios, implementation milestones.
+
+All round-7 feature decisions are accepted. The current frontier is the explicit final-review defaults and confirmation of shared understanding in the consolidated specification. Read-only evidence is in [doodlenote_Feasibility_v1.md](./doodlenote_Feasibility_v1.md); no mobile runtime feasibility has been demonstrated. Do not reduce accepted requirements if an engine fails testing; return the evidenced trade-off for a product decision.
+
+These downstream branches are topics to resolve, not promised features. Recompute the tree after each round; do not silently convert a recommendation into a requirement.
+
+## Existing cloud integration evidence
+
+Read-only repository findings, not mobile requirements or proof of deployed behavior:
+
+- Push/pull support standalone notes and meetings, personal and enhanced Markdown notes, timestamped speaker-labelled transcripts, titles, times, folders, and calendar references. Sources: apps/web/app/api/sync/push/route.ts:18-46 and apps/web/app/api/sync/pull/route.ts:94-124.
+- Audio is absent from the push/pull contract. The media route accepts images only, limited to 3 MB, and uses public Blob access. Audio synchronization and confidential image handling need separate decisions. Source: apps/web/app/api/sync/media/route.ts:6-21,34-57.
+- Cloud linking requires account session, workspace membership, and entitlement. Sync routes validate device credentials and subscription entitlement. Sources: apps/web/app/api/device/link/route.ts:16-30,52-85 and apps/web/lib/sync-auth.ts:23-45,64-97. This does not impose account requirements on independent local use or establish mobile pricing.
+- Push replaces transcript and note bodies without a base-revision check. Competing pushes may overwrite edits; this is an inference from apps/web/app/api/sync/push/route.ts:154-215. Resolve conflict behavior before promising simultaneous editing.
+- The delete API permanently removes meeting rows; pull includes the full surviving ID list. Mobile trash, offline deletion, and unsynced-local identity require deliberate design. Sources: apps/web/app/api/sync/push/route.ts:234-273 and apps/web/app/api/sync/pull/route.ts:26-31,44-59.
+- The shared local model is broader than the cloud payload, including participant records, chat history, and trash metadata. Handwriting strokes and structured task state are not represented in this sync contract. Source: packages/meetings-store/src/types.ts:11-31,43-57,60-97, compared with push/pull above.
+
+Follow-up branches: processing location and privacy; audio retention versus cloud notes sync; account/workspace linking and entitlement; cross-device conflicts and deletion; compatibility of any accepted Pencil or task features. Existing iOS code and design choices were excluded from this research.
+
+## Existing non-iOS AI product evidence
+
+Read-only source verification during round 4, not a mobile requirement or live entitlement verification:
+
+- Desktop settings expose on-device processing and cloud with the user's own key. Source: apps/desktop/src/renderer/src/ModelsView.tsx:1385-1450.
+- The shared AI engine implements Anthropic, OpenAI, Groq, OpenRouter, and local Ollama. Provider credentials are passed to the selected provider SDK. Source: packages/ai/src/cloud-engine.ts:9-46,84-99.
+- The web pricing source describes Sync as server/storage features, while local AI and bring-your-own-key AI are separate from those paid sync features. No managed inference-credit service was found in the bounded web API/lib search. Source: apps/web/app/pricing/page.tsx:16-55. No live prices, entitlements, or vendor terms were checked.
+- Desktop summarization passes both personal Markdown notes and transcript to the selected engine. Sources: apps/desktop/src/main/notes-service.ts:257-282 and packages/ai/src/prompt.ts:90-121,128-153. This is integration context, not automatic mobile feature parity.
+
+## Apple feasibility evidence
+
+Official Apple documentation reviewed on 2026-09-05, without using existing iOS code or plans. These are feasibility boundaries, not accepted technology choices:
+
+- [PencilKit](https://developer.apple.com/documentation/pencilkit/) preserves editable drawings; [Scribble](https://developer.apple.com/documentation/applepencil) converts handwriting entered in text fields into typed text. Preserved ink and handwriting-to-text entry are distinct behaviors. Current PencilKit docs mark PKStrokeRecognizer as beta, so handwriting search, bulk recognition, and AI use of ink require separate feasibility and release-availability checks.
+- [SpeechAnalyzer and SpeechTranscriber](https://developer.apple.com/videos/play/wwdc2025/277/) support local transcription of live or recorded audio, introduced in iOS 26. Device eligibility, supported locale, and downloaded model assets must be checked. Recording must remain useful when transcription is unavailable.
+- [Foundation Models availability](https://developer.apple.com/documentation/FoundationModels/adding-intelligent-app-features-with-generative-models) depends on eligible hardware, Apple Intelligence settings, and model readiness. Its [4,096-token context window](https://developer.apple.com/documentation/foundationmodels/managing-the-context-window) means long meetings require chunking and quality validation. Neither choosing a native framework nor setting a minimum OS alone proves accurate offline summaries for all users.
+- Apple documents [background and locked-screen recording](https://developer.apple.com/documentation/avfaudio/avaudiosession/category-swift.struct/record) and [audio interruptions](https://developer.apple.com/documentation/AVFAudio/handling-audio-interruptions). Calls and some iPad cover behavior can interrupt or mute capture; preserve audio and validate recovery on physical devices.
+- Apple's documented [transcription results](https://developer.apple.com/documentation/speech/speechtranscriber/result) and [result attributes](https://developer.apple.com/documentation/speech/speechtranscriber/resultattributeoption) describe text, timing, confidence, and tentative/final results, but do not establish automatic speaker separation or names. This is a documented capability boundary, not proof that on-device diarization is impossible. Automatic speaker attribution would require separate feasibility work.
+
+## Completion condition
+
+Reach shared understanding on the remaining decisions and obtain the user's confirmation before starting implementation. No application code has been changed for this discovery.
+
+## Final approval, 2026-09-06
+
+Sean confirmed: "Yes this all looks good. Are we ready to build?" The complete specification and defaults D1-D6 are accepted. Shared understanding is established and implementation may start. Earlier pending-review statements above are historical. A fresh native foundation is being built in an isolated worktree; physical-device feasibility and all release gates remain open.

--- a/apps/mobile-native/docs/discovery/doodlenote_Feasibility_v1.md
+++ b/apps/mobile-native/docs/discovery/doodlenote_Feasibility_v1.md
@@ -1,0 +1,83 @@
+# DoodleNote mobile speech and speaker feasibility
+
+Status: Read-only source research, 2026-09-05. No models installed, code executed, device benchmarks run, or mobile engine selected. Existing iOS implementation and plans were excluded.
+
+## Accepted requirements driving this research
+
+Accurate live transcription, offline operation after model download, multilingual launch, and a two-hour recording/import acceptance baseline. Automatic speaker separation is a desired v1 requirement if feasible, with speakers represented in the transcript and generated notes. Real-name recognition, persistent voice profiles, and live speaker-label timing remain separate product decisions.
+
+## Current desktop language evidence
+
+- [Open PR 117](https://github.com/Onyx-Dev-Labs/doodle-note/pull/117), checked at head 55c8bc0bf7148d107bd170b991e1828ef72b12a3, adds English/Multilingual selection for macOS batch imports and retranscription. It excludes multilingual live captions and generated-note language settings. Windows ignores that setting. This verifies ongoing work, not a released feature.
+- [Issue 118](https://github.com/Onyx-Dev-Labs/doodle-note/issues/118) describes Danish conversational recognition problems and requests an optional offline Whisper batch engine. Danish is an evidence-backed language priority. Contributor quality comparisons are not independently validated benchmarks.
+- Current non-iOS source uses English streaming (engine/Sources/engine/Commands.swift:206), default Parakeet v2 batch unless v3 is specified (same file:16), and a plain-English generated-notes prompt (packages/ai/src/prompt.ts:27). These desktop choices do not constrain the fresh mobile product.
+- Desktop mic-versus-system-audio speaker grouping is capture-source separation, not proof of multi-person room diarization. Source: engine/Sources/engine/LiveCommand.swift:9.
+
+## Candidate assessment
+
+### First candidate to evaluate: FluidAudio
+
+Native Swift/CoreML makes FluidAudio a candidate for Apple-device evaluation. Its [package](https://raw.githubusercontent.com/FluidInference/FluidAudio/main/Package.swift) declares iOS 17+, but a build minimum does not prove performance or establish our minimum supported device. The [library](https://github.com/FluidInference/FluidAudio) is Apache-2.0.
+
+- Final speaker separation: [converted Community-1 model](https://huggingface.co/FluidInference/speaker-diarization-coreml) and [upstream Community-1](https://huggingface.co/pyannote/speaker-diarization-community-1) document offline speaker segments/timestamps and label their models CC-BY-4.0. Upstream offers exclusive diarization useful for transcript alignment; wrapper support and exact downloadable artifact rights still need verification. A language-independent acoustic approach is not proof of equal accuracy in every language.
+- Live speaker labels: [LS-EEND documentation](https://raw.githubusercontent.com/FluidInference/FluidAudio/main/Documentation/Diarization/LS-EEND.md) describes streaming variants with four, seven, or ten speakers, but documents up to one hour. Two-hour stability and model artifact licensing were not verified. Do not silently assume chunking preserves speaker identity across that limit.
+- Alternative live labels: [Sortformer documentation](https://raw.githubusercontent.com/FluidInference/FluidAudio/main/Documentation/Diarization/Sortformer.md) describes four unique speakers and weaknesses with overlap or quiet/distant voices. Its memory measurements are vendor reports, not this app's device measurements. The [upstream checkpoint](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2.1) and [converted checkpoint](https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml) show differing license labels; resolve the exact artifact terms before selection.
+- [Model documentation](https://raw.githubusercontent.com/FluidInference/FluidAudio/main/Documentation/Models.md) lists streaming Nemotron multilingual for English, Spanish, French, Italian, Portuguese, German, Chinese, and Japanese. Parakeet v3 is described as 25 European languages through batch/sliding-window transcription. These are documented model capabilities, not demonstrated simultaneous two-hour mobile transcription/diarization performance. Danish live quality remains a specific validation need.
+
+### Comparison candidate: sherpa-onnx
+
+[Official iOS build documentation](https://k2-fsa.github.io/sherpa/onnx/ios/build-sherpa-onnx-swift.html) supports iPhone/iPad builds and an older minimum OS. The [Swift diarization example](https://k2-fsa.github.io/sherpa/onnx/speaker-diarization/swift.html) uses an offline diarization API; support for streaming speech recognition does not establish streaming speaker separation. The library is Apache-2.0, while [model licenses](https://k2-fsa.github.io/sherpa/onnx/speaker-diarization/models.html) must be checked separately. A pyannote segmentation model needs a compatible speaker-embedding model and clustering; it is not a complete solution alone.
+
+## Apple language and speech boundary
+
+[SpeechTranscriber](https://developer.apple.com/documentation/speech/speechtranscriber) exposes hardware availability, supported locales, and installed locales. The [Apple sample](https://developer.apple.com/videos/play/wwdc2025/277/) checks assets and installs missing models, with limits on concurrently allocated languages. Exact launch language commitments require device/runtime checks and language-specific testing.
+
+Apple's documented [result fields](https://developer.apple.com/documentation/speech/speechtranscriber/result) do not establish speaker IDs or names. Speaker separation and real-name identity must not be assumed from choosing Apple's transcription API.
+
+## Required validation before selecting an engine
+
+The launch-language requirements are now English, Danish, Spanish, French, and German, including interface text. Recordings have one selected primary spoken language. Generated notes default to it with an optional supported output-language override, preserving the original transcript. This acceptance does not establish runtime model quality or readiness.
+
+- Select minimum physical iPhone/iPad targets and run recording, live transcript, and Pencil editing together, including speaker processing at the accepted stage.
+- Validate each committed language with real conversational test material whose use is authorized. Include names, accents, interruptions, room noise, and domain terms.
+- Measure transcript accuracy, speaker-attribution accuracy, latency, memory, heat, battery use, and model-download size. Set acceptance thresholds before claiming success; no measured results exist yet.
+- Test two hours with speakers arriving, returning after silence, speaking softly, and overlapping. Preserve source timestamps and stable identities through the final alignment.
+- Preserve complete audio through processing errors, screen lock, app switching, calls, low storage, and restart. Validate export/recovery and prohibit silent truncation.
+- Distinguish anonymous speaker clustering from actual names. Corrections must propagate consistently to transcript and generated notes without replacing user edits silently.
+- Review exact library/model versions, licensing, redistribution, downloads, and offline availability before embedding assets.
+
+No technical candidate is an approved architecture decision. This research supports the next interview round and a later explicitly scoped feasibility implementation after shared understanding is confirmed.
+
+## Offline summaries and distribution boundaries
+
+Additional official Apple research for round 6, 2026-09-05:
+
+- [Apple Intelligence requirements](https://support.apple.com/en-us/121115) list the five selected languages with iOS/iPadOS 26.1, subject to feature availability. Apple Intelligence hardware eligibility, region/settings, and downloaded model readiness are separate constraints; the broad list alone does not guarantee a particular Foundation Models operation.
+- [Foundation Models language guidance](https://developer.apple.com/documentation/foundationmodels/supporting-languages-and-locales-with-foundation-models) directs checking supportsLocale and supportedLanguages. Check both source and requested output language plus [model availability](https://developer.apple.com/documentation/foundationmodels/systemlanguagemodel). Device performance and language quality still need measurement. An alternate local-model strategy would need independent validation if Apple's model is unavailable on a desired target device.
+- [App Review Guidelines](https://developer.apple.com/app-store/review/guidelines/) section 3.1.3(f) provides a potential route for free standalone companions to paid web tools, including cloud storage, without in-app purchase when there is no in-app purchasing or outside-purchase call to action. It is conditional on the actual product and review, not a DoodleNote approval guarantee. Sections 3.1.1 and 3.1.3(b) may govern other digital unlocks; storefront-specific exceptions must not become an assumed global purchase design.
+- The same guidelines do not establish a blanket bring-your-own-key exemption. Third-party AI data sharing needs clear disclosure and explicit permission under 5.1.2(i); entering a key alone must not silently authorize undisclosed data sharing. A reviewable demo/account path will be required for services that reviewers need to exercise.
+
+These findings do not approve mobile pricing, purchase links, subscriptions, third-party data transfers, or App Store publication. They identify constraints for the proposed commercial and AI experience.
+
+## Desktop calendar and Q&A baseline for round 7
+
+Read-only non-iOS source inspection; installed/deployed behavior was not tested:
+
+- Desktop connects Microsoft and Google directly through read-only OAuth/PKCE. Desktop loopback callbacks and Electron token protection must be replaced by native mobile mechanisms. Sources: apps/desktop/src/main/calendar-service.ts:62,140 and apps/desktop/src/main/google-calendar.ts:9.
+- One account per provider is represented, with both providers usable simultaneously and multiple selectable calendars. Defaults are selected initially; events are color-coded. Sources: apps/desktop/src/shared/calendar-api.ts:58,84 and apps/desktop/src/renderer/src/ModelsView.tsx:757. Multiple accounts per provider would expand this baseline.
+- Upcoming events cover 14 days, with local caching and refresh while the app runs. Both provider implementations currently limit initial event results without pagination. Mobile must handle complete results for the chosen date range instead of inheriting silent truncation. Sources: apps/desktop/src/main/calendar-service.ts:64,147,789 and apps/desktop/src/main/google-calendar.ts:168.
+- Join opens the event link. Take notes creates a titled event-linked meeting and starts recording; an already-linked nontrashed meeting is reopened without automatically restarting recording. Sources: apps/desktop/src/renderer/src/HomeView.tsx:53,294 and apps/desktop/src/renderer/src/App.tsx:141.
+- Desktop prompts near event start, skips all-day/duplicate prompts, and uses desktop-specific banners/notifications/panels. These express reminder intent, not a requirement to copy desktop mic detection or polling into iOS. Sources: apps/desktop/src/main/calendar-watcher.ts:7 and apps/desktop/src/main/calendar-service.ts:856.
+- Event normalization preserves organizer and hasParticipants but no attendee list. Participant-name suggestions require additional data handling. Source: apps/desktop/src/shared/calendar-api.ts:25.
+- Disconnect forgets local provider/session information; provider-wide consent revocation is not established for all paths. Sources: apps/desktop/src/main/calendar-service.ts:559 and apps/desktop/src/main/google-calendar.ts:120.
+- Current meeting Q&A uses transcript, typed notes, generated notes, and recent chat. Homepage Q&A instead selects the newest 30 nontrashed records and a 20,000-character default budget, preferring generated notes. It does not satisfy the new full-library transcript/typed-note retrieval requirement. Sources: packages/ai/src/ask-prompt.ts:38; apps/desktop/src/main/notes-service.ts:58,395,605; packages/ai/src/global-ask-prompt.ts:23. Mobile requires an index over eligible full-history sources and evidence-linked answers, not a copy of this recency-limited prompt.
+
+## Native calendar integration boundaries
+
+- [Microsoft authorization-code flow](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow) supports native public clients with PKCE. [calendarView](https://learn.microsoft.com/en-us/graph/api/calendar-list-calendarview?view=graph-rest-1.0) lists Calendars.ReadBasic as minimum delegated access for time-range occurrences; [permission definitions](https://learn.microsoft.com/en-us/graph/permissions-reference#calendarsreadbasic) exclude body/attachments/extensions from that basic scope. Agenda/body or shared/delegated calendar requirements change the permission design. [Tenant consent policy](https://learn.microsoft.com/en-us/entra/identity-platform/application-consent-experience) can still prevent user authorization.
+- [Google native OAuth](https://developers.google.com/identity/protocols/oauth2/native-app) and [iOS API access](https://developers.google.com/identity/sign-in/ios/api-access) support direct provider connections. [Calendar scopes](https://developers.google.com/workspace/calendar/api/auth) include event-readonly and calendar-list-readonly scopes, without Gmail access. Public distribution of sensitive-scope access requires applicable [verification](https://developers.google.com/identity/protocols/oauth2/production-readiness/sensitive-scope-verification); this is a release dependency, not proof that the existing mobile client is configured or approved.
+- Direct calendar authorization can be separate from a DoodleNote account/subscription. EventKit alone is not equivalent to direct provider connections: it depends on device calendar configuration, and [reading event-store data](https://developer.apple.com/documentation/eventkit/accessing-the-event-store) requires full calendar access rather than a read-only grant.
+- Cache already fetched events for offline display and label freshness. [Google incremental synchronization](https://developers.google.com/workspace/calendar/api/guides/sync) documents handling changed/deleted events and invalidated sync tokens. Offline access permission enables token renewal, not live updates without networking.
+- [Local notifications](https://developer.apple.com/documentation/UserNotifications/scheduling-a-notification-locally-from-your-app) can remind users while the app is not running. [Background task scheduling](https://developer.apple.com/documentation/backgroundtasks/choosing-background-strategies-for-your-app) is system-controlled, and Apple documents [background recording-start failures](https://developer.apple.com/documentation/coreaudiotypes/avaudiosession/errorcode/cannotstartrecording). Use a reminder that opens meeting actions and explicit user-started recording. No guaranteed calendar-triggered background microphone start is established.
+
+No calendar account was connected, OAuth registration changed, credential collected, event written, or permission granted during research.

--- a/apps/mobile-native/docs/discovery/doodlenote_Product-Brief_v1.md
+++ b/apps/mobile-native/docs/discovery/doodlenote_Product-Brief_v1.md
@@ -1,0 +1,88 @@
+# DoodleNote iPhone and iPad: product brief
+
+Status: Product scope and operational defaults approved by Sean on 2026-09-06. Implementation is authorized; release and production changes require separate approval.
+
+Updated 2026-09-06. See the [v1 specification](./doodlenote_Specification_v1.md) for the complete accepted scope, accepted operational defaults, and validation plan.
+
+## Product purpose
+
+An independent iPhone and iPad app for professionals to capture in-person conversations, add personal notes, and leave with an accurate transcript, useful summary, and next actions. Existing iOS implementation and planning are excluded. Desktop, shared-model, and cloud evidence informs compatibility only.
+
+## Accepted first-release scope
+
+| Area | Required behavior |
+| --- | --- |
+| Capture | Live in-person audio recording and audio-file import; standalone notes also supported. |
+| Live transcript | Accurate text during recording, including offline operation on supported devices after required models are downloaded. Preserve audio if processing fails. |
+| Speakers | Automatic separation and identification pursued as a v1 requirement subject to feasibility, with live labels desired. Initial target: three to four speakers. Optional device-local saved voice references are accepted; model quality and matching behavior need validation. |
+| iPad notes | Dedicated notes/transcript layout, strong keyboard support, editable Pencil handwriting/sketches, and handwriting-to-typed-text entry. |
+| Generated notes | Editable summary, key points, decisions, and proposed next actions as checklists. Built-in meeting-type formats. Use transcript and typed personal notes. Preserve edited versions when regenerating. Never invent owners or due dates. |
+| Ink | Preserve and synchronize original editable ink and readable previews. Automatic ink recognition, ink search, and AI interpretation of ink are deferred. |
+| Library | Recent-first notes and recordings, optional folders, search across typed notes/summaries/transcripts, timestamp-linked playback when audio exists locally. |
+| Offline core | Recording, personal notes, locally stored content, playback, live transcription, summaries, and meeting/library Q&A after necessary models/content are ready. Validate all five languages on supported devices. |
+| Accounts and AI | Free core local functionality without a DoodleNote account. Existing paid Sync is optional; external AI uses user-supplied provider credentials and separate costs. On-device-first processing with no silent external fallback. |
+| Sync | Explicitly choose a library/workspace for automatic note sync, retaining a separate local-only library. Sync notes, transcripts, ink, and previews. Preserve conflicts and edited summaries. Compatible cloud/viewer changes are part of scope. |
+| Audio | Retain on the recording/importing device until user removal. Cross-device audio playback is outside v1. |
+| Languages | English, Danish, Spanish, French, and German, including interface text. One selected spoken language per recording. Generated notes default to that language, with a supported output-language override; preserve the original-language transcript. |
+| Questions | Offline meeting questions and homepage full-history questions with passage links. Default to the selected library/workspace; explicitly select additional authorized libraries. Exclude Trash and show unavailable/unindexed content. |
+| Calendars | Multiple Office 365/Microsoft 365 and Google accounts; read-only calendar selection, upcoming events, linked notes, links and reminders. Invitee-name suggestions require confirmed voice associations. Same-device call capture is outside v1. |
+| Export and recovery | PDF/Markdown sharing and a complete export/restore archive preserving notes, transcripts, ink, and local audio. Recoverable Trash for 30 days, synced Trash state for synced notes, and confirmation for immediate permanent deletion. |
+| Reliability | Continue recording through screen lock/app switching where permitted, preserve audio on interruption, clearly offer resume. Two-hour live/import test baseline, with no silent truncation of longer content. |
+
+## Accepted speaker approach
+
+Sean approved optional device-local saved voice profiles with default D1 on 2026-09-06:
+
+- Start recording without mandatory voice enrollment.
+- Show anonymous labels until named or reliably matched.
+- Let users confirm a name and optionally remember a voice on this device.
+- Select known participants for later meetings; leave unknown or ambiguous voices unassigned.
+- Correct a passage or tracked speaker and use corrected attribution in the final transcript and generated notes.
+- Keep voice-reference data outside normal cloud note sync. References, profile storage, matching thresholds, correction/version behavior, and exact consent screens require design and validation.
+
+This does not authorize recording anyone or collecting voice-reference data. No runtime capability has been demonstrated.
+
+## Settled language decisions
+
+- Q30 accepted: English, Danish, Spanish, French, and German, including translated interface text.
+- Q31 accepted: generated notes default to the meeting's selected spoken language, with a separate supported output-language override. Preserve the original transcript.
+- Q32 accepted: one selected primary spoken language per recording in v1; automatic mixed-language switching is deferred pending separate validation.
+
+## Current decision round
+
+Questions 43-48 are also settled: multiple calendar accounts, attendee suggestions, offline Q&A, explicit full-library scope, six meeting-type presets, and exclusion of same-device online-call capture. Operational defaults D1-D6 and shared understanding were confirmed on 2026-09-06.
+
+## Calendar behaviors derived from requested desktop parity
+
+Connect Microsoft and Google calendars directly and independently from DoodleNote cloud sync, select calendars, display upcoming events and cached offline information, open meeting links, and create/reopen a titled event-linked note. Use opt-in meeting reminders and an explicit user action to start recording. Preserve created notes if a calendar event changes or disappears. Fetch complete results for the selected date range and handle individual recurring occurrences without creating duplicate notes.
+
+The source baseline has a 14-day view and one account per provider. Mobile expands it to multiple accounts per provider and attendee-name suggestions. Calendar editing and invitations are not part of the requested read-only desktop behavior. Native authentication, notifications, and refresh replace desktop-specific loopback sign-in, polling, and mic detection.
+
+## Other decisions to close before the final build specification
+
+- Exact device/OS support and language-specific engine choices, informed by an explicitly scoped device feasibility phase rather than assumed from library compatibility.
+- Model readiness, optional external providers, failure/retry behavior, and measured quality acceptance criteria for offline summaries and the other speech/AI features.
+- App Store distribution/purchase flow and consumption of existing sync entitlements. Free local functionality is accepted; no purchase flow or release has been approved.
+- Feature choices above are accepted; exact native authentication, retrieval/indexing, and provider integration behavior still requires implementation validation.
+- Synced Trash, local audio deletion, backup/export, account switching/sign-out, workspace scope, and old-client compatibility details.
+- Final speaker-profile behavior and treatment of corrected or regenerated content without losing user edits.
+
+## Proposed delivery sequence
+
+1. Complete: product scope, defaults, exclusions, and acceptance scenarios reviewed with Sean.
+2. Complete: Sean confirmed shared understanding and authorized implementation on 2026-09-06.
+3. Build a narrowly scoped native feasibility prototype for simultaneous durable capture, offline multilingual live transcription, live speaker identification, and Pencil use on physical iPhone and iPad. Evaluate exact model artifacts and distribution rights. Measure the complete two-hour workflow before choosing the supported-device floor.
+4. Resolve evidence-based architecture decisions and build the native user experience plus compatible cloud/viewer extensions in isolated editing workspaces.
+5. Verify end-to-end capture, interruption recovery, language quality, speaker correction, sync/conflicts, ink, export, deletion recovery, and real-device performance before a reviewed beta/release process.
+
+Feasibility failure must produce an explicit trade-off for Sean; it must not silently remove live transcription, multilingual support, Pencil, or requested speaker behavior.
+
+## Supporting records
+
+- [Discovery decisions](./doodlenote_Discovery_v1.md)
+- [Domain glossary](./CONTEXT.md)
+- [Speech and language research](./doodlenote_Feasibility_v1.md)
+- [Speaker identification proposal and diagram](./doodlenote_Speaker-Identification_v1.md)
+- [Independent use and sync decision](./docs/adr/0001-independent-mobile-with-existing-sync.md)
+- [Processing privacy and local audio decision](./docs/adr/0002-explicit-external-ai-and-local-audio.md)
+- [Ink and conflict preservation decision](./docs/adr/0003-extend-sync-for-ink-and-conflict-preservation.md)

--- a/apps/mobile-native/docs/discovery/doodlenote_Speaker-Identification_v1.md
+++ b/apps/mobile-native/docs/discovery/doodlenote_Speaker-Identification_v1.md
@@ -1,0 +1,93 @@
+# DoodleNote speaker identification proposal
+
+Status: Explanation and proposed design for question 27. Live labels are requested if feasible, with a three-to-four-speaker target. Persistent recognition across meetings is not yet accepted. No prototype, model download, or device test has been performed.
+
+## What identification means
+
+Speaker separation determines which stretches of audio belong to different voices. Named identification associates a voice with a person whose name has been supplied or confirmed. Recognition across meetings additionally requires a reusable voice reference and a matching process.
+
+A transcript engine cannot reliably discover an unknown person's real name from voice alone. A contact or attendee list supplies possible names, not the evidence linking each name to a voice. Spoken introductions can help the user assign a name but should not silently become verified identity.
+
+## Recommended experience
+
+1. Start recording immediately. Show the live text and anonymous Speaker 1/2 labels while identity is unknown; label timing must be established by testing.
+2. Tap a speaker label to assign a name. Keep subsequent turns from that tracked speaker associated with the name, with visible handling for uncertainty and corrections.
+3. Optionally select known participants before future recordings. Build a reusable reference only from a clear solo sample or an explicitly confirmed clean excerpt from an earlier recording.
+4. Offer Remember this voice on this device separately. Do not require enrollment to capture a meeting. Saved-profile functionality remains a proposal pending Sean's decision.
+5. Match incoming speech to the selected profiles when evidence is sufficient. Leave an unknown guest or ambiguous speech unassigned rather than force one of the selected names.
+6. Let corrections apply to a passage or to the tracked speaker across the meeting. Do not automatically update a saved voice reference from uncertain or corrected-away speech.
+7. After recording, refine attribution and generate notes using the current speaker mapping. Question 42 now requires preserving manual edits and creating a new generated version for review before replacement. Exact identity propagation and version implementation remain to be designed.
+
+Illustrative screen content below uses fictional meeting statements, not real transcript data:
+
+```text
+Recording
+
+Sean       We need to confirm the installation date.
+Speaker 2  I can check the building schedule.
+           [Assign name]
+Maria      Thursday would work for our team.
+```
+
+The record should clearly distinguish named, anonymous, and uncertain attribution. Avoid presenting an uncalibrated model score as a percentage certainty.
+
+## Proposed processing flow
+
+```mermaid
+flowchart TD
+    A[Microphone audio] --> B[Durable local recording]
+    A --> C[Live words and timestamps]
+    A --> D[Streaming speaker separation]
+    E[Optional confirmed voice references] --> F[Name matching and corrections]
+    D --> F
+    C --> G[Live transcript with speaker labels]
+    F --> G
+    B --> H[Final alignment and attribution review]
+    G --> H
+    H --> I[Generated notes using corrected speakers]
+```
+
+## Work required
+
+- Integrate durable audio capture with concurrent on-device transcription and speaker processing. Keep recording safe if either model fails or falls behind.
+- Select downloadable model versions, verify distribution rights, and manage device eligibility, storage, loading, and readiness.
+- Reconcile transcription timestamps with speaker segments, including provisional versus finalized output, pauses, resampling, returning speakers, and overlap.
+- Maintain stable meeting speaker IDs and confirmed names. Speaker-slot numbers alone must not become a permanent person identity across sessions.
+- Build participant selection, reference capture, matching, correction, and profile deletion if persistent identification is accepted.
+- Protect local voice-reference data. Keep it outside ordinary cloud note synchronization unless a separate profile-sync design is accepted. Whether references retain audio or embeddings depends on the chosen pipeline and must be explicit in the product.
+- Carry corrected names through transcript playback, generated notes, export, and cloud-synced meeting content. Existing cloud payloads include speaker-label strings but do not yet establish a complete stable-person/profile contract.
+- Validate three to four speakers with similar voices, different distances, unknown guests, long silence, overlapping speech, and the selected languages. Validate the complete two-hour pipeline on the minimum supported physical iPhone and iPad, including Pencil use, heat, battery, memory, screen lock, calls, and recovery.
+
+This is multiple integration components using existing pretrained models, not a proposal to train a foundational voice model from scratch. Device testing must establish false-name rates, unknown-speaker rejection, label delay, identity stability, and the supported-device floor before making product claims.
+
+## Concrete technical routes
+
+### First comparison: native Sortformer enrollment
+
+[FluidAudio's diarizer protocol](https://raw.githubusercontent.com/FluidInference/FluidAudio/main/Sources/FluidAudio/Diarizer/DiarizerProtocol.swift) and [Sortformer implementation](https://raw.githubusercontent.com/FluidInference/FluidAudio/main/Sources/FluidAudio/Diarizer/Sortformer/SortformerDiarizer.swift) expose enrollment using reference audio and a supplied name. Enrollment warms the session cache; live processing then emits timed speaker segments.
+
+This gives a direct candidate for named live labels for up to four unique speakers. It does not supply persistent profile storage or a calibrated name-confidence probability. Enrollment selects a dominant slot, can collide with another named slot, and resets the visible timeline. Perform it before recording, reject name collisions, and handle mid-meeting newcomers through application labeling rather than resetting the running diarizer. Reusing it across meetings would require retaining suitable reference audio and enrolling it again per session.
+
+The [Sortformer guide](https://raw.githubusercontent.com/FluidInference/FluidAudio/main/Documentation/Diarization/Sortformer.md) documents four-speaker capacity, tentative/final segments, memory/precision trade-offs, and overlap/distance limitations. Favorable upstream integration feedback is not a DoodleNote benchmark.
+
+### Second comparison: live separation plus reusable voice embeddings
+
+[EmbeddingExtractor](https://raw.githubusercontent.com/FluidInference/FluidAudio/main/Sources/FluidAudio/Diarizer/Extraction/EmbeddingExtractor.swift) and [SpeakerManager](https://raw.githubusercontent.com/FluidInference/FluidAudio/main/Sources/FluidAudio/Diarizer/Clustering/SpeakerManager.swift) provide components for extracting voice representations and matching against known speakers. [Speaker profile types](https://raw.githubusercontent.com/FluidInference/FluidAudio/main/Sources/FluidAudio/Diarizer/Clustering/SpeakerTypes.swift) can be serialized but do not implement disk persistence or encryption for the app.
+
+Connecting those components to live Sortformer slots, restricting matches to selected participants, calibrating acceptance thresholds, preserving unknown speakers, and maintaining corrected profiles would be custom DoodleNote work. This route may avoid retaining separate reusable voice clips, but embeddings still require protection and can remain incompatible across model versions.
+
+An offline final diarizer may improve the completed transcript, but its speaker IDs must be reconciled with confirmed live names rather than blindly replacing them.
+
+## Selection gate
+
+Compare the simplest enrollment path and the embedding path on actual target devices before committing architecture or scheduling the full implementation. Review exact model artifacts: [Sortformer upstream](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2.1) and [converted model](https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml) currently display different license labels. Resolve the terms or select a compatible alternative before embedding the model in a distributed app.
+
+The local approach does not inherently require a paid per-minute inference service. Engineering, device/language testing, model delivery, and any licensed components still have costs; no budget or delivery estimate has been established.
+
+## Interface localization
+
+Sean requests app screen text in the language chosen during setup. Apple's [string catalogs](https://developer.apple.com/documentation/xcode/localizing-and-varying-text-with-a-string-catalog) support translated strings, plurals, and device variants; localization is standard native-app work.
+
+Include app-owned onboarding, buttons, settings, errors, accessibility labels, and relevant generated UI headings, plus locale-appropriate dates/numbers and layout testing on iPhone/iPad. Translation completeness and language review are real work, but no technical blocker to this scope has been found. System-owned prompts and external provider/account pages remain controlled by their respective surfaces and need separate integration handling.
+
+Sean subsequently accepted English, Danish, Spanish, French, and German as launch languages, including translated interface text. Each recording uses one selected primary spoken language; generated notes default to that language with an optional supported output-language override. Preserve the original-language transcript. Automatic mixed-language switching is deferred pending separate validation.

--- a/apps/mobile-native/docs/discovery/doodlenote_Specification_v1.md
+++ b/apps/mobile-native/docs/discovery/doodlenote_Specification_v1.md
@@ -1,0 +1,160 @@
+# DoodleNote for iPhone and iPad
+
+Updated: 2026-09-06
+
+Status: Approved by Sean on 2026-09-06, including feature decisions through Q48 and operational defaults D1-D6. Implementation may begin. Device, model, integration, and release acceptance gates remain open.
+
+## Purpose and boundary
+
+Build a fresh, independent iPhone and iPad app for professionals to record in-person conversations, take personal notes, and obtain useful transcripts, summaries, and next actions. It must also support standalone notes and imported audio.
+
+Ignore existing iOS code and design choices. Existing desktop/web/shared sources are references for product and cloud compatibility, not a mobile implementation to port. Preserve the current repository's unrelated work.
+
+Core local functionality is free and does not require a DoodleNote account. The existing paid cloud-sync service is optional. External AI is optional, explicitly enabled, uses the user's own provider credentials, and has separate provider costs. There is no approved new managed-inference subscription or pricing change.
+
+## Accepted first-release capabilities
+
+| Area | Required behavior |
+| --- | --- |
+| Recording | User-started microphone capture, audio-file import, local playback, and durable audio preservation. In-person conversations and meeting audio from another device are in scope. |
+| Live transcript | Accurate text while recording, with timestamps linked to local audio. Work offline on supported devices after required models are ready. |
+| Speakers | Pursue automatic separation/identification and live labels for three to four speakers, subject to demonstrated feasibility. Preserve clear unknown/uncertain attribution. Calendar invitees are suggestions, not voice identity. |
+| Notes | Standalone notes plus typed personal notes during recording. Keep personal notes distinct from generated content. |
+| iPad | Dedicated notes/transcript layout, keyboard support, editable Pencil handwriting/sketches, and handwriting converted to typed text. |
+| Summaries | Offline generation in supported languages on supported devices after model readiness. Include supported key points, decisions, and checklist actions. Never invent owners, dates, or commitments. |
+| Formats | General meeting; client discovery; project/status update; one-to-one; interview; training/workshop. |
+| Editing | Summaries are editable. Regeneration preserves the edited version and creates a new generated version for review before replacement. |
+| Meeting questions | Answer using the current meeting's transcript and typed notes, with supporting-passage links. Work offline over available content with required models ready. |
+| Homepage questions | Search the full history of eligible recordings/transcripts and notes in the selected library/workspace, with an explicit scope selector for other authorized libraries. Exclude Trash and expose unavailable/unindexed content. Work offline when content and models are ready. |
+| Organization | Recent-first library, optional folders, and search across typed notes, summaries, and transcripts. |
+| Calendars | Direct, read-only Microsoft 365/Office 365 and Google Calendar integration. Multiple accounts per provider, selected calendars, upcoming events, reminders, meeting links, event-linked notes, and optional invitee-name suggestions. |
+| Cloud sync | Explicitly select a library/workspace for automatic note sync and retain a separate local-only library. Include notes, transcripts, editable ink, readable previews, Trash state, and preserved conflicts/summary versions. |
+| Audio ownership | Audio remains on the recording/importing device until removed by the user. Notes sync does not enable playback of that audio on other devices. |
+| Export | PDF and Markdown sharing, plus a complete export/restore archive through Files that preserves notes, transcripts, ink, and local audio. |
+| Recovery | Recoverable Trash for 30 days, synchronized Trash state for synced notes, and explicit confirmation for immediate permanent deletion. |
+
+The accepted two-hour recording/import target is an initial validation baseline, not a hard recording cutoff or a measured performance claim. Longer content must never be silently truncated.
+
+## Languages
+
+Launch with English, Danish, Spanish, French, and German, including DoodleNote interface text. Language selection during setup must affect onboarding, normal screens, buttons, settings, errors, and other app-owned text. Test accessibility text, dates/numbers, plurals, and iPhone/iPad layouts.
+
+Each recording has one selected primary spoken language. Its transcript preserves that language. Generated notes default to the selected spoken language, with an optional supported output-language override. Automatic switching between spoken languages in one recording is outside the first-release commitment.
+
+Model availability and language quality must be checked independently from interface translation. A translated interface must not imply that an unavailable speech model is ready. Keep already captured data usable when assets are missing or processing fails, and offer local retry or the user's explicitly configured alternative where applicable.
+
+## Main user flows
+
+```mermaid
+flowchart TD
+    S[Setup: language and local model readiness] --> H[Home: selected library and upcoming meetings]
+    H --> N[Write a standalone note]
+    H --> R[Start recording or import audio]
+    H --> C[Open a calendar event]
+    C --> R
+    R --> L[Live transcript, speaker labels and personal notes]
+    L --> F[Finalize transcript and attribution]
+    F --> G[Generate a meeting-type summary]
+    G --> M[Review, edit, ask questions and export]
+    H --> Q[Ask across the selected library]
+    M --> Y[Optional notes sync]
+    N --> Y
+```
+
+- Setup does not require DoodleNote account creation. Make model download/readiness and optional calendar/sync connections understandable. Do not block plain note-taking because a model is unavailable.
+- Recording shows a clear recording state, live text, personal notes, and speaker labels when supported. Preserve audio independently of AI progress. Screen lock and app switching must be tested; interruptions require visible state and a clear resume path.
+- iPad supports side-by-side note/transcript work and Pencil input. iPhone must provide usable access to the same meeting content without a compressed desktop layout.
+- Finalization may improve transcription and attribution after recording. Corrections must not silently destroy personal edits or apply a guessed identity to another speaker.
+- Source links from summaries/questions lead to the relevant transcript or typed-note passage. Playback requires audio on the current device; a synced transcript must clearly distinguish missing local audio.
+
+These flows identify functional surfaces, not a finalized visual layout. Exact navigation and interaction design must preserve this capability inventory.
+
+## Questions, retrieval, and evidence
+
+Search all eligible history in the selected scope, not a fixed newest-record window. Bounded model context is acceptable, but retrieval must be able to find relevant old transcript passages and typed-note details. A question about complete counts or lists must not receive an apparently exhaustive answer derived only from a few retrieved excerpts.
+
+Show the selected scope and any processing/download gaps. Do not silently mix unrelated workspaces, use Trash, or include content from a disconnected/unavailable account. Index updates must follow note edits, speaker corrections, version selection, and Trash changes.
+
+Ground answers in transcript and typed notes. Generated summaries may assist retrieval but must not substitute for checking original evidence. Distinguish user-written notes from recorded speech when they conflict. Preserve uncertainty and explain when the available evidence does not answer the question.
+
+Saved ink is visible and exportable, but automatic ink recognition, ink search, and AI interpretation of sketches/handwriting are excluded. Text entered through handwriting-to-text input is ordinary typed text and can participate.
+
+## Calendar behavior
+
+Connect Microsoft/Google accounts independently of DoodleNote cloud sync. Let the user choose accounts and calendars, see upcoming events and cached offline information, follow meeting links, and create/reopen a titled event-linked note. Retain user-created notes when an event changes or disappears.
+
+The desktop 14-day upcoming view is the initial parity reference. Fetch complete results for the chosen date range, handle recurring occurrences, and avoid duplicate notes for the same occurrence within its library. Preserve user-edited note content when calendar metadata changes.
+
+Use opt-in reminders leading to meeting actions and explicitly user-started recording. Do not depend on exact background polling or automatic microphone activation at a scheduled time. A Join action opens the provider's meeting link; it does not capture another app's call audio.
+
+Invitees can be suggested participants. Names must still be associated with confirmed voices. Read-only integration does not create/edit calendar events or send invitations. Multiple account support does not automatically promise enterprise delegated-mailbox access; validate the calendars available under granted read permissions, and surface any unsupported calendar type accurately.
+
+## Sync and compatibility
+
+Mobile must connect to the existing cloud service. Required ink, conflict, recovery, and version behavior needs compatible extensions; it cannot be fulfilled by assuming the current payload already supports it.
+
+Maintain a clear local-only library and explicit synced-library/workspace ownership. Preserve both conflicting versions for reconciliation. Do not silently overwrite user work, upload a local-only note, move content between accounts, or resurrect a deleted record because an older device reconnects.
+
+Protect ink assets; the existing image route's public-asset behavior is not an acceptable assumption for private handwritten notes. Validate iPad editing, iPhone preview, desktop visibility, old-client behavior, sync authentication, and entitlement handling separately.
+
+Existing authenticated provider/account configuration and production deployment are not changed by approving this product specification. Compatibility work must have a reviewed migration/rollback path before production changes.
+
+## Accepted operational defaults
+
+Sean accepted these defaults with the final specification on 2026-09-06.
+
+| ID | Accepted default |
+| --- | --- |
+| D1: Remembered speakers | Include optional saved voice references on the device. Recording works without enrollment. Users confirm names, choose whether to remember a voice, and can remove profiles. Known participants may be selected before later meetings; unknown/ambiguous speech stays unassigned. Do not upload voice profiles through notes sync or update a profile from uncertain speech. |
+| D2: Backup/restore | Use a password-protected encrypted archive for full-fidelity backup. Include notes, transcripts, ink, local audio, and retained summary versions; exclude provider/API credentials and saved voice profiles initially. Restore into a local-only library, preserve duplicate/conflicting versions, and require deliberate sync selection afterward. PDF includes ink; Markdown export includes necessary ink-image assets rather than silently losing it. |
+| D3: Account and deletion behavior | A sync lapse or disconnect must not erase local notes or remove free local capabilities. Explicit sign-out isolates account-bound cached content from other accounts until the same account reauthenticates; local-only content remains available. Calendar disconnect clears that connection/cache while preserving created notes. Trash keeps associated local audio recoverable on its original device during the retention period; removing audio separately preserves text/ink. Process expiry when the app/service can run; do not claim powered-off devices or exported backups were erased. |
+| D4: Optional external AI | Start with OpenAI, Anthropic, Groq, and OpenRouter for optional text summaries/Q&A, corresponding to current desktop cloud-provider categories. Keep initial transcription/speaker processing on-device. Store keys locally in protected credential storage, outside sync/backups. Clearly disclose and explicitly enable transmission to the chosen provider; never silently fall back. Cloud audio transcription and network-hosted Ollama are outside the initial integration scope. |
+| D5: Distribution | Use a device-tested TestFlight beta before App Store release. Plan a free install with existing Sync-account sign-in initially. Do not add purchasing or external purchase calls to action until the App Review route is verified for this product. No new subscription price is proposed. Provider OAuth production configuration and verification are release dependencies, not assumed completed work. |
+| D6: Implementation approach | Start a fresh native SwiftUI implementation in an isolated editing workspace. First build an integrated device feasibility slice, then choose the engine/model/device matrix using evidence. Reuse cloud compatibility knowledge without importing the old iOS implementation. Do not promise older-device coverage from an OS-version check alone or silently drop accepted features if the first candidate fails. |
+
+## Evidence-dependent decisions after the prototype
+
+- Exact speech, speaker, local-generation, and retrieval engines; pinned model artifacts and distribution rights.
+- Minimum supported OS and physical devices for simultaneous capture, live transcription, speaker labels, Pencil use, and offline processing in every launch language.
+- Calibrated transcript/speaker quality and latency targets, model-download/storage requirements, battery/heat/memory results, and long-recording behavior. These need measured baselines and agreed acceptance thresholds, not invented performance claims.
+- Native OAuth client configuration, exact read scopes, provider verification, account/permission edge cases, and App Review acceptance of the actual sync/AI experience.
+- Concrete schema/versioning, private ink storage, deletion/conflict protocol, and backward-compatible desktop/web changes.
+
+These implementation investigations are authorized by the confirmed shared understanding. They do not turn unmet user requirements into optional features automatically.
+
+## Validation and delivery plan
+
+| Stage | Required evidence |
+| --- | --- |
+| 1. Native feasibility slice | Run local recording, live multilingual text, three-to-four-speaker labeling and Pencil editing together on physical iPhone/iPad. Preserve the complete two-hour session. Compare model candidates and document artifact rights. Use test material whose use is authorized. |
+| 2. Offline intelligence | Evaluate summaries and meeting/library questions for each launch language, including different supported summary output languages. Show source links, unknown answers, old-record retrieval, and scope isolation. |
+| 3. Recovery and readiness | Test missing models, airplane mode, slow/failed processing, low storage, screen lock, app switching, calls, restart, interrupted import, and retry. Check complete audio and editable notes survive. |
+| 4. Calendars | Exercise multiple Microsoft/Google accounts, selected calendars, pagination, recurring/rescheduled/canceled events, refresh, cached offline display, reminders, attendee suggestions, reauthentication, and disconnect without deleting notes. |
+| 5. Cloud compatibility | Prove note/transcript/ink sync, readable desktop/iPhone previews, conflicts, preserved versions, Trash/offline deletion behavior, account isolation, and expiry/disconnect handling against a safe test environment. |
+| 6. Export and usability | Round-trip the complete archive including audio/ink, reject incorrect passwords/corrupt archives safely, preserve restore conflicts, and check PDF/Markdown completeness. Review all five UI languages, accessibility, keyboard and Pencil behavior on both device sizes. |
+| 7. Reviewed release | Produce supported-device/model matrix, known limits, test evidence, provider/App Store readiness, and any required migration/rollback plan. TestFlight/public release and production changes remain separate from source completion. |
+
+A failed device test must produce an evidenced recommendation and a decision about engine, hardware, or scope. It must not be described as passing because a library's documentation or a simulator build succeeded.
+
+## Explicit first-release exclusions
+
+- Video import; same-device phone/Teams/Zoom/other-app call-audio capture; unattended calendar-triggered recording.
+- Automatic mixed-language switching within one recording.
+- Automatic understanding or search of preserved ink.
+- Cloud recording-audio sync and cloud voice-profile sync.
+- Public sharing links, real-time collaborative editing, calendar event editing/invitations, and external task assignment/reminder integrations.
+
+A custom summary-template builder, specialist enterprise delegated-calendar behavior, remote local-model servers, and additional integrations are not launch commitments. Their absence must not remove the accepted built-in formats or ordinary connected-calendar support.
+
+## Decision records and evidence
+
+- [Interview and decision history](./doodlenote_Discovery_v1.md)
+- [Concise product brief](./doodlenote_Product-Brief_v1.md)
+- [Domain glossary](./CONTEXT.md)
+- [Read-only feasibility research](./doodlenote_Feasibility_v1.md), gathered 2026-09-05; revisit drifting facts before implementation or release.
+- [Speaker identification proposal and diagram](./doodlenote_Speaker-Identification_v1.md)
+- [Independent product and existing sync](./docs/adr/0001-independent-mobile-with-existing-sync.md)
+- [Explicit external AI and local recording audio](./docs/adr/0002-explicit-external-ai-and-local-audio.md)
+- [Ink and conflict preservation](./docs/adr/0003-extend-sync-for-ink-and-conflict-preservation.md)
+
+Sean confirmed shared understanding of this scope and defaults on 2026-09-06, authorizing the implementation phase. This document does not claim production, App Store, OAuth, model-license, or device-performance validation.

--- a/apps/mobile-native/docs/speaker-evaluation.md
+++ b/apps/mobile-native/docs/speaker-evaluation.md
@@ -1,0 +1,30 @@
+# Streaming speaker integration
+
+This is an experimental native integration, not an accuracy claim or completed speaker-identification feature.
+
+## Reproducible inputs
+
+- FluidAudio source: revision `5c19d5e12320e22bbfb7a1877b089d2665a69add` of https://github.com/FluidInference/FluidAudio, pinned in `project.yml`.
+- Core ML artifact: `Sortformer_v2.1.mlpackage` at revision `ae9a27ab45dc0aa3abede7d2d6bad2b7a69aa6d1` of https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml.
+- The bundled manifest lists the exact four package files, sizes, and SHA-256 digests. Total download is 240,139,774 bytes. Accidental nested packages present upstream are excluded.
+- Runtime configuration is `fastV2_1`; embedded model metadata must match chunk length/context, FIFO, and speaker cache configuration. Every model file is rehashed before use.
+
+The download is explicit, cancellable, staged, and validated before installation. Audio is never uploaded by this integration. An independent bounded stream feeds an actor that executes Core ML. Failed or slow speaker processing reports a visible error and leaves the source recording and Apple transcription running. A finalization timeout requests cancellation, but cannot forcibly interrupt an in-flight Core ML call.
+
+## Labels and names
+
+Four anonymous speaker slots are supported per session. Live labels can change as the timeline finalizes. Manual names survive revised turns within a session and are not automatically applied to a reused slot in another session. Persisted speaker intervals can be joined to transcript passages without modifying the transcription itself.
+
+The passage join unions intervals per speaker. Two speakers each covering at least 10% of a passage yield “Multiple speakers”; a single speaker requires at least 65% coverage to receive a label. Otherwise the passage stays unassigned. These are uncalibrated display heuristics, not measured identity confidence. Word-level splitting, overlapping-speech quality, saved voice references, and automatic recognition of known people remain open work.
+
+## Evidence and remaining gates
+
+The exact downloaded model passed size and SHA-256 checks, compiled, loaded with matching embedded configuration, and processed two seconds of synthetic silence through the actual engine in a simulator test. This only verifies execution and frame progression. It does not establish attribution, speech accuracy, latency, memory, battery, or thermal behavior with real meetings.
+
+The opt-in test `SpeakerTests/testPinnedModelProcessesSyntheticAudioWhenProvided` reads `DOODLENOTE_SPEAKER_MODEL` in the test-runner environment. Point it at a complete verified `.mlpackage` directory. Normal CI skips that one test and does not download the model. Unit tests separately exercise label rules, session-scoped naming, hash rejection, and preservation of recorded audio when a bounded speaker consumer overflows.
+
+## Licensing before distribution
+
+FluidAudio's Apache 2.0 license is included in app resources. The converted model card declares CC BY 4.0, while the NVIDIA upstream model declares the NVIDIA Open Model License. Source and license links are recorded in `Resources/ThirdParty/Model-NOTICE.txt`. The relationship between those notices and redistribution obligations must be reviewed before shipping the downloadable artifact. Inventory and include applicable notices for the complete dependency graph before distribution. No app release or model republishing is part of this checkpoint.
+
+Sources: [FluidAudio](https://github.com/FluidInference/FluidAudio), [converted model](https://huggingface.co/FluidInference/diar-streaming-sortformer-coreml), [NVIDIA terms](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/).

--- a/apps/mobile-native/docs/validation.md
+++ b/apps/mobile-native/docs/validation.md
@@ -1,0 +1,33 @@
+# Native foundation validation
+
+Date: 2026-09-06. Source base: `d624cfb` on a separate `codex/mobile-native-foundation` branch. All implementation changes are confined to `apps/mobile-native`. Existing iOS source was not inspected or reused.
+
+## Completed locally
+
+| Check | Evidence |
+| --- | --- |
+| Fresh native build/launch | Built and launched on iPhone 17 Pro and iPad Pro 11-inch (M5) simulators, iOS 26.5, using Xcode 26.6 (17F113). |
+| Unit and UI suite | Seven tests passed with zero failures/skips on each simulator. Unit cases use synthetic PCM, not microphone audio. |
+| Note persistence | Typed text, language, ink data, and transcript survive disk round trips. UI creates/edits a note, terminates the app, and checks the text after relaunch. |
+| Recovery metadata | Previously recording notes become interrupted at startup, retaining associated audio. Corrupt/future-schema files remain unchanged while readable notes load. |
+| Speech text updates | Overlapping provisional results are replaced; a repeated draft cannot overwrite finalized text for the same interval. No inferred speaker name is assigned. |
+| Saved audio | A 12-second synthetic 16 kHz stream preserves all 192,000 source frames across three closed CAF chunks. Appends after finish are rejected. |
+| Speech conversion | A two-second synthetic 48 kHz stereo stream preserves 96,000 source frames and produces a 16 kHz mono speech stream. The test exposed a converter tail left buffered at stop; an explicit end-of-stream drain fixed it. |
+| Built configuration | Inspected the built Info.plist: background audio is an array containing `audio`, version/build are present, and multiple scenes are disabled. |
+| iPad layout | Inspected the XCTest screenshot showing separate ink and transcript panes and the PencilKit palette. Recording controls were moved above the editor to avoid the floating palette. |
+
+Final full-suite result bundles on the local build host:
+
+- iPad: `test_sim_2026-09-06T17-59-54-221Z_pid58085_ddd87a48.xcresult`
+- iPhone: `test_sim_2026-09-06T18-00-56-455Z_pid58085_434c836a.xcresult`
+
+Bundles are in the XcodeBuildMCP `Doodle-Note-194c8b9beb19/result-bundles` directory. The final iPad palette-layout check also passed: `test_sim_2026-09-06T18-02-27-886Z_pid58085_11916b15.xcresult`. These are local evidence, not repository CI artifacts. The existing repository CI is not a native-mobile test gate; a dedicated native workflow remains to be added.
+
+## Not established
+
+- No physical device installation, microphone recording, human voice enrollment, or speech model download was performed during these checks. The simulator reports speech unavailable and keeps note editing usable.
+- No real speech accuracy, diarization, saved speaker matching, language-quality, live latency, thermal, battery, or two-hour measurement exists yet.
+- Pencil hardware behavior, nonempty drawing round-trip interaction, Scribble, long-document performance, interruption/route changes, low-storage handling, and crash-tail audio repair need device tests and further implementation.
+- No cloud/schema/OAuth/App Store configuration was changed. Calendar, sync, offline generation/Q&A, import/export/Trash, and translated UI remain accepted release requirements, not completed features.
+
+This evidence supports review of the foundation only. It does not satisfy stage 1 of the full specification or authorize a release.

--- a/apps/mobile-native/docs/validation.md
+++ b/apps/mobile-native/docs/validation.md
@@ -1,33 +1,36 @@
 # Native foundation validation
 
-Date: 2026-09-06. Source base: `d624cfb` on a separate `codex/mobile-native-foundation` branch. All implementation changes are confined to `apps/mobile-native`. Existing iOS source was not inspected or reused.
+Date: 2026-09-06. Branch: `codex/mobile-native-foundation`; this continuation builds on foundation commit `df4cec8`. Changes are confined to `apps/mobile-native` and its dedicated CI workflow. Existing iOS source was not inspected or reused.
 
 ## Completed locally
 
 | Check | Evidence |
 | --- | --- |
 | Fresh native build/launch | Built and launched on iPhone 17 Pro and iPad Pro 11-inch (M5) simulators, iOS 26.5, using Xcode 26.6 (17F113). |
-| Unit and UI suite | Seven tests passed with zero failures/skips on each simulator. Unit cases use synthetic PCM, not microphone audio. |
-| Note persistence | Typed text, language, ink data, and transcript survive disk round trips. UI creates/edits a note, terminates the app, and checks the text after relaunch. |
+| Unit and UI suite | iPhone: 18 tests passed, zero failures/skips, including opt-in Core ML inference. iPad: 17 regular tests passed plus the inference test passed separately. Unit cases use synthetic PCM, not microphone audio. |
+| Note persistence | Typed text, language, a nonempty PencilKit drawing, transcript, and speaker annotations survive disk round trips. UI creates/edits a note, terminates the app, and checks the text after relaunch. |
 | Recovery metadata | Previously recording notes become interrupted at startup, retaining associated audio. Corrupt/future-schema files remain unchanged while readable notes load. |
 | Speech text updates | Overlapping provisional results are replaced; a repeated draft cannot overwrite finalized text for the same interval. No inferred speaker name is assigned. |
 | Saved audio | A 12-second synthetic 16 kHz stream preserves all 192,000 source frames across three closed CAF chunks. Appends after finish are rejected. |
 | Speech conversion | A two-second synthetic 48 kHz stereo stream preserves 96,000 source frames and produces a 16 kHz mono speech stream. The test exposed a converter tail left buffered at stop; an explicit end-of-stream drain fixed it. |
+| Open audio recovery | A real nonzero stereo PCM fixture with an unknown data length and torn final frame recovers into a validated copy, preserving the original byte-for-byte and avoiding duplicate playback on repeated startup. Malformed input is reported and preserved. |
+| Speaker pipeline | Exact pinned model compiled and processed synthetic silence with frame progression. Four-slot display, conservative overlap/coverage rules, session-scoped name corrections, hash-corruption rejection, and audio preservation on speaker queue overflow passed. |
 | Built configuration | Inspected the built Info.plist: background audio is an array containing `audio`, version/build are present, and multiple scenes are disabled. |
 | iPad layout | Inspected the XCTest screenshot showing separate ink and transcript panes and the PencilKit palette. Recording controls were moved above the editor to avoid the floating palette. |
 
 Final full-suite result bundles on the local build host:
 
-- iPad: `test_sim_2026-09-06T17-59-54-221Z_pid58085_ddd87a48.xcresult`
-- iPhone: `test_sim_2026-09-06T18-00-56-455Z_pid58085_434c836a.xcresult`
+- iPad regular suite: `test_sim_2026-09-06T18-36-37-252Z_pid65562_e294bfd7.xcresult`
+- iPad actual model: `test_sim_2026-09-06T18-40-36-286Z_pid65562_31f423df.xcresult`
+- iPhone complete suite after final error-display changes: `test_sim_2026-09-06T18-41-11-482Z_pid65562_e7a3554a.xcresult`
 
-Bundles are in the XcodeBuildMCP `Doodle-Note-194c8b9beb19/result-bundles` directory. The final iPad palette-layout check also passed: `test_sim_2026-09-06T18-02-27-886Z_pid58085_11916b15.xcresult`. These are local evidence, not repository CI artifacts. The existing repository CI is not a native-mobile test gate; a dedicated native workflow remains to be added.
+Bundles are in the XcodeBuildMCP `Doodle-Note-194c8b9beb19/result-bundles` directory. The final iPad palette-layout check also passed: `test_sim_2026-09-06T18-02-27-886Z_pid58085_11916b15.xcresult`. These are local evidence, not repository CI artifacts. A dedicated `Native mobile` workflow now generates the project and runs simulator unit/UI tests on changes to this app. Its normal run skips only the opt-in model inference test. Remote CI status must be checked on the PR; local evidence does not imply remote success.
 
 ## Not established
 
 - No physical device installation, microphone recording, human voice enrollment, or speech model download was performed during these checks. The simulator reports speech unavailable and keeps note editing usable.
 - No real speech accuracy, diarization, saved speaker matching, language-quality, live latency, thermal, battery, or two-hour measurement exists yet.
-- Pencil hardware behavior, nonempty drawing round-trip interaction, Scribble, long-document performance, interruption/route changes, low-storage handling, and crash-tail audio repair need device tests and further implementation.
+- Pencil hardware behavior, Scribble, long-document performance, interruption/route changes, low-storage handling, and real process-kill/power-loss recovery need device tests. Synthetic recovery cannot recover unwritten audio or establish power-loss durability.
 - No cloud/schema/OAuth/App Store configuration was changed. Calendar, sync, offline generation/Q&A, import/export/Trash, and translated UI remain accepted release requirements, not completed features.
 
 This evidence supports review of the foundation only. It does not satisfy stage 1 of the full specification or authorize a release.

--- a/apps/mobile-native/docs/validation.md
+++ b/apps/mobile-native/docs/validation.md
@@ -1,28 +1,30 @@
 # Native foundation validation
 
-Date: 2026-09-06. Branch: `codex/mobile-native-foundation`; this continuation builds on foundation commit `df4cec8`. Changes are confined to `apps/mobile-native` and its dedicated CI workflow. Existing iOS source was not inspected or reused.
+Date: 2026-09-06. Branch: `codex/mobile-native-foundation`; this continuation builds on foundation commit `df4cec8`. Changes are confined to `apps/mobile-native`, its dedicated CI workflow, and root contributor pointers to the fresh app. Existing iOS source was not inspected or reused.
 
 ## Completed locally
 
 | Check | Evidence |
 | --- | --- |
 | Fresh native build/launch | Built and launched on iPhone 17 Pro and iPad Pro 11-inch (M5) simulators, iOS 26.5, using Xcode 26.6 (17F113). |
-| Unit and UI suite | iPhone: 18 tests passed, zero failures/skips, including opt-in Core ML inference. iPad: 17 regular tests passed plus the inference test passed separately. Unit cases use synthetic PCM, not microphone audio. |
+| Unit and UI suite | iPhone and iPad: each passed 23 tests, zero failures/skips, including opt-in Core ML inference (21 unit tests and two UI tests). Unit cases use synthetic PCM, not microphone audio. |
 | Note persistence | Typed text, language, a nonempty PencilKit drawing, transcript, and speaker annotations survive disk round trips. UI creates/edits a note, terminates the app, and checks the text after relaunch. |
-| Recovery metadata | Previously recording notes become interrupted at startup, retaining associated audio. Corrupt/future-schema files remain unchanged while readable notes load. |
+| Recovery metadata | Previously recording notes become interrupted at startup, retaining associated audio. Corrupt/future-schema files remain unchanged while readable notes load. An injected recovery metadata write failure leaves the original bytes unchanged and still exposes the readable note, ink and transcript. |
 | Speech text updates | Overlapping provisional results are replaced; a repeated draft cannot overwrite finalized text for the same interval. No inferred speaker name is assigned. |
 | Saved audio | A 12-second synthetic 16 kHz stream preserves all 192,000 source frames across three closed CAF chunks. Appends after finish are rejected. |
 | Speech conversion | A two-second synthetic 48 kHz stereo stream preserves 96,000 source frames and produces a 16 kHz mono speech stream. The test exposed a converter tail left buffered at stop; an explicit end-of-stream drain fixed it. |
 | Open audio recovery | A real nonzero stereo PCM fixture with an unknown data length and torn final frame recovers into a validated copy, preserving the original byte-for-byte and avoiding duplicate playback on repeated startup. Malformed input is reported and preserved. |
 | Speaker pipeline | Exact pinned model compiled and processed synthetic silence with frame progression. Four-slot display, conservative overlap/coverage rules, session-scoped name corrections, hash-corruption rejection, and audio preservation on speaker queue overflow passed. |
+| Recording preparation | Suspended permission and language-probe tests verify playback is excluded throughout preparation and navigation cannot replace the recording language. |
+| Speaker conversion | Persistent 16 kHz conversion preserves the source clock and waveform across 44.1/48 kHz input packet sizes. Independent left/right channel tests verify downmix includes both channels. End-of-stream filter padding does not extend the recording clock. |
 | Built configuration | Inspected the built Info.plist: background audio is an array containing `audio`, version/build are present, and multiple scenes are disabled. |
 | iPad layout | Inspected the XCTest screenshot showing separate ink and transcript panes and the PencilKit palette. Recording controls were moved above the editor to avoid the floating palette. |
 
 Final full-suite result bundles on the local build host:
 
-- iPad regular suite: `test_sim_2026-09-06T18-36-37-252Z_pid65562_e294bfd7.xcresult`
-- iPad actual model: `test_sim_2026-09-06T18-40-36-286Z_pid65562_31f423df.xcresult`
-- iPhone complete suite after final error-display changes: `test_sim_2026-09-06T18-41-11-482Z_pid65562_e7a3554a.xcresult`
+- iPad complete suite: `test_sim_2026-09-06T19-15-43-127Z_pid65562_e8c8baae.xcresult`
+- iPhone complete suite: `test_sim_2026-09-06T19-19-09-519Z_pid65562_321678ba.xcresult`
+- Stereo downmix regression first failed with silent right-channel output, then passed after explicit downmix; targeted green run: `test_sim_2026-09-06T19-15-34-747Z_pid65562_d0bd7c94.xcresult`
 
 Bundles are in the XcodeBuildMCP `Doodle-Note-194c8b9beb19/result-bundles` directory. The final iPad palette-layout check also passed: `test_sim_2026-09-06T18-02-27-886Z_pid58085_11916b15.xcresult`. These are local evidence, not repository CI artifacts. A dedicated `Native mobile` workflow now generates the project and runs simulator unit/UI tests on changes to this app. Its normal run skips only the opt-in model inference test. Remote CI status must be checked on the PR; local evidence does not imply remote success.
 
@@ -34,3 +36,17 @@ Bundles are in the XcodeBuildMCP `Doodle-Note-194c8b9beb19/result-bundles` direc
 - No cloud/schema/OAuth/App Store configuration was changed. Calendar, sync, offline generation/Q&A, import/export/Trash, and translated UI remain accepted release requirements, not completed features.
 
 This evidence supports review of the foundation only. It does not satisfy stage 1 of the full specification or authorize a release.
+
+## ONY-240 review handoff
+
+Three read-only subagents reviewed capture/recovery, storage/speaker handling, and all roadmap dependencies. Findings were addressed on the existing branch and PR #124. Focused second passes reported no remaining blocking findings; this is agent review, not GitHub human approval.
+
+Reproduce the suite with the README XcodeGen/xcodebuild commands. For the local model smoke test, pass `TEST_RUNNER_DOODLENOTE_SPEAKER_MODEL=/absolute/path/Sortformer_v2.1.mlpackage` to xcodebuild after obtaining and verifying the manifest-pinned model. Model execution uses synthetic silence and proves neither recognition nor attribution accuracy.
+
+Check this:
+1. Generate/open `DoodleNoteNative.xcodeproj`, select its scheme and an iOS 26 simulator. Create a note, type text, draw nonempty ink, return to the library, and reopen it. Expect both edits retained and usable compact/regular layouts.
+2. With speech unavailable or no model installed, open a note and use its editor. Expect an explicit readiness explanation and fully usable local text/ink editing.
+3. On supported physical hardware with microphone permission and saved audio, start recording and immediately navigate between notes. Expect playback disabled during preparation/capture, the chosen recording language retained, and recording controls visible above the Pencil palette. Physical hardware is unavailable for this check today.
+4. Review the synthetic failure tests and preservation assertions for recovery metadata write failure, damaged audio originals and speaker queue overflow. Expect readable notes and saved source audio to remain available; a speaker failure must not claim the recording stopped.
+
+Remaining gates: required human review/product QA and explicit merge approval. The disconnected external SSD contains earlier uncommitted recovery work; reconcile it non-destructively when available. The internal fixes do not claim that comparison occurred. Retain this workspace because the untracked roadmap and unavailable external work still need preservation. ONY-241 and ONY-242 require ONY-240 to land before implementation; the other feature issues inherit those dependency gates.

--- a/apps/mobile-native/project.yml
+++ b/apps/mobile-native/project.yml
@@ -11,11 +11,17 @@ settings:
     TARGETED_DEVICE_FAMILY: "1,2"
     CODE_SIGN_STYLE: Automatic
     GENERATE_INFOPLIST_FILE: YES
+packages:
+  FluidAudio:
+    url: https://github.com/FluidInference/FluidAudio.git
+    revision: 5c19d5e12320e22bbfb7a1877b089d2665a69add
 targets:
   DoodleNoteNative:
     type: application
     platform: iOS
     sources: [Sources]
+    dependencies:
+      - package: FluidAudio
     info:
       path: Config/Info.plist
       properties:

--- a/apps/mobile-native/project.yml
+++ b/apps/mobile-native/project.yml
@@ -1,0 +1,63 @@
+name: DoodleNoteNative
+options:
+  bundleIdPrefix: ai.doodlenote
+  deploymentTarget:
+    iOS: "26.0"
+  developmentLanguage: en
+  createIntermediateGroups: true
+settings:
+  base:
+    SWIFT_VERSION: "6.0"
+    TARGETED_DEVICE_FAMILY: "1,2"
+    CODE_SIGN_STYLE: Automatic
+    GENERATE_INFOPLIST_FILE: YES
+targets:
+  DoodleNoteNative:
+    type: application
+    platform: iOS
+    sources: [Sources]
+    info:
+      path: Config/Info.plist
+      properties:
+        CFBundleDisplayName: DoodleNote
+        CFBundleShortVersionString: "0.1.0"
+        CFBundleVersion: "1"
+        NSMicrophoneUsageDescription: Record conversations you choose to capture and save the audio on this device.
+        NSSpeechRecognitionUsageDescription: Create a transcript of your recording using speech models on this device.
+        UIBackgroundModes: [audio]
+        UIApplicationSceneManifest:
+          UIApplicationSupportsMultipleScenes: false
+          UISceneConfigurations: {}
+        UILaunchScreen: {}
+        UISupportedInterfaceOrientations~iphone:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+        UISupportedInterfaceOrientations~ipad:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: ai.doodlenote.native.prototype
+        GENERATE_INFOPLIST_FILE: NO
+  DoodleNoteNativeTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources: [Tests]
+    dependencies:
+      - target: DoodleNoteNative
+  DoodleNoteNativeUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    sources: [UITests]
+    dependencies:
+      - target: DoodleNoteNative
+schemes:
+  DoodleNoteNative:
+    build:
+      targets:
+        DoodleNoteNative: all
+    test:
+      targets: [DoodleNoteNativeTests, DoodleNoteNativeUITests]


### PR DESCRIPTION
## Linear Issue
- [ONY-240: Adopt the fresh native mobile foundation and PR #124](https://linear.app/onyxdevlabs/issue/ONY-240/adopt-the-fresh-native-mobile-foundation-and-pr-124)

## Outcome
A fresh standalone SwiftUI iPhone/iPad foundation supports local typed/Pencil notes, chunked recording and playback, device-available Apple live speech, interrupted PCM recovery, and experimental on-device speaker labels. This adopts the existing branch and PR. It is a foundation checkpoint, not the complete v1 release.

## What Changed
- Added the independent `apps/mobile-native` app, reproducible XcodeGen setup, dedicated simulator CI, approved discovery specification, and updated root contributor pointers. Historical iOS source was not reused.
- Preserves journaled audio originals and repairs supported interrupted PCM into validated copies. Readable notes remain visible when writing recovered metadata fails.
- Reserves recording preparation against competing playback and passive language checks.
- Pins and verifies optional FluidAudio/Sortformer downloads. Speaker processing uses a separate bounded queue and persistent mono conversion; queue failure preserves saved audio and transcription. Names are manually confirmed and session scoped.

## Bug Evidence / Root Cause
- Recovery metadata writes previously shared the decode failure path, hiding readable notes on write failure. An injected out-of-space regression now verifies visibility and original-byte preservation.
- Playback remained available before preparation assigned a note ID, and navigation could supersede the pending speech locale. Suspended permission/probe tests cover both races.
- Per-packet speaker conversion lost resampler continuity. A persistent converter now produces packet-size-independent timing/waveforms at 44.1/48 kHz. A right-channel-only fixture failed with silence until explicit downmix was enabled. Tail padding is excluded from the recording clock.

## Acceptance Criteria Evidence
- [x] Existing branch and PR retained as the sole foundation lane.
- [x] Full diff and focused capture/storage/speaker reviews completed; findings addressed on this branch. XcodeGen project regenerated, simulator unit/UI suites passed.
- [x] Tests verify nonempty PencilKit/text/transcript/speaker-name persistence, audio frame preservation, and recovery original preservation. UI note text survives process termination/relaunch.
- [x] Device accuracy, remembered voices, calendars, sync, AI, translations and distribution remain explicitly unfinished.
- [x] Root contributor pointers now target the fresh app.
- [ ] Human product QA and GitHub review remain required. The checkpoint is not Done until approved and merged.
- [ ] External-SSD recovery edits cannot be compared while the drive is disconnected. Preserve both checkouts and reconcile when available; no claim that this comparison occurred.

## Verification
- `xcodegen generate --spec apps/mobile-native/project.yml` passed.
- `git diff --check` passed.
- XcodeBuildMCP `test_sim` with `CODE_SIGNING_ALLOWED=NO` and the verified local model path: **23 passed, zero failures/skips on each iPhone and iPad simulator** (21 unit tests, two UI tests). Xcode 26.6, iOS 26.5.
- iPad bundle: `test_sim_2026-09-06T19-15-43-127Z_pid65562_e8c8baae.xcresult`.
- iPhone bundle: `test_sim_2026-09-06T19-19-09-519Z_pid65562_321678ba.xcresult`.
- Remote CI is green on `2c4130e`: [Native mobile](https://github.com/Onyx-Dev-Labs/doodle-note/actions/runs/34054601741), [main checks and Windows packaging](https://github.com/Onyx-Dev-Labs/doodle-note/actions/runs/34054601681), and [CodeQL](https://github.com/Onyx-Dev-Labs/doodle-note/actions/runs/34054601677). Normal native CI skips only the opt-in model inference test. Synthetic model execution is not accuracy evidence.
- Detailed evidence and limits: `apps/mobile-native/docs/validation.md`. Focused agent rereviews reported no remaining blocking findings; required human review remains separate.

## Local QA
From `apps/mobile-native`:
```sh
xcodegen generate
open DoodleNoteNative.xcodeproj
```
Choose the DoodleNoteNative scheme and an installed iOS 26 simulator. Automated reproduction:
```sh
xcodebuild -project DoodleNoteNative.xcodeproj -scheme DoodleNoteNative \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' \
  -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO test
```

Check this:
1. On iPhone and iPad layouts, create a note, type text and draw ink, then reopen it. Expect retained content and usable compact/regular layouts with recording controls above the Pencil palette.
2. With speech unavailable or models absent, open a note and edit it. Expect a clear readiness explanation and usable local text/ink editing.
3. On a supported physical device with saved audio, start recording and navigate between notes during preparation. Expect playback disabled until capture ends and the chosen recording language retained. Physical hardware is unavailable for this check today.
4. Review recovery/overflow fixture assertions: readable notes and original source audio remain preserved when recovery writes or speaker processing fail. Speaker failure must not claim capture stopped.

## Risks and Release Notes
- The iOS 26 minimum is a prototype API requirement. Sean reported iPadOS 18.5; final hardware/OS support is ONY-241 work.
- No real microphone/Pencil, five-language accuracy, remembered voice recognition, two-hour, thermal/battery, or power-loss validation. No release readiness claim.
- FluidAudio source is pinned and licensed; converted-model/NVIDIA redistribution notices still require ONY-241 review before distribution.
- No production schema, OAuth, signing, paid infrastructure or store configuration changed. This PR contains no production data migration. Existing local originals are preserved.
- No merge or release authority granted. Retain the internal workspace and untouched external checkout; do not delete untracked roadmap material. Rollback of the checkpoint is a reviewed revert, not deletion of user notes.

## Follow-ups
- ONY-241 and ONY-242 are the next dependency wave after ONY-240 lands. Remaining ONY-243 through ONY-266 retain their explicit prerequisite gates.
- Full v1 scope remains in ONY-239 and its child contracts. This PR does not close that roadmap.
