### PR TITLE
[ONY-242] Add versioned mobile libraries, note history, and source anchors

### DIFF
--- a/apps/mobile-native/Sources/DoodleNoteApp.swift
+++ b/apps/mobile-native/Sources/DoodleNoteApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct DoodleNoteApp: App {
     @State private var library: NoteLibrary
     @State private var recording = RecordingSession()
+    @Environment(\.scenePhase) private var scenePhase
 
     init() {
         let base = URL.applicationSupportDirectory.appendingPathComponent("DoodleNoteNative", isDirectory: true)
@@ -17,7 +18,18 @@ struct DoodleNoteApp: App {
     }
 
     var body: some Scene {
-        WindowGroup { LibraryView(library: library, recording: recording) }
+        WindowGroup {
+            LibraryView(library: library, recording: recording)
+                .onChange(of: scenePhase) { _, phase in
+                    if phase != .active {
+                        let task = SaveBackgroundLifetime()
+                        Task {
+                            await library.flush()
+                            task.end()
+                        }
+                    }
+                }
+        }
     }
 }
 
@@ -26,11 +38,14 @@ struct LibraryView: View {
     @Bindable var recording: RecordingSession
     @State private var selection: UUID?
     @State private var search = ""
+    @State private var folderID: UUID?
+    @State private var folderName = ""
+    @State private var creatingFolder = false
 
     private var visibleNotes: [NoteRecord] {
-        library.notes.filter { note in
-            search.isEmpty || ([note.title, note.text] + note.passages.map(\.text))
-                .contains { $0.localizedCaseInsensitiveContains(search) }
+        library.visibleNotes.filter { note in
+            (folderID == nil || note.metadata?.folderID == folderID) && (search.isEmpty || ([note.title, note.text] + note.passages.map(\.text) + (note.metadata?.summaries.map(\.text) ?? []))
+                .contains { $0.localizedCaseInsensitiveContains(search) })
         }.sorted { $0.updatedAt > $1.updatedAt }
     }
 
@@ -38,8 +53,15 @@ struct LibraryView: View {
         NavigationSplitView {
             List(selection: $selection) {
                 Section {
-                    Label("Only on this device", systemImage: "iphone")
-                        .font(.subheadline).foregroundStyle(.secondary)
+                    Picker("Library", selection: Binding(get: { library.selectedLibraryID }, set: { id in
+                        library.selectLibrary(id); selection = nil; folderID = nil
+                    })) {
+                        ForEach(library.libraries) { Text($0.name).tag($0.id) }
+                    }
+                    Picker("Folder", selection: $folderID) {
+                        Text("All notes").tag(UUID?.none)
+                        ForEach(library.folders) { Text($0.name).tag(Optional($0.id)) }
+                    }
                 }
                 Section("Notes") {
                     ForEach(visibleNotes) { note in
@@ -58,15 +80,16 @@ struct LibraryView: View {
             .navigationTitle("DoodleNote")
             .searchable(text: $search, prompt: "Search notes and transcripts")
             .overlay {
-                if library.notes.isEmpty {
+                if library.visibleNotes.isEmpty {
                     ContentUnavailableView("Your notes start here", systemImage: "note.text",
                         description: Text("Create a note to write, draw, or record a conversation."))
                         .allowsHitTesting(false)
                 }
             }
             .toolbar {
+                Button("New folder", systemImage: "folder.badge.plus") { creatingFolder = true }
                 Button("New note", systemImage: "square.and.pencil") { selection = library.create() }
-                    .disabled(library.disk == nil).accessibilityIdentifier("newNote")
+                    .disabled(library.disk == nil || library.loading).accessibilityIdentifier("newNote")
             }
         } detail: {
             if let selection, library.note(selection) != nil {
@@ -76,7 +99,20 @@ struct LibraryView: View {
                     description: Text("Your notes stay on this device. No account is required."))
             }
         }
+        .alert("New folder", isPresented: $creatingFolder) {
+            TextField("Folder name", text: $folderName)
+            Button("Create") { let name = folderName; folderName = ""; Task { await library.addFolder(name) } }
+            Button("Cancel", role: .cancel) { folderName = "" }
+        }
         .safeAreaInset(edge: .bottom) {
+            if library.loading { ProgressView("Opening notes…") }
+            if library.pendingSaves > 0 { Text("Saving changes…").font(.caption) }
+            if let problem = library.saveProblem {
+                HStack {
+                    Text(problem).font(.callout).foregroundStyle(.red)
+                    Button("Retry saving") { library.retrySaving() }.accessibilityIdentifier("retrySaving")
+                }.padding().background(.regularMaterial)
+            }
             if let problem = library.problem ?? recording.problem {
                 Text(problem).font(.callout).foregroundStyle(.red)
                     .padding().frame(maxWidth: .infinity).background(.regularMaterial)
@@ -87,5 +123,21 @@ struct LibraryView: View {
                     .padding().frame(maxWidth: .infinity).background(.regularMaterial)
             }
         }
+    }
+}
+
+/// Expiration ends the UIKit assertion, not the persistence work or its unsaved status.
+@MainActor private final class SaveBackgroundLifetime {
+    private var identifier = UIBackgroundTaskIdentifier.invalid
+    init() {
+        identifier = UIApplication.shared.beginBackgroundTask(withName: "Save notes") { [weak self] in
+            self?.end()
+        }
+    }
+    func end() {
+        guard identifier != .invalid else { return }
+        let current = identifier
+        identifier = .invalid
+        UIApplication.shared.endBackgroundTask(current)
     }
 }

--- a/apps/mobile-native/Sources/LibraryContracts.swift
+++ b/apps/mobile-native/Sources/LibraryContracts.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+/// Identity is explicit. Transport state and credentials never determine ownership.
+struct LibraryIdentity: Codable, Equatable, Hashable, Sendable {
+    let accountID: String
+    let workspaceID: String
+}
+
+struct LibraryRecord: Codable, Identifiable, Equatable, Sendable {
+    static let localID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+    let id: UUID
+    var name: String
+    let identity: LibraryIdentity?
+    static let local = LibraryRecord(id: localID, name: "Only on this device", identity: nil)
+}
+
+struct NoteFolder: Codable, Identifiable, Equatable, Sendable {
+    let id: UUID
+    let libraryID: UUID
+    var name: String
+}
+
+/// occurrenceID is the provider's stable original occurrence identity, never the displayed start date.
+struct EventOccurrenceKey: Codable, Equatable, Hashable, Sendable {
+    let provider: String
+    let accountID: String
+    let calendarID: String
+    let eventID: String
+    let occurrenceID: String
+}
+
+struct SourceAnchor: Codable, Equatable, Sendable {
+    enum Content: Codable, Equatable, Sendable {
+        case personalParagraph(Int)
+        case transcript(UUID)
+    }
+    let libraryID: UUID
+    let noteID: UUID
+    let revisionID: UUID
+    let content: Content
+}
+
+struct NoteRevision: Codable, Identifiable, Equatable, Sendable {
+    let id: UUID
+    let noteID: UUID
+    let libraryID: UUID
+    let savedAt: Date
+    let title: String
+    let text: String
+    let passages: [TranscriptPassage]
+    let speakerAnnotations: SpeakerAnnotations?
+
+    init(_ note: NoteRecord) {
+        id = note.metadata!.revisionID
+        noteID = note.id
+        libraryID = note.metadata!.libraryID
+        savedAt = note.updatedAt
+        title = note.title
+        text = note.text
+        passages = note.passages
+        speakerAnnotations = note.speakerAnnotations
+    }
+
+    func resolve(_ anchor: SourceAnchor) -> String? {
+        guard anchor.noteID == noteID, anchor.revisionID == id, anchor.libraryID == libraryID else { return nil }
+        switch anchor.content {
+        case .personalParagraph(let index):
+            let paragraphs = text.components(separatedBy: "\n")
+            return paragraphs.indices.contains(index) ? paragraphs[index] : nil
+        case .transcript(let id): return passages.first { $0.id == id }?.text
+        }
+    }
+}
+
+/// Appending a new edited version retains the generated original and its citations.
+struct SummaryVersion: Codable, Identifiable, Equatable, Sendable {
+    enum Origin: String, Codable, Sendable { case generated, edited }
+    let id: UUID
+    let parentID: UUID?
+    let createdAt: Date
+    let origin: Origin
+    let format: String
+    let language: SpokenLanguage
+    let text: String
+    let sources: [SourceAnchor]
+}
+
+struct NoteMetadata: Codable, Equatable, Sendable {
+    var libraryID = LibraryRecord.localID
+    var folderID: UUID? = nil
+    var revisionID = UUID()
+    var event: EventOccurrenceKey? = nil
+    var summaries: [SummaryVersion] = []
+    var selectedSummaryID: UUID? = nil
+}
+
+struct ProcessingJob: Codable, Identifiable, Equatable, Sendable {
+    enum Kind: String, Codable, Sendable { case audioImport, summary, eventNote }
+    enum State: String, Codable, Sendable { case pending, running, retryable, completed, cancelled }
+    let id: UUID
+    let libraryID: UUID
+    let kind: Kind
+    let idempotencyKey: String
+    /// Reserved before work begins, reused after a crash between output and completion.
+    let noteID: UUID
+    let versionID: UUID
+    var state: State = .pending
+    var attempts = 0
+    var lastError: String? = nil
+}
+
+struct LibraryCatalog: Codable, Equatable, Sendable {
+    var schemaVersion = 1
+    var libraries: [LibraryRecord] = [.local]
+    var folders: [NoteFolder] = []
+    var jobs: [ProcessingJob] = []
+}
+
+enum LibraryDataError: LocalizedError {
+    case invalidOwnership, immutableHistory, invalidDocument, unsupportedVersion, invalidJob
+    var errorDescription: String? {
+        switch self {
+        case .invalidOwnership: "The note or folder belongs to a different library."
+        case .immutableHistory: "A retained version cannot be overwritten."
+        case .invalidDocument: "The saved document is invalid; its original file is preserved."
+        case .unsupportedVersion: "This library requires a newer version of DoodleNote."
+        case .invalidJob: "The processing request does not match its saved identity."
+        }
+    }
+}

--- a/apps/mobile-native/Sources/LibraryRepository.swift
+++ b/apps/mobile-native/Sources/LibraryRepository.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+/// One serial owner for catalog/job transactions and immutable output writes.
+/// No network calls or credentials; authentication is supplied explicitly by the caller.
+actor LibraryRepository {
+    let disk: NoteDiskStore
+    init(disk: NoteDiskStore) { self.disk = disk }
+
+    func catalog() throws -> LibraryCatalog { try readCatalog() }
+    func load() throws -> (notes: [NoteRecord], unreadable: [String], audioProblems: [String], recoveryWriteProblems: [String], migrationProblems: [String]) {
+        try disk.load()
+    }
+
+    private func readCatalog() throws -> LibraryCatalog {
+        let url = disk.root.appendingPathComponent("libraries.json")
+        guard FileManager.default.fileExists(atPath: url.path) else { return LibraryCatalog() }
+        let value = try JSONDecoder().decode(LibraryCatalog.self, from: Data(contentsOf: url))
+        guard value.schemaVersion == 1 else { throw LibraryDataError.unsupportedVersion }
+        guard value.libraries.first(where: { $0.id == LibraryRecord.localID }) == .local,
+              Set(value.libraries.map(\.id)).count == value.libraries.count,
+              value.libraries.allSatisfy({ $0.id == LibraryRecord.localID || $0.identity != nil }) else {
+            throw LibraryDataError.invalidOwnership
+        }
+        let libraryIDs = Set(value.libraries.map(\.id))
+        guard Set(value.folders.map(\.id)).count == value.folders.count,
+              value.folders.allSatisfy({ libraryIDs.contains($0.libraryID) }),
+              Set(value.jobs.map(\.id)).count == value.jobs.count,
+              Set(value.jobs.map { [$0.libraryID.uuidString, $0.kind.rawValue, $0.idempotencyKey] }).count == value.jobs.count,
+              value.jobs.allSatisfy({ libraryIDs.contains($0.libraryID) }) else {
+            throw LibraryDataError.invalidDocument
+        }
+        return value
+    }
+
+    private func saveCatalog(_ value: LibraryCatalog) throws {
+        try disk.write(value, to: disk.root.appendingPathComponent("libraries.json"))
+    }
+
+    func addLibrary(name: String, identity: LibraryIdentity) throws -> LibraryRecord {
+        guard !identity.accountID.isEmpty, !identity.workspaceID.isEmpty else { throw LibraryDataError.invalidOwnership }
+        var catalog = try readCatalog()
+        if let existing = catalog.libraries.first(where: { $0.identity == identity }) { return existing }
+        let library = LibraryRecord(id: UUID(), name: name, identity: identity)
+        catalog.libraries.append(library)
+        try saveCatalog(catalog)
+        return library
+    }
+
+    func authorize(_ libraryID: UUID, identities: Set<LibraryIdentity>) throws {
+        let catalog = try readCatalog()
+        guard let library = catalog.libraries.first(where: { $0.id == libraryID }),
+              library.id == LibraryRecord.localID || library.identity.map(identities.contains) == true else {
+            throw LibraryDataError.invalidOwnership
+        }
+    }
+
+    func addFolder(name: String, libraryID: UUID, identities: Set<LibraryIdentity>) throws -> NoteFolder {
+        try authorize(libraryID, identities: identities)
+        var catalog = try readCatalog()
+        let folder = NoteFolder(id: UUID(), libraryID: libraryID, name: name)
+        catalog.folders.append(folder)
+        try saveCatalog(catalog)
+        return folder
+    }
+
+    func save(_ note: NoteRecord, identities: Set<LibraryIdentity>) throws {
+        guard let metadata = note.metadata else { throw LibraryDataError.invalidDocument }
+        try authorize(metadata.libraryID, identities: identities)
+        if let folderID = metadata.folderID {
+            guard try readCatalog().folders.contains(where: { $0.id == folderID && $0.libraryID == metadata.libraryID }) else {
+                throw LibraryDataError.invalidOwnership
+            }
+        }
+        try disk.save(note)
+    }
+
+    func resolve(_ anchor: SourceAnchor, identities: Set<LibraryIdentity>) throws -> String? {
+        try authorize(anchor.libraryID, identities: identities)
+        return try disk.revision(anchor).resolve(anchor)
+    }
+
+    func beginEventNote(libraryID: UUID, event: EventOccurrenceKey,
+                        identities: Set<LibraryIdentity>) throws -> ProcessingJob {
+        guard [event.provider, event.accountID, event.calendarID, event.eventID, event.occurrenceID].allSatisfy({ !$0.isEmpty }) else {
+            throw LibraryDataError.invalidJob
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let key = try encoder.encode(event).base64EncodedString()
+        return try beginJob(libraryID: libraryID, kind: .eventNote, key: key, identities: identities)
+    }
+
+    func beginJob(libraryID: UUID, kind: ProcessingJob.Kind, key: String,
+                  noteID: UUID? = nil, identities: Set<LibraryIdentity>) throws -> ProcessingJob {
+        try authorize(libraryID, identities: identities)
+        guard !key.isEmpty else { throw LibraryDataError.invalidJob }
+        var catalog = try readCatalog()
+        if let existing = catalog.jobs.first(where: { $0.libraryID == libraryID && $0.kind == kind && $0.idempotencyKey == key }) {
+            guard noteID == nil || existing.noteID == noteID else { throw LibraryDataError.invalidJob }
+            return existing
+        }
+        if kind == .summary {
+            guard let noteID else { throw LibraryDataError.invalidJob }
+            let note = try JSONDecoder().decode(NoteRecord.self,
+                from: Data(contentsOf: disk.directory(for: noteID).appendingPathComponent("note.json")))
+            guard note.id == noteID, note.metadata?.libraryID == libraryID else { throw LibraryDataError.invalidOwnership }
+        }
+        let job = ProcessingJob(id: UUID(), libraryID: libraryID, kind: kind, idempotencyKey: key,
+                                noteID: noteID ?? UUID(), versionID: UUID())
+        catalog.jobs.append(job)
+        try saveCatalog(catalog)
+        return job
+    }
+
+    func transitionJob(_ id: UUID, to state: ProcessingJob.State, error: String? = nil,
+                       identities: Set<LibraryIdentity>) throws -> ProcessingJob {
+        var catalog = try readCatalog()
+        guard let i = catalog.jobs.firstIndex(where: { $0.id == id }) else { throw LibraryDataError.invalidJob }
+        try authorize(catalog.jobs[i].libraryID, identities: identities)
+        guard catalog.jobs[i].state != .completed, catalog.jobs[i].state != .cancelled else { return catalog.jobs[i] }
+        guard state != .completed else { throw LibraryDataError.invalidJob }
+        catalog.jobs[i].state = state
+        if state == .running { catalog.jobs[i].attempts += 1 }
+        catalog.jobs[i].lastError = error
+        try saveCatalog(catalog)
+        return catalog.jobs[i]
+    }
+
+    /// Output is saved before completion. Replay returns the already committed output unchanged.
+    func commit(_ output: NoteRecord, for jobID: UUID, identities: Set<LibraryIdentity>,
+                afterOutput: (@Sendable () throws -> Void)? = nil) throws -> NoteRecord {
+        var catalog = try readCatalog()
+        guard let i = catalog.jobs.firstIndex(where: { $0.id == jobID }) else { throw LibraryDataError.invalidJob }
+        let job = catalog.jobs[i]
+        try authorize(job.libraryID, identities: identities)
+        guard job.state != .cancelled, output.id == job.noteID, output.metadata?.libraryID == job.libraryID else {
+            throw LibraryDataError.invalidJob
+        }
+        let file = disk.directory(for: job.noteID).appendingPathComponent("note.json")
+        var result = output
+        if FileManager.default.fileExists(atPath: file.path) {
+            let existing = try JSONDecoder().decode(NoteRecord.self, from: Data(contentsOf: file))
+            guard existing.id == job.noteID, existing.metadata?.libraryID == job.libraryID else { throw LibraryDataError.invalidOwnership }
+            if job.kind != .summary || existing.metadata?.summaries.contains(where: { $0.id == job.versionID }) == true {
+                result = existing
+            } else {
+                guard let version = output.metadata?.summaries.first(where: { $0.id == job.versionID }) else {
+                    throw LibraryDataError.invalidJob
+                }
+                result = existing
+                result.metadata?.summaries.append(version)
+                if result.metadata?.selectedSummaryID == nil { result.metadata?.selectedSummaryID = version.id }
+                result.metadata?.revisionID = UUID()
+                result.updatedAt = Date()
+            }
+        }
+        if job.kind == .summary {
+            guard result.metadata?.summaries.contains(where: { $0.id == job.versionID }) == true else { throw LibraryDataError.invalidJob }
+        }
+        try save(result, identities: identities)
+        try afterOutput?()
+        catalog.jobs[i].state = .completed
+        catalog.jobs[i].lastError = nil
+        try saveCatalog(catalog)
+        return result
+    }
+}

--- a/apps/mobile-native/Sources/NoteEditor.swift
+++ b/apps/mobile-native/Sources/NoteEditor.swift
@@ -9,6 +9,8 @@ struct NoteEditor: View {
     @State private var pane = 0
     @State private var player = LocalPlayback()
     @State private var showSpeakers = false
+    @State private var summaryText = ""
+    @State private var editingSummary: SummaryVersion?
 
     private var note: NoteRecord { library.note(id) ?? NoteRecord(id: id) }
     private var isActive: Bool { recording.noteID == id }
@@ -26,7 +28,13 @@ struct NoteEditor: View {
     var body: some View {
         VStack(spacing: 0) {
             TextField("Untitled note", text: binding(\.title), axis: .vertical)
-                .font(.largeTitle.bold()).padding().accessibilityIdentifier("noteTitle")
+                .font(.largeTitle.bold()).padding().accessibilityIdentifier("noteTitle").disabled(note.schemaVersion != 2)
+            Picker("Move to folder", selection: Binding(get: { note.metadata?.folderID }, set: { folder in
+                library.update(id) { $0.metadata?.folderID = folder }
+            })) {
+                Text("No folder").tag(UUID?.none)
+                ForEach(library.folders) { Text($0.name).tag(Optional($0.id)) }
+            }.padding(.horizontal).disabled(note.schemaVersion != 2).accessibilityIdentifier("noteFolder")
             if note.captureState == .interrupted {
                 Label("Recording interrupted. Saved audio and notes are retained. Start again when ready.", systemImage: "pause.circle")
                     .font(.callout).foregroundStyle(.orange).padding(.horizontal)
@@ -35,7 +43,7 @@ struct NoteEditor: View {
                 Picker("Spoken language", selection: binding(\.language)) {
                     ForEach(SpokenLanguage.allCases) { Text($0.name).tag($0) }
                 }
-                .disabled(recording.noteID != nil || recording.busy || recording.speech.readiness == .downloading)
+                .disabled(note.schemaVersion != 2 || recording.noteID != nil || recording.busy || recording.speech.readiness == .downloading)
                 Spacer()
                 if let started = recording.startedAt, isActive {
                     Label { Text(started, style: .timer).monospacedDigit() } icon: { Image(systemName: "record.circle.fill") }
@@ -56,6 +64,7 @@ struct NoteEditor: View {
                     Text("Notes").tag(0)
                     Text("Ink").tag(1)
                     Text("Transcript").tag(2)
+                    Text("Summary").tag(3)
                 }.pickerStyle(.segmented).padding()
                 if pane == 2 { transcript } else { notePane }
             }
@@ -73,14 +82,41 @@ struct NoteEditor: View {
     }
 
     private var notePicker: some View {
-        Picker("Content", selection: $pane) { Text("Notes").tag(0); Text("Ink").tag(1) }
+        Picker("Content", selection: $pane) { Text("Notes").tag(0); Text("Ink").tag(1); Text("Summary").tag(3) }
             .pickerStyle(.segmented).padding()
     }
 
     @ViewBuilder private var notePane: some View {
-        if pane == 1 {
+        if pane == 3 {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Summary versions").font(.headline)
+                    if note.metadata?.summaries.isEmpty != false {
+                        Text("Generated summaries will appear here. Your personal notes remain separate.")
+                            .foregroundStyle(.secondary)
+                    }
+                    ForEach(note.metadata?.summaries ?? []) { version in
+                        Text(version.origin == .edited ? "Edited version" : "Generated version").font(.caption)
+                        Text(version.text).textSelection(.enabled)
+                        Button("Edit as new version") { summaryText = version.text; editingSummary = version }.disabled(note.schemaVersion != 2)
+                    }
+                }.frame(maxWidth: .infinity, alignment: .leading).padding()
+            }
+            .sheet(item: $editingSummary) { version in
+                NavigationStack {
+                    TextEditor(text: $summaryText).padding().navigationTitle("Edit summary")
+                        .toolbar {
+                            Button("Cancel") { editingSummary = nil }
+                            Button("Save version") {
+                                library.saveSummaryEdit(noteID: id, parent: version, text: summaryText)
+                                editingSummary = nil
+                            }
+                        }
+                }
+            }
+        } else if pane == 1 {
             if note.ink.isEmpty || (try? PKDrawing(data: note.ink)) != nil {
-                InkCanvas(data: binding(\.ink)).accessibilityLabel("Drawing canvas")
+                InkCanvas(data: binding(\.ink), editable: note.schemaVersion == 2).accessibilityLabel("Drawing canvas")
             } else {
                 ContentUnavailableView("Drawing could not be opened", systemImage: "pencil.tip.crop.circle.badge.exclamationmark",
                     description: Text("The original drawing is preserved."))
@@ -88,8 +124,12 @@ struct NoteEditor: View {
         } else {
             VStack(alignment: .leading, spacing: 0) {
                 Text("Your personal notes").font(.caption).foregroundStyle(.secondary).padding(.horizontal)
-                TextEditor(text: binding(\.text)).padding(.horizontal, 8)
-                    .accessibilityLabel("Personal notes").accessibilityIdentifier("personalNotes")
+                if note.schemaVersion == 2 {
+                    TextEditor(text: binding(\.text)).padding(.horizontal, 8)
+                        .accessibilityLabel("Personal notes").accessibilityIdentifier("personalNotes")
+                } else {
+                    ScrollView { Text(note.text).textSelection(.enabled).frame(maxWidth: .infinity, alignment: .leading).padding() }
+                }
             }
         }
     }
@@ -156,7 +196,7 @@ struct NoteEditor: View {
                         else { await recording.start(id, library: library) }
                     }
                 }.buttonStyle(.borderedProminent).tint(isActive ? .red : .accentColor)
-                    .disabled(recording.busy || (recording.noteID != nil && !isActive) || recording.speech.readiness == .downloading || recording.speakers.preparing)
+                    .disabled(note.schemaVersion != 2 || recording.busy || (recording.noteID != nil && !isActive) || recording.speech.readiness == .downloading || recording.speakers.preparing)
                     .accessibilityIdentifier("recordButton")
             }
             if recording.busy { ProgressView("Preparing or finalizing recording…").font(.caption) }
@@ -181,7 +221,7 @@ struct NoteEditor: View {
                         TextField(annotations.name(for: key), text: Binding(
                             get: { library.note(id)?.speakerAnnotations?.names[key] ?? "" },
                             set: { name in library.update(id) { $0.speakerAnnotations?.names[key] = name.trimmingCharacters(in: .whitespacesAndNewlines) } }))
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(.roundedBorder).disabled(note.schemaVersion != 2)
                     }
                 }
                 Text("Names apply to this recording session. Remembering voices across meetings is still being built.")
@@ -197,6 +237,7 @@ struct NoteEditor: View {
 
 struct InkCanvas: UIViewRepresentable {
     @Binding var data: Data
+    var editable = true
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
     func makeUIView(context: Context) -> PKCanvasView {
@@ -214,11 +255,12 @@ struct InkCanvas: UIViewRepresentable {
     }
     func updateUIView(_ canvas: PKCanvasView, context: Context) {
         context.coordinator.parent = self
+        canvas.drawingGestureRecognizer.isEnabled = editable
         if context.coordinator.lastData != data {
             context.coordinator.lastData = data
             canvas.drawing = (try? PKDrawing(data: data)) ?? PKDrawing()
         }
-        context.coordinator.picker.setVisible(true, forFirstResponder: canvas)
+        context.coordinator.picker.setVisible(editable, forFirstResponder: canvas)
     }
     final class Coordinator: NSObject, PKCanvasViewDelegate {
         var parent: InkCanvas

--- a/apps/mobile-native/Sources/NoteRecord.swift
+++ b/apps/mobile-native/Sources/NoteRecord.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum SpokenLanguage: String, Codable, CaseIterable, Identifiable {
+enum SpokenLanguage: String, Codable, CaseIterable, Identifiable, Sendable {
     case english = "en-US", danish = "da-DK", spanish = "es-ES"
     case french = "fr-FR", german = "de-DE"
 
@@ -16,7 +16,7 @@ enum SpokenLanguage: String, Codable, CaseIterable, Identifiable {
     }
 }
 
-struct TranscriptPassage: Codable, Identifiable, Equatable {
+struct TranscriptPassage: Codable, Identifiable, Equatable, Sendable {
     var id = UUID()
     var start: TimeInterval
     var end: TimeInterval
@@ -26,9 +26,10 @@ struct TranscriptPassage: Codable, Identifiable, Equatable {
     var speakerName: String? = nil
 }
 
-struct NoteRecord: Codable, Identifiable, Equatable {
-    enum CaptureState: String, Codable { case idle, recording, finished, interrupted }
-    var schemaVersion = 1
+struct NoteRecord: Codable, Identifiable, Equatable, Sendable {
+    enum CaptureState: String, Codable, Sendable { case idle, recording, finished, interrupted }
+    var schemaVersion = 2
+    var metadata: NoteMetadata? = NoteMetadata()
     var id = UUID()
     var createdAt = Date()
     var updatedAt = Date()

--- a/apps/mobile-native/Sources/NoteStore.swift
+++ b/apps/mobile-native/Sources/NoteStore.swift
@@ -1,7 +1,8 @@
 import Foundation
+import CryptoKit
 import Observation
 
-struct NoteDiskStore {
+struct NoteDiskStore: Sendable {
     let root: URL
 
     init(root: URL) throws {
@@ -19,29 +20,132 @@ struct NoteDiskStore {
         return url
     }
 
-    func save(_ note: NoteRecord) throws {
+    func save(_ note: NoteRecord, migrationOriginal: Data? = nil) throws {
         let dir = directory(for: note.id)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let data = try JSONEncoder().encode(note)
-        try data.write(to: dir.appendingPathComponent("note.json"),
-                       options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+        let file = dir.appendingPathComponent("note.json")
+        if FileManager.default.fileExists(atPath: file.path), note.schemaVersion != 2 {
+            throw LibraryDataError.unsupportedVersion
+        }
+        if note.schemaVersion == 2 {
+            guard let metadata = note.metadata else { throw LibraryDataError.invalidDocument }
+            let ids = Set(metadata.summaries.map(\.id))
+            guard ids.count == metadata.summaries.count,
+                  metadata.selectedSummaryID.map(ids.contains) ?? true,
+                  metadata.summaries.allSatisfy({ version in
+                      (version.parentID.map { $0 != version.id && ids.contains($0) } ?? (version.origin == .generated))
+                        && version.sources.allSatisfy { $0.noteID == note.id && $0.libraryID == metadata.libraryID }
+                  }) else { throw LibraryDataError.immutableHistory }
+            var retainedIDs: Set<UUID> = []
+            for version in metadata.summaries {
+                if version.origin == .edited {
+                    guard let parent = version.parentID, retainedIDs.contains(parent) else { throw LibraryDataError.immutableHistory }
+                } else if version.parentID != nil { throw LibraryDataError.immutableHistory }
+                retainedIDs.insert(version.id)
+            }
+            if FileManager.default.fileExists(atPath: file.path) {
+                let existingBytes = try Data(contentsOf: file)
+                let old = try JSONDecoder().decode(NoteRecord.self, from: existingBytes)
+                guard (1...2).contains(old.schemaVersion) else { throw LibraryDataError.unsupportedVersion }
+                if old.schemaVersion == 1 {
+                    guard migrationOriginal == existingBytes,
+                          try Data(contentsOf: dir.appendingPathComponent("note.schema1.original.json")) == existingBytes,
+                          FileManager.default.fileExists(atPath: dir.appendingPathComponent("migration-1-to-2.json").path) else {
+                        throw LibraryDataError.invalidDocument
+                    }
+                } else if old.metadata == nil { throw LibraryDataError.invalidDocument }
+                guard old.id == note.id else { throw LibraryDataError.invalidDocument }
+                if let previous = old.metadata, old.schemaVersion == 2 {
+                    guard previous.libraryID == metadata.libraryID else { throw LibraryDataError.invalidOwnership }
+                    for version in previous.summaries {
+                        guard metadata.summaries.contains(version) else { throw LibraryDataError.immutableHistory }
+                    }
+                }
+            }
+            let revision = NoteRevision(note)
+            let history = dir.appendingPathComponent("revisions", isDirectory: true)
+            try FileManager.default.createDirectory(at: history, withIntermediateDirectories: true)
+            let revisionFile = history.appendingPathComponent(revision.id.uuidString + ".json")
+            if FileManager.default.fileExists(atPath: revisionFile.path) {
+                let existing = try JSONDecoder().decode(NoteRevision.self, from: Data(contentsOf: revisionFile))
+                guard existing == revision else { throw LibraryDataError.immutableHistory }
+            } else { try write(revision, to: revisionFile) }
+        }
+        try write(note, to: file)
     }
 
-    func load(persistRecovery: ((NoteRecord) throws -> Void)? = nil) throws
-        -> (notes: [NoteRecord], unreadable: [String], audioProblems: [String], recoveryWriteProblems: [String]) {
+    func write<T: Encodable>(_ value: T, to file: URL) throws {
+        try JSONEncoder().encode(value).write(to: file,
+            options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+    }
+
+    struct MigrationRecord: Codable {
+        let fromVersion: Int
+        let toVersion: Int
+        let noteID: UUID
+        let originalFile: String
+        let originalSHA256: String
+    }
+
+    func migrate(_ source: NoteRecord, data: Data, directory: URL,
+                 beforeCommit: (() throws -> Void)? = nil) throws -> NoteRecord {
+        guard source.id.uuidString == directory.lastPathComponent, source.schemaVersion == 1 else {
+            throw LibraryDataError.invalidDocument
+        }
+        let backup = directory.appendingPathComponent("note.schema1.original.json")
+        if FileManager.default.fileExists(atPath: backup.path) {
+            guard try Data(contentsOf: backup) == data else { throw LibraryDataError.invalidDocument }
+        } else { try data.write(to: backup, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication]) }
+        let record = MigrationRecord(fromVersion: 1, toVersion: 2, noteID: source.id,
+            originalFile: backup.lastPathComponent, originalSHA256: SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined())
+        try write(record, to: directory.appendingPathComponent("migration-1-to-2.json"))
+        var note = source
+        note.schemaVersion = 2
+        note.metadata = NoteMetadata(revisionID: source.id)
+        try beforeCommit?()
+        try save(note, migrationOriginal: data)
+        guard try JSONDecoder().decode(NoteRecord.self, from: Data(contentsOf: directory.appendingPathComponent("note.json"))) == note else {
+            throw LibraryDataError.invalidDocument
+        }
+        return note
+    }
+
+    func revision(_ anchor: SourceAnchor) throws -> NoteRevision {
+        let file = directory(for: anchor.noteID).appendingPathComponent("revisions")
+            .appendingPathComponent(anchor.revisionID.uuidString + ".json")
+        let revision = try JSONDecoder().decode(NoteRevision.self, from: Data(contentsOf: file))
+        guard revision.libraryID == anchor.libraryID, revision.noteID == anchor.noteID,
+              revision.id == anchor.revisionID else { throw LibraryDataError.invalidOwnership }
+        return revision
+    }
+
+    func load(persistRecovery: ((NoteRecord) throws -> Void)? = nil, beforeMigrationCommit: (() throws -> Void)? = nil) throws
+        -> (notes: [NoteRecord], unreadable: [String], audioProblems: [String], recoveryWriteProblems: [String], migrationProblems: [String]) {
         let dirs = try FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: nil)
         var notes: [NoteRecord] = []
         var unreadable: [String] = []
         var audioProblems: [String] = []
         var recoveryWriteProblems: [String] = []
+        var migrationProblems: [String] = []
         for dir in dirs where UUID(uuidString: dir.lastPathComponent) != nil {
             do {
-                var note = try JSONDecoder().decode(NoteRecord.self,
-                    from: Data(contentsOf: dir.appendingPathComponent("note.json")))
-                guard note.schemaVersion == 1, note.id.uuidString == dir.lastPathComponent else {
+                let data = try Data(contentsOf: dir.appendingPathComponent("note.json"))
+                var note = try JSONDecoder().decode(NoteRecord.self, from: data)
+                guard (1...2).contains(note.schemaVersion), note.id.uuidString == dir.lastPathComponent else {
                     unreadable.append(dir.lastPathComponent)
                     continue
                 }
+                if note.schemaVersion == 1 {
+                    do { note = try migrate(note, data: data, directory: dir, beforeCommit: beforeMigrationCommit) }
+                    catch {
+                        // A failed write must not hide readable source data or allow bypassing migration.
+                        note.metadata = NoteMetadata(revisionID: note.id)
+                        notes.append(note)
+                        migrationProblems.append(dir.lastPathComponent)
+                        continue
+                    }
+                }
+                guard note.metadata != nil else { throw LibraryDataError.invalidDocument }
                 let recovery = AudioRecovery.recover(directory: dir.appendingPathComponent("audio"))
                 audioProblems.append(contentsOf: recovery.unreadable)
                 if note.captureState == .recording {
@@ -54,7 +158,7 @@ struct NoteDiskStore {
                 notes.append(note)
             } catch { unreadable.append(dir.lastPathComponent) }
         }
-        return (notes.sorted { $0.updatedAt > $1.updatedAt }, unreadable, audioProblems, recoveryWriteProblems)
+        return (notes.sorted { $0.updatedAt > $1.updatedAt }, unreadable, audioProblems, recoveryWriteProblems, migrationProblems)
     }
 
     func audioFiles(for id: UUID) -> [URL] {
@@ -72,52 +176,169 @@ struct NoteDiskStore {
 @MainActor @Observable
 final class NoteLibrary {
     private(set) var notes: [NoteRecord] = []
+    private(set) var catalog = LibraryCatalog()
+    private(set) var selectedLibraryID = LibraryRecord.localID
+    private(set) var identities: Set<LibraryIdentity> = []
+    private(set) var pendingSaves = 0
+    private(set) var loading = true
+    private(set) var completedWrites = 0
+    private var queued: [UUID: (NoteRecord, Set<LibraryIdentity>)] = [:]
+    private var loadTask: Task<Void, Never>?
+    private var unsavedIDs: Set<UUID> = []
     var problem: String?
+    private(set) var saveProblem: String?
     private(set) var disk: NoteDiskStore?
+    private var repository: LibraryRepository?
+    private var saveTask: Task<Void, Never>?
+
+    var libraries: [LibraryRecord] {
+        catalog.libraries.filter { $0.id == LibraryRecord.localID || $0.identity.map(identities.contains) == true }
+    }
+    var visibleNotes: [NoteRecord] {
+        notes.filter { $0.metadata?.libraryID == selectedLibraryID }
+            .sorted { $0.updatedAt > $1.updatedAt }
+    }
+    var folders: [NoteFolder] { catalog.folders.filter { $0.libraryID == selectedLibraryID } }
 
     init(root: URL) {
         do {
             let disk = try NoteDiskStore(root: root)
             self.disk = disk
-            let result = try disk.load()
-            notes = result.notes
-            if !result.unreadable.isEmpty {
-                problem = "Some saved notes could not be opened. Their files have been preserved."
-            } else if !result.audioProblems.isEmpty {
-                problem = "Some interrupted audio needs recovery. Original files and notes are preserved."
-            } else if !result.recoveryWriteProblems.isEmpty {
-                problem = "Recovered notes are available, but recovery status could not be saved. Free device storage before continuing."
+            repository = LibraryRepository(disk: disk)
+            loadTask = Task {
+                do {
+                    guard let repository else { return }
+                    let result = try await repository.load()
+                    notes = result.notes
+                    if !result.migrationProblems.isEmpty {
+                        problem = "Some notes are read-only until their storage upgrade can finish. Free device storage and reopen the app. Original files are preserved."
+                    } else if !result.unreadable.isEmpty {
+                        problem = "Some saved notes could not be opened. Their files have been preserved."
+                    } else if !result.audioProblems.isEmpty {
+                        problem = "Some interrupted audio needs recovery. Original files and notes are preserved."
+                    } else if !result.recoveryWriteProblems.isEmpty {
+                        problem = "Recovered notes are available, but recovery status could not be saved. Free device storage before continuing."
+                    }
+                    await refreshCatalog()
+                } catch { problem = "Local storage could not be opened. \(error.localizedDescription)" }
+                loading = false
             }
-        } catch { problem = "Local storage could not be opened. \(error.localizedDescription)" }
+        } catch { loading = false; problem = "Local storage could not be opened. \(error.localizedDescription)" }
+    }
+
+    func waitUntilLoaded() async { await loadTask?.value }
+
+    func refreshCatalog() async {
+        do { if let repository { catalog = try await repository.catalog() } }
+        catch { problem = error.localizedDescription }
+    }
+
+    /// Call only after explicit identity authentication; signing in never moves a note.
+    func authenticate(_ identity: LibraryIdentity, name: String) async throws {
+        guard let repository else { throw LibraryDataError.invalidDocument }
+        _ = try await repository.addLibrary(name: name, identity: identity)
+        identities.insert(identity)
+        await refreshCatalog()
+    }
+
+    /// Caller must stop active capture first; transport offline/paused is NOT sign-out.
+    func signOut(_ identity: LibraryIdentity, captureActive: Bool) async -> Bool {
+        guard !captureActive else { problem = "Stop recording before signing out."; return false }
+        await flush()
+        guard pendingSaves == 0, unsavedIDs.isEmpty else { return false }
+        identities.remove(identity)
+        selectedLibraryID = LibraryRecord.localID
+        return true
+    }
+
+    func selectLibrary(_ id: UUID) {
+        guard libraries.contains(where: { $0.id == id }) else { return }
+        selectedLibraryID = id
     }
 
     @discardableResult func create() -> UUID? {
-        let note = NoteRecord()
-        guard persist(note) else { return nil }
+        var note = NoteRecord()
+        note.metadata?.libraryID = selectedLibraryID
+        guard disk != nil, !loading else { return nil }
         notes.insert(note, at: 0)
+        enqueue(note)
         return note.id
     }
 
-    func note(_ id: UUID) -> NoteRecord? { notes.first { $0.id == id } }
-
-    @discardableResult func update(_ id: UUID, _ change: (inout NoteRecord) -> Void) -> Bool {
-        guard let i = notes.firstIndex(where: { $0.id == id }) else { return false }
-        var note = notes[i]
-        change(&note)
-        note.updatedAt = Date()
-        // Keep unsaved edits visible if storage fails. Never display a false saved status.
-        notes[i] = note
-        return persist(note)
+    func note(_ id: UUID) -> NoteRecord? {
+        notes.first { note in
+            note.id == id && libraries.contains(where: { $0.id == note.metadata?.libraryID })
+        }
     }
 
-    private func persist(_ note: NoteRecord) -> Bool {
-        do {
-            guard let disk else { return false }
-            try disk.save(note)
-            return true
-        } catch {
-            problem = "Changes could not be saved. Keep the app open and free device storage. \(error.localizedDescription)"
+    @discardableResult func update(_ id: UUID, _ change: (inout NoteRecord) -> Void) -> Bool {
+        guard let original = note(id), let i = notes.firstIndex(where: { $0.id == id }) else { return false }
+        var note = original
+        change(&note)
+        guard note.id == original.id, note.metadata?.libraryID == original.metadata?.libraryID,
+              note.schemaVersion == 2 else { problem = LibraryDataError.invalidOwnership.localizedDescription; return false }
+        if let folder = note.metadata?.folderID,
+           !catalog.folders.contains(where: { $0.id == folder && $0.libraryID == note.metadata?.libraryID }) {
+            problem = LibraryDataError.invalidOwnership.localizedDescription
             return false
+        }
+        note.updatedAt = Date()
+        note.metadata?.revisionID = UUID()
+        notes[i] = note
+        enqueue(note)
+        return true
+    }
+
+    private func enqueue(_ note: NoteRecord) {
+        queued[note.id] = (note, identities)
+        unsavedIDs.insert(note.id)
+        pendingSaves = queued.count + (saveTask == nil ? 0 : 1)
+        guard saveTask == nil, let repository else { return }
+        saveTask = Task {
+            while let id = queued.keys.first, let (snapshot, authorized) = queued.removeValue(forKey: id) {
+                pendingSaves = queued.count + 1
+                do {
+                    try await repository.save(snapshot, identities: authorized)
+                    completedWrites += 1
+                    if notes.first(where: { $0.id == id })?.metadata?.revisionID == snapshot.metadata?.revisionID {
+                        unsavedIDs.remove(id)
+                        if unsavedIDs.isEmpty { saveProblem = nil }
+                    }
+                } catch {
+                    unsavedIDs.insert(id)
+                    saveProblem = "Changes could not be saved. Keep the app open and free device storage. \(error.localizedDescription)"
+                }
+            }
+            pendingSaves = 0
+            saveTask = nil
+        }
+    }
+
+    @discardableResult func flush() async -> Bool {
+        await saveTask?.value
+        return unsavedIDs.isEmpty
+    }
+
+    func retrySaving() {
+        for id in unsavedIDs {
+            if let note = note(id) { enqueue(note) }
+        }
+    }
+
+    func addFolder(_ name: String) async {
+        guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, let repository else { return }
+        do {
+            _ = try await repository.addFolder(name: name, libraryID: selectedLibraryID, identities: identities)
+            await refreshCatalog()
+        } catch { problem = error.localizedDescription }
+    }
+
+    func saveSummaryEdit(noteID: UUID, parent: SummaryVersion, text: String) {
+        update(noteID) { note in
+            let version = SummaryVersion(id: UUID(), parentID: parent.id, createdAt: Date(), origin: .edited,
+                format: parent.format, language: parent.language, text: text, sources: parent.sources)
+            note.metadata?.summaries.append(version)
+            note.metadata?.selectedSummaryID = version.id
         }
     }
 }

--- a/apps/mobile-native/Sources/RecordingSession.swift
+++ b/apps/mobile-native/Sources/RecordingSession.swift
@@ -61,6 +61,14 @@ final class RecordingSession {
                 try? audioSession.setActive(false)
                 return
             }
+            guard await library.flush() else {
+                speechFeed?.1.finish()
+                speakerFeed?.finish()
+                await speech.finish()
+                await speakers.finish()
+                try? audioSession.setActive(false)
+                return
+            }
             let writer = AudioChunkWriter(directory: directory,
                 speechFormat: speechFeed?.0, speechInput: speechFeed?.1, speakerInput: speakerFeed,
                 onCaptureError: { [weak self] message in

--- a/apps/mobile-native/Sources/SpeakerAnnotations.swift
+++ b/apps/mobile-native/Sources/SpeakerAnnotations.swift
@@ -9,7 +9,7 @@ struct SpeakerTurn: Codable, Equatable, Sendable {
     var key: String { "\(sessionID.uuidString):\(slot)" }
 }
 
-struct SpeakerAnnotations: Codable, Equatable {
+struct SpeakerAnnotations: Codable, Equatable, Sendable {
     var turns: [SpeakerTurn] = []
     var names: [String: String] = [:]
     var order: [String]? = nil

--- a/apps/mobile-native/Tests/LibraryContractTests.swift
+++ b/apps/mobile-native/Tests/LibraryContractTests.swift
@@ -1,0 +1,324 @@
+import XCTest
+@testable import DoodleNoteNative
+
+final class LibraryContractTests: XCTestCase {
+    func store() throws -> NoteDiskStore {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return try NoteDiskStore(root: root)
+    }
+
+    func legacy(_ disk: NoteDiskStore) throws -> (NoteRecord, Data) {
+        var note = NoteRecord()
+        note.schemaVersion = 1
+        note.metadata = nil
+        note.text = "Original personal notes\nSecond paragraph"
+        note.ink = Data(repeating: 7, count: 1024)
+        note.passages = [TranscriptPassage(start: 1, end: 3, text: "Bonjour", isFinal: true, speakerName: "Taylor")]
+        try disk.save(note)
+        let audio = try disk.audioDirectory(for: note.id).appendingPathComponent("0001.caf")
+        try Data([4, 5, 6]).write(to: audio)
+        return (note, try Data(contentsOf: disk.directory(for: note.id).appendingPathComponent("note.json")))
+    }
+
+    func testMigrationRetainsOriginalContentAudioAndRollbackBytes() throws {
+        let disk = try store()
+        let (old, bytes) = try legacy(disk)
+        let result = try disk.load()
+        let note = try XCTUnwrap(result.notes.first)
+        XCTAssertEqual(note.schemaVersion, 2)
+        XCTAssertEqual(note.metadata?.libraryID, LibraryRecord.localID)
+        XCTAssertEqual(note.text, old.text)
+        XCTAssertEqual(note.ink, old.ink)
+        XCTAssertEqual(note.passages, old.passages)
+        XCTAssertEqual(note.createdAt, old.createdAt)
+        XCTAssertEqual(note.updatedAt, old.updatedAt)
+        let dir = disk.directory(for: note.id)
+        XCTAssertEqual(try Data(contentsOf: dir.appendingPathComponent("note.schema1.original.json")), bytes)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: dir.appendingPathComponent("migration-1-to-2.json").path))
+        XCTAssertEqual(try Data(contentsOf: dir.appendingPathComponent("audio/0001.caf")), Data([4, 5, 6]))
+        XCTAssertEqual(try disk.load().notes, [note])
+    }
+
+    func testInterruptedMigrationIsRestartableAndMismatchedIdentityUntouched() throws {
+        let disk = try store()
+        let (old, bytes) = try legacy(disk)
+        let dir = disk.directory(for: old.id)
+        XCTAssertThrowsError(try disk.migrate(old, data: bytes, directory: dir, beforeCommit: { throw CocoaError(.fileWriteOutOfSpace) }))
+        XCTAssertEqual(try Data(contentsOf: dir.appendingPathComponent("note.json")), bytes)
+        XCTAssertEqual(try disk.load().notes.first?.metadata?.revisionID, old.id)
+        let other = disk.directory(for: UUID())
+        try FileManager.default.createDirectory(at: other, withIntermediateDirectories: true)
+        try bytes.write(to: other.appendingPathComponent("note.json"))
+        let result = try disk.load()
+        XCTAssertTrue(result.unreadable.contains(other.lastPathComponent))
+        XCTAssertEqual(try Data(contentsOf: other.appendingPathComponent("note.json")), bytes)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: other.appendingPathComponent("note.schema1.original.json").path))
+    }
+
+    func testMigrationWriteFailureKeepsReadableLegacyNoteAndOriginalBytes() throws {
+        let disk = try store()
+        let (old, bytes) = try legacy(disk)
+        let result = try disk.load(beforeMigrationCommit: { throw CocoaError(.fileWriteOutOfSpace) })
+        XCTAssertEqual(result.notes.first?.text, old.text)
+        XCTAssertEqual(result.notes.first?.ink, old.ink)
+        XCTAssertEqual(result.notes.first?.schemaVersion, 1)
+        XCTAssertEqual(result.migrationProblems, [old.id.uuidString])
+        XCTAssertTrue(result.unreadable.isEmpty)
+        XCTAssertEqual(try Data(contentsOf: disk.directory(for: old.id).appendingPathComponent("note.json")), bytes)
+        XCTAssertEqual(try disk.load().notes.first?.schemaVersion, 2)
+    }
+
+    func testNormalSaveCannotBypassMigrationOrOverwriteMalformedMetadata() throws {
+        let disk = try store()
+        let (legacyNote, bytes) = try legacy(disk)
+        var replacement = legacyNote
+        replacement.schemaVersion = 2
+        replacement.metadata = NoteMetadata()
+        XCTAssertThrowsError(try disk.save(replacement))
+        let file = disk.directory(for: legacyNote.id).appendingPathComponent("note.json")
+        XCTAssertEqual(try Data(contentsOf: file), bytes)
+        replacement.metadata = nil
+        let invalidBytes = try JSONEncoder().encode(replacement)
+        try invalidBytes.write(to: file)
+        replacement.metadata = NoteMetadata()
+        XCTAssertThrowsError(try disk.save(replacement))
+        XCTAssertEqual(try Data(contentsOf: file), invalidBytes)
+    }
+
+    func testAnchorsSurviveLaterEditsAndRejectAnotherLibrary() async throws {
+        let disk = try store()
+        let repository = LibraryRepository(disk: disk)
+        var note = NoteRecord()
+        note.text = "First paragraph\nOriginal second"
+        note.passages = [TranscriptPassage(start: 1, end: 2, text: "Transcript original", isFinal: true)]
+        try await repository.save(note, identities: [])
+        let anchor = SourceAnchor(libraryID: LibraryRecord.localID, noteID: note.id,
+            revisionID: note.metadata!.revisionID, content: .personalParagraph(1))
+        let transcript = SourceAnchor(libraryID: LibraryRecord.localID, noteID: note.id,
+            revisionID: note.metadata!.revisionID, content: .transcript(note.passages[0].id))
+        note.text = "Everything replaced"
+        note.passages = []
+        note.metadata?.revisionID = UUID()
+        try await repository.save(note, identities: [])
+        let resolved = try await repository.resolve(anchor, identities: [])
+        let speech = try await repository.resolve(transcript, identities: [])
+        XCTAssertEqual(resolved, "Original second")
+        XCTAssertEqual(speech, "Transcript original")
+        let forged = SourceAnchor(libraryID: UUID(), noteID: note.id, revisionID: anchor.revisionID, content: anchor.content)
+        do { _ = try await repository.resolve(forged, identities: []); XCTFail("Cross-library anchor accepted") }
+        catch { }
+    }
+
+    func testOwnershipFoldersAndLocalLibraryAreExplicit() async throws {
+        let disk = try store()
+        let repository = LibraryRepository(disk: disk)
+        let identity = LibraryIdentity(accountID: "account-a", workspaceID: "workspace-a")
+        let account = try await repository.addLibrary(name: "Work", identity: identity)
+        var local = NoteRecord()
+        try await repository.save(local, identities: [identity])
+        let folder = try await repository.addFolder(name: "Work folder", libraryID: account.id, identities: [identity])
+        local.metadata?.folderID = folder.id
+        do { try await repository.save(local, identities: [identity]); XCTFail("Cross-library folder accepted") } catch { }
+        local.metadata?.folderID = nil
+        local.metadata?.libraryID = account.id
+        do { try await repository.save(local, identities: [identity]); XCTFail("Implicit adoption accepted") } catch { }
+        let catalog = try await LibraryRepository(disk: disk).catalog()
+        XCTAssertEqual(catalog.libraries.first, .local)
+        do { try await repository.authorize(account.id, identities: []); XCTFail("Signed-out account accessible") } catch { }
+    }
+
+    func testSummaryCommitPreservesConcurrentPersonalEditsAndReplaysOnce() async throws {
+        let disk = try store()
+        let repository = LibraryRepository(disk: disk)
+        var note = NoteRecord()
+        note.text = "Original"
+        let prior = SummaryVersion(id: UUID(), parentID: nil, createdAt: Date(), origin: .generated,
+            format: "meeting", language: .english, text: "Earlier generated", sources: [])
+        let edited = SummaryVersion(id: UUID(), parentID: prior.id, createdAt: Date(), origin: .edited,
+            format: "meeting", language: .english, text: "User edited summary", sources: [])
+        note.metadata?.summaries = [prior, edited]
+        note.metadata?.selectedSummaryID = edited.id
+        try await repository.save(note, identities: [])
+        let job = try await repository.beginJob(libraryID: LibraryRecord.localID, kind: .summary, key: "generate-once", noteID: note.id, identities: [])
+        var output = note
+        let version = SummaryVersion(id: job.versionID, parentID: nil, createdAt: Date(), origin: .generated,
+            format: "meeting", language: .english, text: "Generated", sources: [])
+        output.metadata?.summaries.append(version)
+        note.text = "Personal edit made during generation"
+        note.title = "Edited title"
+        note.ink = Data([9, 8, 7])
+        note.metadata?.revisionID = UUID()
+        try await repository.save(note, identities: [])
+        do {
+            _ = try await repository.commit(output, for: job.id, identities: [], afterOutput: { throw CocoaError(.fileWriteOutOfSpace) })
+            XCTFail("Expected simulated crash")
+        } catch { }
+        let restarted = LibraryRepository(disk: disk)
+        let replayJob = try await restarted.beginJob(libraryID: LibraryRecord.localID, kind: .summary, key: "generate-once", noteID: note.id, identities: [])
+        XCTAssertEqual(replayJob.id, job.id)
+        let replay = try await restarted.commit(output, for: job.id, identities: [])
+        XCTAssertEqual(replay.text, note.text)
+        XCTAssertEqual(replay.ink, note.ink)
+        XCTAssertEqual(replay.title, note.title)
+        XCTAssertEqual(replay.metadata?.summaries, [prior, edited, version])
+        XCTAssertEqual(replay.metadata?.selectedSummaryID, edited.id)
+        let catalog = try await restarted.catalog()
+        XCTAssertEqual(catalog.jobs.first?.state, .completed)
+    }
+
+    func testImportReplayRetainsReservedIdentityAndDoesNotOverwriteUserEdit() async throws {
+        let disk = try store()
+        let repository = LibraryRepository(disk: disk)
+        let job = try await repository.beginJob(libraryID: LibraryRecord.localID, kind: .audioImport, key: "file-hash", identities: [])
+        var output = NoteRecord(id: job.noteID)
+        output.text = "Imported"
+        _ = try await repository.commit(output, for: job.id, identities: [])
+        var edited = output
+        edited.text = "Edited after import"
+        edited.metadata?.revisionID = UUID()
+        try await repository.save(edited, identities: [])
+        let replay = try await LibraryRepository(disk: disk).commit(output, for: job.id, identities: [])
+        XCTAssertEqual(replay.text, edited.text)
+        XCTAssertEqual(try disk.load().notes.count, 1)
+    }
+
+    func testJobCannotCompleteBeforeOutputAndCancellationIsDurable() async throws {
+        let disk = try store()
+        let repository = LibraryRepository(disk: disk)
+        let job = try await repository.beginJob(libraryID: LibraryRecord.localID, kind: .audioImport, key: "input", identities: [])
+        do {
+            _ = try await repository.transitionJob(job.id, to: .completed, identities: [])
+            XCTFail("Completed without durable output")
+        } catch { }
+        _ = try await repository.transitionJob(job.id, to: .running, identities: [])
+        _ = try await repository.transitionJob(job.id, to: .retryable, error: "Interrupted", identities: [])
+        let retry = try await LibraryRepository(disk: disk).beginJob(libraryID: LibraryRecord.localID, kind: .audioImport, key: "input", identities: [])
+        XCTAssertEqual(retry.state, .retryable)
+        XCTAssertEqual(retry.attempts, 1)
+        _ = try await repository.transitionJob(job.id, to: .cancelled, identities: [])
+        do {
+            _ = try await repository.commit(NoteRecord(id: job.noteID), for: job.id, identities: [])
+            XCTFail("Cancelled job committed")
+        } catch { }
+    }
+
+    func testEventOccurrenceIdentityIncludesAccountCalendarAndLibrary() async throws {
+        let disk = try store()
+        let repository = LibraryRepository(disk: disk)
+        let event = EventOccurrenceKey(provider: "google", accountID: "a", calendarID: "c", eventID: "e", occurrenceID: "original-instance")
+        let job = try await repository.beginEventNote(libraryID: LibraryRecord.localID, event: event, identities: [])
+        let replay = try await repository.beginEventNote(libraryID: LibraryRecord.localID, event: event, identities: [])
+        XCTAssertEqual(job.noteID, replay.noteID)
+        let other = EventOccurrenceKey(provider: "google", accountID: "b", calendarID: "c", eventID: "e", occurrenceID: "original-instance")
+        let separate = try await repository.beginEventNote(libraryID: LibraryRecord.localID, event: other, identities: [])
+        XCTAssertNotEqual(job.noteID, separate.noteID)
+    }
+
+    func testEditedSummaryRetainsOriginalAndRejectsInvalidSelection() throws {
+        let disk = try store()
+        var note = NoteRecord()
+        let original = SummaryVersion(id: UUID(), parentID: nil, createdAt: Date(), origin: .generated,
+            format: "meeting", language: .english, text: "Original summary", sources: [])
+        note.metadata?.summaries = [original]
+        try disk.save(note)
+        let edited = SummaryVersion(id: UUID(), parentID: original.id, createdAt: Date(), origin: .edited,
+            format: "meeting", language: .english, text: "Edited summary", sources: [])
+        note.metadata?.summaries.append(edited)
+        note.metadata?.selectedSummaryID = edited.id
+        try disk.save(note)
+        XCTAssertEqual(try disk.load().notes.first?.metadata?.summaries, [original, edited])
+        note.metadata?.selectedSummaryID = UUID()
+        XCTAssertThrowsError(try disk.save(note))
+    }
+
+    func testRetainedSummaryCannotBeChangedOrDuplicatedAndDowngradeRejected() throws {
+        let disk = try store()
+        var note = NoteRecord()
+        let version = SummaryVersion(id: UUID(), parentID: nil, createdAt: Date(), origin: .generated,
+            format: "meeting", language: .english, text: "Original", sources: [])
+        note.metadata?.summaries = [version]
+        try disk.save(note)
+        note.metadata?.summaries = []
+        XCTAssertThrowsError(try disk.save(note))
+        note.metadata?.summaries = [version, version]
+        XCTAssertThrowsError(try disk.save(note))
+        note.schemaVersion = 1
+        XCTAssertThrowsError(try disk.save(note))
+    }
+}
+
+@MainActor final class LibraryEditingTests: XCTestCase {
+    func testLargeRapidEditsCoalesceAndPersistLatestContent() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let library = NoteLibrary(root: root)
+        await library.waitUntilLoaded()
+        let id = try XCTUnwrap(library.create())
+        let ink = Data(repeating: 5, count: 10 * 1024 * 1024)
+        for index in 0..<200 {
+            library.update(id) { $0.text = "Latest edit \(index)"; $0.ink = ink }
+        }
+        XCTAssertLessThanOrEqual(library.pendingSaves, 2)
+        let saved = await library.flush()
+        XCTAssertTrue(saved)
+        XCTAssertLessThanOrEqual(library.completedWrites, 2)
+        let reopened = NoteLibrary(root: root)
+        await reopened.waitUntilLoaded()
+        XCTAssertEqual(reopened.note(id)?.text, "Latest edit 199")
+        XCTAssertEqual(reopened.note(id)?.ink, ink)
+    }
+
+    func testFailedLatestSaveRemainsUnsavedUntilRetrySucceeds() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let library = NoteLibrary(root: root)
+        await library.waitUntilLoaded()
+        let id = try XCTUnwrap(library.create())
+        let first = await library.flush()
+        XCTAssertTrue(first)
+        let dir = try XCTUnwrap(library.disk).directory(for: id)
+        let saved = dir.appendingPathComponent("note.json")
+        let bytes = try Data(contentsOf: saved)
+        try FileManager.default.removeItem(at: saved)
+        try FileManager.default.createDirectory(at: saved, withIntermediateDirectories: false)
+        library.update(id) { $0.text = "Latest must not disappear" }
+        let failed = await library.flush()
+        XCTAssertFalse(failed)
+        XCTAssertNotNil(library.saveProblem)
+        XCTAssertEqual(library.note(id)?.text, "Latest must not disappear")
+        try FileManager.default.removeItem(at: saved)
+        try bytes.write(to: saved)
+        library.retrySaving()
+        let retried = await library.flush()
+        XCTAssertTrue(retried)
+        XCTAssertNil(library.saveProblem)
+        XCTAssertEqual(try library.disk?.load().notes.first?.text, "Latest must not disappear")
+    }
+
+    func testFolderMoveAndSignOutKeepLocalNotesIndependent() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let library = NoteLibrary(root: root)
+        await library.waitUntilLoaded()
+        let localID = try XCTUnwrap(library.create())
+        await library.addFolder("Discovery")
+        let folder = try XCTUnwrap(library.folders.first)
+        library.update(localID) { $0.metadata?.folderID = folder.id }
+        let identity = LibraryIdentity(accountID: "account-a", workspaceID: "workspace-a")
+        try await library.authenticate(identity, name: "Work")
+        let account = try XCTUnwrap(library.libraries.first { $0.identity == identity })
+        library.selectLibrary(account.id)
+        XCTAssertTrue(library.visibleNotes.isEmpty)
+        let accountNote = try XCTUnwrap(library.create())
+        let refused = await library.signOut(identity, captureActive: true)
+        XCTAssertFalse(refused)
+        let signedOut = await library.signOut(identity, captureActive: false)
+        XCTAssertTrue(signedOut)
+        XCTAssertNil(library.note(accountNote))
+        XCTAssertEqual(library.note(localID)?.metadata?.folderID, folder.id)
+        XCTAssertEqual(library.note(localID)?.metadata?.libraryID, LibraryRecord.localID)
+        try await library.authenticate(identity, name: "Work")
+        XCTAssertNotNil(library.note(accountNote))
+    }
+}

--- a/apps/mobile-native/Tests/PreparationTests.swift
+++ b/apps/mobile-native/Tests/PreparationTests.swift
@@ -24,6 +24,7 @@ import XCTest
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: root) }
         let library = NoteLibrary(root: root)
+        await library.waitUntilLoaded()
         let id = try XCTUnwrap(library.create())
         var pending: CheckedContinuation<Bool, Never>?
         let entered = expectation(description: "Permission request entered")

--- a/apps/mobile-native/UITests/NoteEditingTests.swift
+++ b/apps/mobile-native/UITests/NoteEditingTests.swift
@@ -13,6 +13,31 @@ import XCTest
         XCTAssertTrue(app.buttons["Download speaker model"].exists)
         XCTAssertTrue(app.buttons["recordButton"].isEnabled)
     }
+    func testFolderAndSummaryEmptyStatePreservePersonalNote() {
+        let app = XCUIApplication()
+        app.launchArguments = ["--ui-testing"]
+        app.launch()
+        XCTAssertTrue(app.buttons["New folder"].waitForExistence(timeout: 10))
+        app.buttons["New folder"].tap()
+        let name = "Folder \(UUID().uuidString.prefix(6))"
+        app.alerts.textFields.firstMatch.typeText(name)
+        app.alerts.buttons["Create"].tap()
+        app.buttons["newNote"].tap()
+        XCTAssertTrue(app.buttons["noteFolder"].waitForExistence(timeout: 5))
+        app.buttons["noteFolder"].tap()
+        app.buttons[name].firstMatch.tap()
+        XCTAssertTrue(app.buttons["noteFolder"].label.contains(name))
+        app.buttons["Summary"].tap()
+        XCTAssertTrue(app.staticTexts["Summary versions"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Generated summaries will appear here. Your personal notes remain separate."].exists)
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Folder and independent summary pane"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+        app.buttons["Notes"].tap()
+        XCTAssertTrue(app.textViews["personalNotes"].exists)
+    }
+
     func testCreateEditAndRecoverAfterRelaunch() {
         let app = XCUIApplication()
         app.launchArguments = ["--ui-testing"]

--- a/apps/mobile-native/docs/data-contract.md
+++ b/apps/mobile-native/docs/data-contract.md
@@ -1,0 +1,54 @@
+# Versioned local data (ONY-242)
+
+The app retains per-note UUID directories and existing relative `audio/*.caf` paths. Schema 2 adds explicit library/folder ownership, source revision identity, event occurrence identity, and immutable summary versions. This is a local contract; it neither changes the cloud protocol nor authenticates accounts or enables generation/import/calendar providers.
+
+## Ownership
+
+`LibraryRecord.localID` is a fixed local-only identity, always available without an account. Additional libraries require an explicit account ID and workspace ID. `LibraryRepository` validates access against the supplied authenticated identities. The integration layer must supply only identities authenticated by its credential service. A library is never inferred from the current login, and saving an existing note with a different library is rejected.
+
+A signed-out account's records remain on disk but are unavailable through the library and source-resolution APIs until that identity authenticates again. Paused/offline/expired sync transport does not call sign-out or change ownership. Sign-out requires capture to stop, flushes pending edits, and fails if any latest edit remains unsaved. The future credential/sync integration must use this boundary and must not expose raw `NoteDiskStore` as an authorized account reader.
+
+Folders are scoped to a library. Moves change only folder ID; cross-library folder IDs and ownership changes are rejected. The interface defaults to recent-first notes in the selected library and supports optional folders. No user-facing fake login has been added.
+
+## Migration and rollback
+
+For each valid schema 1 document, migration validates the directory UUID against the document ID before writing anything. It saves exact original bytes to `note.schema1.original.json`, then writes `migration-1-to-2.json` with source SHA-256 and versions, then atomically replaces `note.json` with schema 2. The initial revision uses the note UUID so retries retain a stable identity. Audio directories are never moved. Migration retains title, personal text, ink bytes, language, original dates, transcript IDs/times/names, and speaker annotations.
+
+An interrupted migration can be retried: the original backup must match the source bytes. A migration write failure exposes readable legacy content as read-only with an explicit storage-upgrade message. A future version, malformed document, or mismatched directory identity is preserved and reported, never rewritten. Schema downgrade writes over existing documents are rejected.
+
+Rollback is deliberate, not an automatic destructive downgrade: stop the app, copy the entire application-support directory to a safe backup, verify the manifest SHA-256 against `note.schema1.original.json`, preserve the current schema 2 file separately, then restore the original bytes as `note.json` for the older build. This restores the pre-migration snapshot only; post-migration edits and new notes remain in the saved schema 2 copy for later recovery. Do not delete revisions or audio. No production migration or rollback was executed during development.
+
+## Sources and summaries
+
+Source anchors include library, note, revision, and paragraph index or transcript passage UUID. `revisions/<revision UUID>.json` retains immutable source text and speaker annotations. Paragraph indices refer to that immutable revision, not mutable editor text. Existing revision files cannot be overwritten with different content. Transcript timing remains seconds; future sync adapters must explicitly convert the desktop millisecond contract.
+
+Summary versions are independent from personal text and ink. Generated and edited records use distinct IDs, and edited records reference an earlier retained parent. The store rejects removals, modifications, duplicate IDs, dangling selections, and invalid parents. Editing appends a version. A generated result merges into the latest note instead of replacing concurrent personal edits; an existing selected edited version remains selected for review. Source anchors must be persisted before handing them to a job or external consumer: call `flush()` and require success before publishing a revision ID.
+
+## Jobs and event identities
+
+`libraries.json` stores durable job state and a library/kind/idempotency key. A job reserves both its note ID and version ID before work. Retries reuse these IDs. `commit` validates the job and scope, writes output first, then marks complete. A restart between those writes returns the existing output, preserving subsequent user edits and preventing duplicate notes/summary versions. Only `commit` can complete a job; cancellation is terminal. Future workers should inspect running jobs after restart and explicitly transition them to retryable before resuming work. Last errors must contain safe diagnostic categories, never transcript content or credentials.
+
+Event occurrence identity contains provider, provider account, calendar, event, and provider-stable occurrence ID. It excludes mutable display start time. `beginEventNote` scopes its deterministic encoded identity to the selected library, so recurring events, separate accounts, and rescheduling do not accidentally share a note.
+
+## Responsiveness and limits
+
+Initial document loading/migration and durable saves execute on the repository actor, away from the main actor. Editor state updates immediately. Queued snapshots coalesce by note; a rapid burst retains at most one waiting snapshot per note plus the active write. Capture preparation and backgrounding flush the queue. Save failures keep the latest edit in memory, display a retry action, and prevent successful flush/sign-out until persisted.
+
+The stress fixture issues 200 edits with a 10 MiB ink payload without yielding, asserts at most two pending writes, flushes, and reopens the exact latest text/ink. This proves queue bounding and persistence under synthetic simulator load, not physical-device latency. The current implementation still loads the available document set into memory and writes full JSON/ink per durable save. Very large libraries, long recordings, battery/storage pressure, and physical-device performance remain qualification work under ONY-241/265; no database scalability claim is made. Search remains a basic local filter; the complete-history retrieval index is ONY-251.
+
+## Verification and human QA
+
+```sh
+xcodegen generate --spec apps/mobile-native/project.yml
+xcodebuild test -project apps/mobile-native/DoodleNoteNative.xcodeproj -scheme DoodleNoteNative -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /tmp/ony242-derived CODE_SIGNING_ALLOWED=NO
+```
+
+`LibraryContractTests` covers original-byte migration/retry, read-only migration failure, directory identity, immutable citations, ownership/folders, summary/concurrent edits/crash replay, import replay, event identity, versions, and durable job state. `LibraryEditingTests` covers large coalesced edits, failed-save retry, folder ownership, sign-out, and reauthentication. Existing capture/ink/speech/speaker tests remain regression checks. The actual speaker-model smoke test is opt-in and is not accuracy coverage.
+
+Check this:
+
+1. Create a note, type text, draw ink, close/reopen the app. Expect both content types retained; pending saves should clear.
+2. Create a folder from Home, open the note, select that folder, and return to Home. Filtering by the folder should find it without changing its library.
+3. Open Summary in an ordinary local note. Expect a clear empty state, with personal notes preserved. In a fixture with generated versions, edit as a new version and verify the original remains visible.
+4. Load a schema 1 fixture with writable storage; expect preserved dates/text/ink/transcript and original-byte backup. With simulated migration write failure, expect readable but disabled editing and an explicit recovery message.
+5. Review iPhone and iPad layouts and text sizing. Physical Pencil, 2-hour recording and large-library performance qualification remain separate release gates.


### PR DESCRIPTION
## Linear Issue
- [ONY-242](https://linear.app/onyxdevlabs/issue/ONY-242/add-versioned-mobile-libraries-note-history-and-source-anchors)

## Outcome
The fresh native app now keeps explicit library ownership, immutable citation sources and summary history, and durable processing identities. Existing prototype notes migrate with original-byte recovery evidence. Large editor bursts queue coalesced background saves instead of encoding ink on the main actor.

## What Changed
- Schema 2 metadata, local-only and explicit account/workspace libraries, optional folders and recent-first scoped notes.
- Validated original-byte schema-1 backup and migration journal; unreadable/future documents remain unchanged, failed migrations expose read-only content.
- Immutable revision files, stable source anchors, append-only generated/edited summary versions, and provider/account/calendar/occurrence keys.
- Serialized durable jobs reserve output IDs before work and survive a crash between output and completion without duplication or replacing concurrent edits.
- Background initial loading, bounded per-note save coalescing, failed-save retry, capture flush, and expiration-safe background save assertion.
- Folder UI and separate Summary pane with retained edit versions. Actual generation, credentials, calendar providers, and cloud sync remain later issues.

## Bug Evidence / Root Cause
Independent review reproduced a stale summary output overwriting a concurrent personal edit; commit now merges only the reserved summary version into the latest note. Regression fixtures also cover migration-write failures hiding readable notes, implicit ownership changes, malformed metadata overwrites, premature job completion, and a failed latest save falsely appearing persisted.

## Acceptance Criteria Evidence
- [x] Prototype migration preserves original content, dates, passage identities/names, ink bytes and audio paths: migration/original-byte/retry/malformed-identity fixtures, plus existing nonempty Pencil ink round trip.
- [x] Local-only and explicit account/workspace ownership: cross-library folder/write/source rejection and sign-out/reauthentication tests. Signing in never adopts a local note.
- [x] Stable note/revision/source and event identities, retained generated/edited summaries: immutable anchor resolution after edits, summary history/selection, and event-account replay tests.
- [x] Durable state and retry identities: import/summary crash replay, reserved IDs, cancellation, attempts and premature completion rejection tests.
- [x] Recent-first scoped library, folders, separate generated/personal content and responsive persistence: folder/summary UI test and 200-edit/10-MiB-ink stress fixture with bounded writes and exact reopen.
- [ ] Sean's physical-device and product QA. Simulator evidence does not qualify 2-hour sessions or very large real libraries; those release gates remain ONY-241/265.

## Verification
- `xcodegen generate --spec apps/mobile-native/project.yml` passed.
- `TEST_RUNNER_DOODLENOTE_SPEAKER_MODEL=/tmp/doodlenote-sortformer-evaluation/Sortformer_v2.1.mlpackage xcodebuild test -project apps/mobile-native/DoodleNoteNative.xcodeproj -scheme DoodleNoteNative -destination 'platform=iOS Simulator,id=F6067793-A05A-4174-A892-AC5C0F7A2FCB' -derivedDataPath /tmp/ony242-derived CODE_SIGNING_ALLOWED=NO` passed: 39 tests, zero failures/skips, iPhone 17 Pro iOS 26.5.
- Equivalent command with iPad simulator `8EEF4C09-BF6B-4A1E-9416-BFD874E454FA`: passed: 39 tests, zero failures/skips, iPad Pro 11-inch (M5), iOS 26.5.
- `git diff --check` passed.
- [Native mobile CI](https://github.com/Onyx-Dev-Labs/doodle-note/actions/runs/34056068744) passed: 36 unit cases (one explicitly skipped opt-in model) and 3 UI cases, zero failures. All other checks, Windows packaging, CodeQL and Vercel passed at this HEAD.
- The pinned-model test runs synthetic inference only. It does not verify speaker accuracy or language quality. Routine CI omits that opt-in model fixture.

## Local QA
Generate the project using the command above and open `apps/mobile-native/DoodleNoteNative.xcodeproj` in Xcode. Run scheme `DoodleNoteNative` on an iPhone or iPad simulator. Use a fresh local library or synthetic fixtures; no account/network setup is required.

Check this:
1. Create a note with typed text and ink, relaunch, and reopen it. Expect both retained and the saving indicator to clear.
2. Create a folder from Home, move the note with its folder picker, and filter Home by that folder. Expect the note in the same library.
3. Open Summary. An ordinary note shows an honest empty state. In a summary fixture, edit as a new version; expect the original and edit retained, with personal notes unchanged.
4. Open an old fixture with insufficient-storage migration failure. Expect readable Notes/Ink/Transcript navigation and disabled mutation, with original files preserved. Restore writable storage and reopen to retry migration.
5. Exercise a recoverable save failure and Retry saving. Expect the latest visible edit retained and the error to clear only after persistence succeeds.
6. Review iPad split layout and iPhone segmented content, including keyboard and larger text. Physical Pencil and long-session performance are separate qualification gates.

## Risks and Release Notes
Schema migration occurs locally when the app opens its data. Exact schema-1 bytes and a SHA-256 migration journal are retained; `docs/data-contract.md` documents deliberate rollback without deleting schema-2 edits. No production/server migration, cloud protocol change, account sign-in UI, release, signing, or store submission is included.

The repository actor serializes writes, but full note JSON/ink is still written per durable save and available documents remain in memory. Large-library/long-recording resource qualification is explicitly pending. Callers must flush a source revision before publishing its anchors. Future authentication adapters must supply verified identities and stop capture before explicit sign-out; sync pause/offline/lapse must not sign out or reassign notes.

## Follow-ups
Continue dependent issues only after this PR reaches its required merge boundary. Complete-history retrieval/indexing is ONY-251; generation is ONY-250; provider/calendar and cloud integrations retain their own issue scope. No historical `apps/ios` source was used or edited.
