### PR TITLE
[ONY-254] Add native multi-account calendar contracts and secure credentials

### DIFF
--- a/apps/mobile-native/Sources/Calendar/CalendarAccountStore.swift
+++ b/apps/mobile-native/Sources/Calendar/CalendarAccountStore.swift
@@ -1,0 +1,225 @@
+import Foundation
+
+actor CalendarAccountStore {
+    private struct Cache: Codable { var version = 1; var connections: [CalendarConnection] = [] }
+    private let file: URL
+    private let credentials: any CalendarCredentialStore
+    private var cache: Cache
+    private var attempts: [CalendarProvider: UUID] = [:]
+    private var generations: [CalendarAccountKey: UUID] = [:]
+    private var refreshing: [CalendarAccountKey: UUID] = [:]
+    private var retries: [CalendarAccountKey: Int] = [:]
+    private let persist: @Sendable (Data, URL) throws -> Void
+
+    init(directory: URL, credentials: any CalendarCredentialStore = KeychainCalendarCredentials(),
+         persist: @escaping @Sendable (Data, URL) throws -> Void = { data, url in
+             try data.write(to: url, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+         }) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication])
+        var directory = directory
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try directory.setResourceValues(values)
+        file = directory.appendingPathComponent("calendar-cache.json")
+        self.credentials = credentials
+        self.persist = persist
+        if FileManager.default.fileExists(atPath: file.path) {
+            cache = try JSONDecoder().decode(Cache.self, from: Data(contentsOf: file))
+            guard cache.version == 1, Set(cache.connections.map(\.account)).count == cache.connections.count else {
+                throw CalendarFailure.storage
+            }
+            for connection in cache.connections {
+                guard !connection.account.subject.isEmpty,
+                      connection.events.allSatisfy({ $0.key.provider == connection.account.provider.rawValue && $0.key.accountID == connection.account.subject }),
+                      Set(connection.calendars.map(\.id)).count == connection.calendars.count else { throw CalendarFailure.storage }
+                if let window = connection.window { _ = try CalendarWindow(start: window.start, end: window.end) }
+            }
+        } else { cache = Cache() }
+    }
+
+    func snapshots() -> [CalendarConnection] { cache.connections }
+    func connecting() -> Set<CalendarProvider> { Set(attempts.keys) }
+    func isRefreshing(_ account: CalendarAccountKey) -> Bool { refreshing[account] != nil }
+
+    private func commit(_ candidate: Cache) throws {
+        do { try persist(JSONEncoder().encode(candidate), file); cache = candidate }
+        catch { throw CalendarFailure.storage }
+    }
+
+    func cancelConnect(_ provider: CalendarProvider) { attempts.removeValue(forKey: provider) }
+
+    @discardableResult
+    func connect(using adapter: any CalendarProviderAdapter, existing: CalendarAccountKey? = nil) async throws -> CalendarAccountKey {
+        guard existing == nil || (existing?.provider == adapter.provider && cache.connections.contains(where: {
+            $0.account == existing && $0.state != .disconnecting
+        })) else { throw CalendarFailure.invalidResponse }
+        let ticket = UUID()
+        attempts[adapter.provider] = ticket
+        defer { if attempts[adapter.provider] == ticket { attempts.removeValue(forKey: adapter.provider) } }
+        do {
+            let result = try await adapter.authorize(existing: existing)
+            guard attempts[adapter.provider] == ticket, !Task.isCancelled else { throw CalendarFailure.cancelled }
+            guard result.account.provider == adapter.provider, !result.account.subject.isEmpty, result.account.subject.utf8.count <= 2048, result.displayName.utf8.count <= 1024,
+                  existing == nil || existing == result.account,
+                  !cache.connections.contains(where: { $0.account == result.account && $0.state == .disconnecting }) else {
+                throw CalendarFailure.invalidResponse
+            }
+            let isNew = !cache.connections.contains { $0.account == result.account }
+            if isNew {
+                // Persist cleanup intent before any Keychain write, so failed rollback remains retryable after restart.
+                var intent = cache
+                var pending = CalendarConnection(account: result.account, displayName: result.displayName)
+                pending.state = .disconnecting
+                intent.connections.append(pending)
+                try commit(intent)
+            }
+            generations[result.account] = UUID()
+            do {
+                try credentials.write(result.credential, for: result.account)
+                var candidate = cache
+                guard let i = candidate.connections.firstIndex(where: { $0.account == result.account }) else { throw CalendarFailure.storage }
+                candidate.connections[i].displayName = result.displayName
+                candidate.connections[i].state = .connected
+                candidate.connections[i].failure = nil
+                try commit(candidate)
+            } catch {
+                if isNew { try? disconnect(result.account) }
+                // Reauth retains the fresh credential under the existing account if cache persistence fails.
+                throw CalendarFailure.storage
+            }
+            generations[result.account] = UUID()
+            return result.account
+        } catch { throw CalendarFailure.safe(error) }
+    }
+
+    /// Durable disconnect intent precedes removal. Failure leaves a retryable, unusable account.
+    /// Caller can retry these on launch; this store has no note-directory access.
+    func disconnect(_ account: CalendarAccountKey) throws {
+        attempts.removeValue(forKey: account.provider)
+        generations[account] = UUID()
+        refreshing.removeValue(forKey: account)
+        guard let i = cache.connections.firstIndex(where: { $0.account == account }) else {
+            try credentials.remove(account)
+            return
+        }
+        var candidate = cache
+        candidate.connections[i].state = .disconnecting
+        candidate.connections[i].events = []
+        candidate.connections[i].calendars = []
+        candidate.connections[i].selectedCalendarIDs = nil
+        candidate.connections[i].window = nil
+        try commit(candidate)
+        try credentials.remove(account)
+        candidate.connections.removeAll { $0.account == account }
+        try commit(candidate)
+        retries.removeValue(forKey: account)
+    }
+
+    func finishPendingDisconnects() throws {
+        for account in cache.connections.filter({ $0.state == .disconnecting }).map(\.account) { try disconnect(account) }
+    }
+
+    func select(_ ids: Set<String>?, for account: CalendarAccountKey) throws {
+        guard let i = cache.connections.firstIndex(where: { $0.account == account && $0.state != .disconnecting }),
+              ids.map({ $0.isSubset(of: Set(cache.connections[i].calendars.map(\.id))) }) ?? true else {
+            throw CalendarFailure.invalidResponse
+        }
+        generations[account] = UUID()
+        var candidate = cache
+        candidate.connections[i].selectedCalendarIDs = ids
+        // An old selection's response cannot overwrite this preference or show hidden calendars.
+        let selected = ids ?? Set(candidate.connections[i].calendars.filter(\.isDefault).map(\.id))
+        candidate.connections[i].events.removeAll { !selected.contains($0.key.calendarID) }
+        try commit(candidate)
+    }
+
+    /// Coalesces simultaneous refreshes per account. Cross-account reads remain independent.
+    func refresh(_ account: CalendarAccountKey, using adapter: any CalendarProviderAdapter,
+                 window: CalendarWindow, now: Date = Date()) async throws {
+        _ = try CalendarWindow(start: window.start, end: window.end)
+        guard adapter.provider == account.provider,
+              let initial = cache.connections.first(where: { $0.account == account && $0.state == .connected }) else {
+            throw CalendarFailure.reauthenticationRequired
+        }
+        if case .rateLimited(let retryAt) = initial.failure, now < retryAt { throw CalendarFailure.rateLimited(retryAt: retryAt) }
+        guard refreshing[account] == nil else { return }
+        let generation = generations[account] ?? UUID()
+        generations[account] = generation
+        let refreshTicket = UUID()
+        refreshing[account] = refreshTicket
+        defer { if refreshing[account] == refreshTicket { refreshing.removeValue(forKey: account) } }
+        do {
+            guard let oldSecret = try credentials.read(account) else { throw CalendarFailure.reauthenticationRequired }
+            let secret = try await adapter.renewCredential(account: account, credential: oldSecret)
+            try ensureCurrent(account, generation)
+            try credentials.write(secret, for: account)
+            let calendars = try await adapter.calendars(account: account, credential: secret)
+            guard calendars.count <= 1000, Set(calendars.map(\.id)).count == calendars.count, calendars.allSatisfy({ !$0.id.isEmpty && $0.id.utf8.count <= 2048 && $0.name.utf8.count <= 4096 }) else {
+                throw CalendarFailure.invalidResponse
+            }
+            let selected = initial.selectedCalendarIDs ?? Set(calendars.filter(\.isDefault).map(\.id))
+            var events: [CalendarOccurrence] = []
+            var cursors: Set<String> = []
+            var cursor: String? = nil
+            if !selected.isEmpty {
+                repeat {
+                    try ensureCurrent(account, generation)
+                    let page = try await adapter.events(account: account, credential: secret, calendarIDs: selected,
+                                                        window: window, cursor: cursor)
+                    guard page.events.count <= 20_000 else { throw CalendarFailure.invalidResponse }
+                    events.append(contentsOf: page.events)
+                    cursor = page.next
+                    if let cursor {
+                        guard cursors.insert(cursor).inserted, cursors.count < 100 else { throw CalendarFailure.invalidResponse }
+                    }
+                    guard events.count <= 20_000 else { throw CalendarFailure.invalidResponse }
+                } while cursor != nil
+            }
+            try ensureCurrent(account, generation)
+            guard events.allSatisfy({ event in
+                event.key.provider == account.provider.rawValue && event.key.accountID == account.subject &&
+                selected.contains(event.key.calendarID) && !event.key.eventID.isEmpty && !event.key.occurrenceID.isEmpty &&
+                event.key.eventID.utf8.count <= 4096 && event.key.occurrenceID.utf8.count <= 4096 && event.title.utf8.count <= 16_384 &&
+                event.start.timeIntervalSince1970.isFinite && event.end.timeIntervalSince1970.isFinite &&
+                event.end > event.start && event.end > window.start && event.start < window.end && TimeZone(identifier: event.timeZoneID) != nil
+            }) else { throw CalendarFailure.invalidResponse }
+            var candidate = cache
+            guard let i = candidate.connections.firstIndex(where: { $0.account == account }) else { throw CalendarFailure.cancelled }
+            candidate.connections[i].calendars = calendars
+            // Page-boundary duplicates are acceptable; conflicting copies are rejected.
+            var unique: [EventOccurrenceKey: CalendarOccurrence] = [:]
+            for event in events {
+                guard unique[event.key] == nil || unique[event.key] == event else { throw CalendarFailure.invalidResponse }
+                unique[event.key] = event
+            }
+            candidate.connections[i].events = unique.values.sorted { $0.start < $1.start }
+            candidate.connections[i].window = window
+            candidate.connections[i].refreshedAt = now
+            candidate.connections[i].failure = nil
+            try commit(candidate)
+            retries[account] = 0
+        } catch {
+            let safe = CalendarFailure.safe(error)
+            guard generations[account] == generation else { throw CalendarFailure.cancelled }
+            var candidate = cache
+            if let i = candidate.connections.firstIndex(where: { $0.account == account && $0.state == .connected }) {
+                if safe == .reauthenticationRequired { candidate.connections[i].state = .reauthenticationRequired }
+                if safe == .transient {
+                    let attempt = min((retries[account] ?? 0) + 1, 8)
+                    retries[account] = attempt
+                    candidate.connections[i].failure = .rateLimited(retryAt: now.addingTimeInterval(min(pow(2, Double(attempt)), 300)))
+                } else { candidate.connections[i].failure = safe }
+                try commit(candidate)
+            }
+            throw safe
+        }
+    }
+
+    private func ensureCurrent(_ account: CalendarAccountKey, _ generation: UUID) throws {
+        guard !Task.isCancelled, generations[account] == generation,
+              cache.connections.contains(where: { $0.account == account && $0.state == .connected }) else {
+            throw CalendarFailure.cancelled
+        }
+    }
+}

--- a/apps/mobile-native/Sources/Calendar/CalendarContracts.swift
+++ b/apps/mobile-native/Sources/Calendar/CalendarContracts.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+enum CalendarProvider: String, Codable, CaseIterable, Sendable { case google, microsoft }
+
+struct CalendarAccountKey: Codable, Hashable, Sendable {
+    let provider: CalendarProvider
+    /// Stable provider subject (Microsoft tenant + object ID), never display email.
+    let subject: String
+    var storageKey: String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        return (try! encoder.encode(self)).base64EncodedString()
+    }
+}
+
+struct CalendarDescriptor: Codable, Equatable, Sendable {
+    let id: String
+    let name: String
+    let isDefault: Bool
+}
+
+struct CalendarOccurrence: Codable, Equatable, Sendable {
+    let key: EventOccurrenceKey
+    let title: String
+    let start: Date
+    let end: Date
+    /// All-day dates retain the originating zone, never interpreted in the device zone.
+    let timeZoneID: String
+    let isAllDay: Bool
+}
+
+struct CalendarWindow: Codable, Equatable, Sendable {
+    let start: Date
+    let end: Date
+    init(start: Date, end: Date) throws {
+        guard start.timeIntervalSince1970.isFinite, end.timeIntervalSince1970.isFinite,
+              end > start, end.timeIntervalSince(start) <= 32 * 86400 else { throw CalendarFailure.invalidResponse }
+        self.start = start
+        self.end = end
+    }
+}
+
+struct CalendarPage: Sendable {
+    let events: [CalendarOccurrence]
+    /// Adapter-owned opaque pagination cursor. Never persist or log it.
+    let next: String?
+}
+
+struct CalendarSecret: Sendable, CustomStringConvertible, CustomDebugStringConvertible {
+    let data: Data
+    var description: String { "<calendar credential>" }
+    var debugDescription: String { description }
+}
+
+struct CalendarAuthorization: Sendable {
+    let account: CalendarAccountKey
+    let displayName: String
+    let credential: CalendarSecret
+}
+
+/// No event mutation/invitation methods. Adapters own OAuth/PKCE, token refresh and provider normalization.
+protocol CalendarProviderAdapter: Sendable {
+    var provider: CalendarProvider { get }
+    func authorize(existing: CalendarAccountKey?) async throws -> CalendarAuthorization
+    func renewCredential(account: CalendarAccountKey, credential: CalendarSecret) async throws -> CalendarSecret
+    func calendars(account: CalendarAccountKey, credential: CalendarSecret) async throws -> [CalendarDescriptor]
+    func events(account: CalendarAccountKey, credential: CalendarSecret, calendarIDs: Set<String>,
+                window: CalendarWindow, cursor: String?) async throws -> CalendarPage
+}
+
+enum CalendarFailure: Error, Codable, Equatable, Sendable {
+    case cancelled, offline, reauthenticationRequired, invalidResponse, storage, unavailable
+    case rateLimited(retryAt: Date)
+    case transient
+
+    static func safe(_ error: Error) -> CalendarFailure {
+        if error is CancellationError { return .cancelled }
+        return error as? CalendarFailure ?? .unavailable
+    }
+}
+
+struct CalendarConnection: Codable, Equatable, Sendable {
+    enum State: String, Codable, Sendable { case connected, reauthenticationRequired, disconnecting }
+    let account: CalendarAccountKey
+    var displayName: String
+    var state: State = .connected
+    /// nil chooses provider defaults; empty deliberately hides all calendars.
+    var selectedCalendarIDs: Set<String>? = nil
+    var calendars: [CalendarDescriptor] = []
+    var events: [CalendarOccurrence] = []
+    var window: CalendarWindow? = nil
+    var refreshedAt: Date? = nil
+    var failure: CalendarFailure? = nil
+}
+
+/// Reject ambiguous timestamps instead of silently assigning the current device timezone.
+enum CalendarDateNormalizer {
+    static func instant(_ iso: String) throws -> Date {
+        guard iso.range(of: #"(Z|[+-]\d{2}:\d{2})$"#, options: .regularExpression) != nil else {
+            throw CalendarFailure.invalidResponse
+        }
+        let format = ISO8601DateFormatter()
+        format.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let value = format.date(from: iso) { return value }
+        format.formatOptions = [.withInternetDateTime]
+        guard let value = format.date(from: iso) else { throw CalendarFailure.invalidResponse }
+        return value
+    }
+
+    static func day(_ date: String, timeZoneID: String) throws -> Date {
+        guard let zone = TimeZone(identifier: timeZoneID) else { throw CalendarFailure.invalidResponse }
+        let format = DateFormatter()
+        format.locale = Locale(identifier: "en_US_POSIX")
+        format.calendar = Calendar(identifier: .gregorian)
+        format.timeZone = zone
+        format.dateFormat = "yyyy-MM-dd"
+        format.isLenient = false
+        guard let value = format.date(from: date), format.string(from: value) == date else {
+            throw CalendarFailure.invalidResponse
+        }
+        return value
+    }
+}

--- a/apps/mobile-native/Sources/Calendar/CalendarCredentialStore.swift
+++ b/apps/mobile-native/Sources/Calendar/CalendarCredentialStore.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Security
+
+/// Synchronous operations run only on CalendarAccountStore's actor, with no suspension between credential/cache commits.
+protocol CalendarCredentialStore: Sendable {
+    func read(_ account: CalendarAccountKey) throws -> CalendarSecret?
+    func write(_ credential: CalendarSecret, for account: CalendarAccountKey) throws
+    func remove(_ account: CalendarAccountKey) throws
+}
+
+struct CalendarKeychainFailure: Error { let status: OSStatus }
+
+struct KeychainCalendarCredentials: CalendarCredentialStore {
+    let service: String
+    init(service: String = "ai.doodlenote.native.calendar") { self.service = service }
+
+    private func query(_ account: CalendarAccountKey) -> [String: Any] {
+        [kSecClass as String: kSecClassGenericPassword, kSecAttrService as String: service,
+         kSecAttrAccount as String: account.storageKey, kSecAttrSynchronizable as String: false]
+    }
+    func read(_ account: CalendarAccountKey) throws -> CalendarSecret? {
+        var query = query(account)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var value: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &value)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess, let data = value as? Data else { throw CalendarKeychainFailure(status: status) }
+        return CalendarSecret(data: data)
+    }
+    func write(_ credential: CalendarSecret, for account: CalendarAccountKey) throws {
+        let attributes: [String: Any] = [kSecValueData as String: credential.data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly]
+        let status = SecItemUpdate(query(account) as CFDictionary, attributes as CFDictionary)
+        if status == errSecItemNotFound {
+            var item = query(account)
+            attributes.forEach { item[$0.key] = $0.value }
+            let added = SecItemAdd(item as CFDictionary, nil)
+            guard added == errSecSuccess else { throw CalendarKeychainFailure(status: added) }
+        } else if status != errSecSuccess { throw CalendarKeychainFailure(status: status) }
+    }
+    func remove(_ account: CalendarAccountKey) throws {
+        let status = SecItemDelete(query(account) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else { throw CalendarKeychainFailure(status: status) }
+    }
+}

--- a/apps/mobile-native/Sources/Calendar/CalendarPreview.swift
+++ b/apps/mobile-native/Sources/Calendar/CalendarPreview.swift
@@ -1,0 +1,98 @@
+#if DEBUG
+import SwiftUI
+
+/// Preview-only adapter. Never used by the app's production account flow.
+actor CalendarFixtureAdapter: CalendarProviderAdapter {
+    nonisolated let provider: CalendarProvider
+    let subject: String
+    var failure: CalendarFailure?
+    init(provider: CalendarProvider, subject: String) { self.provider = provider; self.subject = subject }
+    func setFailure(_ failure: CalendarFailure?) { self.failure = failure }
+    func authorize(existing: CalendarAccountKey?) async throws -> CalendarAuthorization {
+        CalendarAuthorization(account: CalendarAccountKey(provider: provider, subject: subject),
+            displayName: "Fixture \(provider.rawValue) \(subject)", credential: CalendarSecret(data: Data("preview-only".utf8)))
+    }
+    func renewCredential(account: CalendarAccountKey, credential: CalendarSecret) async throws -> CalendarSecret { credential }
+    func calendars(account: CalendarAccountKey, credential: CalendarSecret) async throws -> [CalendarDescriptor] {
+        if let failure { throw failure }
+        return [CalendarDescriptor(id: "primary", name: "Fixture calendar", isDefault: true)]
+    }
+    func events(account: CalendarAccountKey, credential: CalendarSecret, calendarIDs: Set<String>, window: CalendarWindow, cursor: String?) async throws -> CalendarPage {
+        CalendarPage(events: [CalendarOccurrence(key: EventOccurrenceKey(provider: provider.rawValue,
+            accountID: subject, calendarID: "primary", eventID: "fixture", occurrenceID: "original-occurrence"),
+            title: "Fixture planning meeting", start: window.start, end: window.end, timeZoneID: "UTC", isAllDay: false)], next: nil)
+    }
+}
+
+private final class PreviewCalendarCredentials: CalendarCredentialStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [CalendarAccountKey: CalendarSecret] = [:]
+    func read(_ account: CalendarAccountKey) throws -> CalendarSecret? { lock.withLock { values[account] } }
+    func write(_ credential: CalendarSecret, for account: CalendarAccountKey) throws { lock.withLock { values[account] = credential } }
+    func remove(_ account: CalendarAccountKey) throws { lock.withLock { values.removeValue(forKey: account) } }
+}
+
+struct CalendarContractPreview: View {
+    @State private var store: CalendarAccountStore?
+    @State private var snapshots: [CalendarConnection] = []
+    @State private var message = "Fixture only. No network or real accounts."
+    private let first = CalendarFixtureAdapter(provider: .google, subject: "A")
+    private let second = CalendarFixtureAdapter(provider: .microsoft, subject: "B")
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Text(message)
+                Button("Connect fixture accounts") { run { store in
+                    _ = try await store.connect(using: first)
+                    _ = try await store.connect(using: second)
+                } }
+                Button("Refresh fixtures") { run { store in
+                    for adapter in [first, second] {
+                        await adapter.setFailure(nil)
+                        try await store.refresh(CalendarAccountKey(provider: adapter.provider, subject: adapter.subject), using: adapter,
+                            window: CalendarWindow(start: Date(), end: Date().addingTimeInterval(3600)))
+                    }
+                } }
+                ForEach(snapshots, id: \.account) { connection in
+                    Section(connection.displayName) {
+                        Text("State: \(connection.state.rawValue), cached events: \(connection.events.count)")
+                        ForEach(connection.events, id: \.key) { Text($0.title) }
+                        Button("Simulate offline refresh") { run { store in
+                            let adapter = connection.account.provider == .google ? first : second
+                            await adapter.setFailure(.offline)
+                            try await store.refresh(connection.account, using: adapter,
+                                window: CalendarWindow(start: Date(), end: Date().addingTimeInterval(3600)))
+                        } }
+                        Button("Require reauthentication") { run { store in
+                            let adapter = connection.account.provider == .google ? first : second
+                            await adapter.setFailure(.reauthenticationRequired)
+                            try await store.refresh(connection.account, using: adapter,
+                                window: CalendarWindow(start: Date(), end: Date().addingTimeInterval(3600)))
+                        } }
+                        Button("Reauthenticate") { run { store in
+                            let adapter = connection.account.provider == .google ? first : second
+                            await adapter.setFailure(nil)
+                            _ = try await store.connect(using: adapter, existing: connection.account)
+                        } }
+                        Button("Disconnect account") { run { try await $0.disconnect(connection.account) } }
+                    }
+                }
+            }.navigationTitle("Calendar contract fixture")
+        }.task {
+            do { store = try CalendarAccountStore(directory: FileManager.default.temporaryDirectory.appendingPathComponent("calendar-preview-\(UUID())"), credentials: PreviewCalendarCredentials()) }
+            catch { message = "Fixture storage unavailable" }
+        }
+    }
+    private func run(_ operation: @escaping @MainActor (CalendarAccountStore) async throws -> Void) {
+        Task {
+            guard let store else { return }
+            do { try await operation(store); message = "Fixture operation completed" }
+            catch { message = "Fixture result: \(CalendarFailure.safe(error))" }
+            snapshots = await store.snapshots()
+        }
+    }
+}
+
+#Preview { CalendarContractPreview() }
+#endif

--- a/apps/mobile-native/Tests/CalendarContractTests.swift
+++ b/apps/mobile-native/Tests/CalendarContractTests.swift
@@ -1,0 +1,296 @@
+import XCTest
+@testable import DoodleNoteNative
+
+final class MemoryCalendarCredentials: CalendarCredentialStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [CalendarAccountKey: CalendarSecret] = [:]
+    var removalFails = false
+    func read(_ account: CalendarAccountKey) throws -> CalendarSecret? { lock.withLock { values[account] } }
+    func write(_ credential: CalendarSecret, for account: CalendarAccountKey) throws { lock.withLock { values[account] = credential } }
+    func remove(_ account: CalendarAccountKey) throws {
+        try lock.withLock {
+            if removalFails { throw CalendarFailure.storage }
+            values.removeValue(forKey: account)
+        }
+    }
+}
+
+actor MockCalendarAdapter: CalendarProviderAdapter {
+    nonisolated let provider: CalendarProvider
+    let subject: String
+    var failure: CalendarFailure?
+    var suspended = false
+    var continuation: CheckedContinuation<CalendarAuthorization, Error>?
+    var pendingRead: CheckedContinuation<[CalendarDescriptor], Error>?
+    var suspendRead = false
+    var suspendRenew = false
+    var pendingRenew: CheckedContinuation<CalendarSecret, Error>?
+    func pauseRenew() { suspendRenew = true }
+    func waitingRenew() -> Bool { pendingRenew != nil }
+    func resumeRenew() { pendingRenew?.resume(returning: CalendarSecret(data: Data("stale-rotation".utf8))); pendingRenew = nil }
+    var pageCalls = 0
+    var seenCredentials: [Data] = []
+    init(_ provider: CalendarProvider, subject: String = "subject") { self.provider = provider; self.subject = subject }
+    func configure(failure: CalendarFailure? = nil, suspended: Bool = false, suspendRead: Bool = false) {
+        self.failure = failure; self.suspended = suspended; self.suspendRead = suspendRead
+    }
+    func authorization() -> CalendarAuthorization {
+        CalendarAuthorization(account: CalendarAccountKey(provider: provider, subject: subject), displayName: "Fixture account",
+                              credential: CalendarSecret(data: Data("fixture-secret-never-in-cache".utf8)))
+    }
+    func authorize(existing: CalendarAccountKey?) async throws -> CalendarAuthorization {
+        if suspended { return try await withCheckedThrowingContinuation { continuation = $0 } }
+        if let failure { throw failure }
+        return authorization()
+    }
+    func resumeAuthorization() { continuation?.resume(returning: authorization()); continuation = nil }
+    func waiting() -> Bool { continuation != nil }
+    func waitingRead() -> Bool { pendingRead != nil }
+    func renewCredential(account: CalendarAccountKey, credential: CalendarSecret) async throws -> CalendarSecret {
+        if suspendRenew { return try await withCheckedThrowingContinuation { pendingRenew = $0 } }
+        return CalendarSecret(data: Data("rotated-fixture".utf8))
+    }
+    func calendars(account: CalendarAccountKey, credential: CalendarSecret) async throws -> [CalendarDescriptor] {
+        seenCredentials.append(credential.data)
+        if suspendRead { return try await withCheckedThrowingContinuation { pendingRead = $0 } }
+        if let failure { throw failure }
+        return [CalendarDescriptor(id: "primary", name: "Calendar", isDefault: true)]
+    }
+    func resumeRead() {
+        pendingRead?.resume(returning: [CalendarDescriptor(id: "primary", name: "Calendar", isDefault: true)])
+        pendingRead = nil
+    }
+    func events(account: CalendarAccountKey, credential: CalendarSecret, calendarIDs: Set<String>,
+                window: CalendarWindow, cursor: String?) async throws -> CalendarPage {
+        seenCredentials.append(credential.data)
+        pageCalls += 1
+        return CalendarPage(events: [CalendarOccurrence(key: EventOccurrenceKey(provider: provider.rawValue,
+            accountID: subject, calendarID: "primary", eventID: "event", occurrenceID: cursor ?? "first"),
+            title: "Fixture meeting", start: window.start, end: window.end, timeZoneID: "America/Chicago", isAllDay: false)],
+            next: cursor == nil ? "second" : nil)
+    }
+}
+
+final class CalendarContractTests: XCTestCase {
+    func root() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+    func window() throws -> CalendarWindow { try CalendarWindow(start: Date(timeIntervalSince1970: 100), end: Date(timeIntervalSince1970: 200)) }
+
+    func testBothProviderAdaptersSatisfyMultiAccountCacheContract() async throws {
+        for provider in CalendarProvider.allCases {
+            let directory = try root()
+            let secrets = MemoryCalendarCredentials()
+            let store = try CalendarAccountStore(directory: directory, credentials: secrets)
+            let first = MockCalendarAdapter(provider, subject: "a")
+            let second = MockCalendarAdapter(provider, subject: "b")
+            let a = try await store.connect(using: first)
+            let b = try await store.connect(using: second)
+            try await store.refresh(a, using: first, window: window())
+            try await store.refresh(b, using: second, window: window())
+            XCTAssertEqual(try secrets.read(a)?.data, Data("rotated-fixture".utf8))
+            let seen = await first.seenCredentials
+            XCTAssertTrue(seen.allSatisfy { $0 == Data("rotated-fixture".utf8) })
+            try await store.select([], for: a)
+            let reopened = try CalendarAccountStore(directory: directory, credentials: secrets)
+            let snapshots = await reopened.snapshots()
+            XCTAssertEqual(snapshots.count, 2)
+            XCTAssertEqual(snapshots.first { $0.account == a }?.events.count, 0)
+            XCTAssertEqual(snapshots.first { $0.account == b }?.events.count, 2)
+            XCTAssertFalse(String(decoding: try Data(contentsOf: directory.appendingPathComponent("calendar-cache.json")), as: UTF8.self).contains("fixture-secret"))
+            await second.configure(failure: .offline)
+            do { try await reopened.refresh(b, using: second, window: window()); XCTFail() } catch { XCTAssertEqual(error as? CalendarFailure, .offline) }
+            let offline = await reopened.snapshots()
+            XCTAssertEqual(offline.first { $0.account == b }?.events.count, 2)
+            try await reopened.disconnect(a)
+            XCTAssertNil(try secrets.read(a))
+            XCTAssertNotNil(try secrets.read(b))
+            let remaining = await reopened.snapshots()
+            XCTAssertEqual(remaining.map(\.account), [b])
+        }
+    }
+
+    func testCanceledAuthorizationCannotRestoreDisconnectedAccount() async throws {
+        let store = try CalendarAccountStore(directory: root(), credentials: MemoryCalendarCredentials())
+        let adapter = MockCalendarAdapter(.google)
+        await adapter.configure(suspended: true)
+        let task = Task { try await store.connect(using: adapter) }
+        while !(await adapter.waiting()) { await Task.yield() }
+        await store.cancelConnect(.google)
+        await adapter.resumeAuthorization()
+        do { _ = try await task.value; XCTFail() } catch { XCTAssertEqual(error as? CalendarFailure, .cancelled) }
+        let values = await store.snapshots()
+        XCTAssertTrue(values.isEmpty)
+    }
+
+    func testDisconnectInvalidatesInFlightRefreshAndRetriesFailedCredentialRemoval() async throws {
+        let directory = try root()
+        let secrets = MemoryCalendarCredentials()
+        let store = try CalendarAccountStore(directory: directory, credentials: secrets)
+        let adapter = MockCalendarAdapter(.microsoft)
+        let account = try await store.connect(using: adapter)
+        await adapter.configure(suspendRead: true)
+        let window = try window()
+        let task = Task { try await store.refresh(account, using: adapter, window: window) }
+        while !(await adapter.waitingRead()) { await Task.yield() }
+        secrets.removalFails = true
+        do { try await store.disconnect(account); XCTFail() } catch { XCTAssertEqual(error as? CalendarFailure, .storage) }
+        await adapter.resumeRead()
+        do { try await task.value; XCTFail() } catch { XCTAssertEqual(error as? CalendarFailure, .cancelled) }
+        let pending = await store.snapshots()
+        XCTAssertEqual(pending.first?.state, .disconnecting)
+        XCTAssertEqual(pending.first?.events, [])
+        secrets.removalFails = false
+        let reopened = try CalendarAccountStore(directory: directory, credentials: secrets)
+        try await reopened.finishPendingDisconnects()
+        let values = await reopened.snapshots()
+        XCTAssertTrue(values.isEmpty)
+        XCTAssertNil(try secrets.read(account))
+    }
+
+    func testReauthenticationPreservesSubjectPreferencesAndRateLimit() async throws {
+        let store = try CalendarAccountStore(directory: root(), credentials: MemoryCalendarCredentials())
+        let adapter = MockCalendarAdapter(.google)
+        let account = try await store.connect(using: adapter)
+        try await store.refresh(account, using: adapter, window: window())
+        try await store.select([], for: account)
+        await adapter.configure(failure: .reauthenticationRequired)
+        do { try await store.refresh(account, using: adapter, window: window()); XCTFail() } catch {}
+        await adapter.configure()
+        let same = try await store.connect(using: adapter, existing: account)
+        XCTAssertEqual(same, account)
+        let values = await store.snapshots()
+        XCTAssertEqual(values.first?.selectedCalendarIDs, [])
+        let retry = Date().addingTimeInterval(120)
+        await adapter.configure(failure: .rateLimited(retryAt: retry))
+        do { try await store.refresh(account, using: adapter, window: window()); XCTFail() } catch {}
+        await adapter.configure()
+        do { try await store.refresh(account, using: adapter, window: window()); XCTFail() } catch {
+            XCTAssertEqual(error as? CalendarFailure, .rateLimited(retryAt: retry))
+        }
+    }
+
+    func testFailedConnectLeavesDurableCleanupIntent() async throws {
+        let directory = try root()
+        let secrets = MemoryCalendarCredentials()
+        secrets.removalFails = true
+        let writer = FailingCalendarWriter()
+        let store = try CalendarAccountStore(directory: directory, credentials: secrets, persist: writer.write)
+        let adapter = MockCalendarAdapter(.google)
+        do { _ = try await store.connect(using: adapter); XCTFail() } catch { XCTAssertEqual(error as? CalendarFailure, .storage) }
+        let pending = await store.snapshots()
+        XCTAssertEqual(pending.first?.state, .disconnecting)
+        secrets.removalFails = false
+        let reopened = try CalendarAccountStore(directory: directory, credentials: secrets)
+        try await reopened.finishPendingDisconnects()
+        let values = await reopened.snapshots()
+        XCTAssertTrue(values.isEmpty)
+        XCTAssertNil(try secrets.read(CalendarAccountKey(provider: .google, subject: "subject")))
+    }
+
+    func testOldRefreshCannotClearNewRefreshAfterReconnect() async throws {
+        let store = try CalendarAccountStore(directory: root(), credentials: MemoryCalendarCredentials())
+        let old = MockCalendarAdapter(.google)
+        let account = try await store.connect(using: old)
+        await old.configure(suspendRead: true)
+        let window = try window()
+        let first = Task { try await store.refresh(account, using: old, window: window) }
+        while !(await old.waitingRead()) { await Task.yield() }
+        try await store.disconnect(account)
+        let new = MockCalendarAdapter(.google)
+        _ = try await store.connect(using: new)
+        await new.configure(suspendRead: true)
+        let second = Task { try await store.refresh(account, using: new, window: window) }
+        while !(await new.waitingRead()) { await Task.yield() }
+        await old.resumeRead()
+        do { try await first.value; XCTFail() } catch { XCTAssertEqual(error as? CalendarFailure, .cancelled) }
+        let stillRefreshing = await store.isRefreshing(account)
+        XCTAssertTrue(stillRefreshing)
+        await new.resumeRead()
+        try await second.value
+        let finished = await store.isRefreshing(account)
+        XCTAssertFalse(finished)
+    }
+
+    func testFailedReauthenticationInvalidatesOlderTokenRotation() async throws {
+        let secrets = MemoryCalendarCredentials()
+        let writer = FailingCalendarWriter(failAfter: 2)
+        let store = try CalendarAccountStore(directory: root(), credentials: secrets, persist: writer.write)
+        let adapter = MockCalendarAdapter(.google)
+        let account = try await store.connect(using: adapter)
+        await adapter.pauseRenew()
+        let window = try window()
+        let refresh = Task { try await store.refresh(account, using: adapter, window: window) }
+        while !(await adapter.waitingRenew()) { await Task.yield() }
+        do { _ = try await store.connect(using: adapter, existing: account); XCTFail() } catch { XCTAssertEqual(error as? CalendarFailure, .storage) }
+        await adapter.resumeRenew()
+        do { try await refresh.value; XCTFail() } catch { XCTAssertEqual(error as? CalendarFailure, .cancelled) }
+        XCTAssertEqual(try secrets.read(account)?.data, Data("fixture-secret-never-in-cache".utf8))
+        let snapshots = await store.snapshots()
+        XCTAssertEqual(snapshots.count, 1)
+    }
+
+    func testCorruptCachedWindowIsRejectedWithoutOverwritingFile() async throws {
+        let directory = try root()
+        let store = try CalendarAccountStore(directory: directory, credentials: MemoryCalendarCredentials())
+        let adapter = MockCalendarAdapter(.google)
+        let account = try await store.connect(using: adapter)
+        try await store.refresh(account, using: adapter, window: window())
+        let file = directory.appendingPathComponent("calendar-cache.json")
+        var object = try JSONSerialization.jsonObject(with: Data(contentsOf: file)) as! [String: Any]
+        var connections = object["connections"] as! [[String: Any]]
+        connections[0]["window"] = ["start": 100, "end": 0]
+        object["connections"] = connections
+        let bytes = try JSONSerialization.data(withJSONObject: object)
+        try bytes.write(to: file)
+        XCTAssertThrowsError(try CalendarAccountStore(directory: directory, credentials: MemoryCalendarCredentials()))
+        XCTAssertEqual(try Data(contentsOf: file), bytes)
+    }
+
+    func testIdentityAndDateNormalization() throws {
+        XCTAssertNotEqual(CalendarAccountKey(provider: .google, subject: "a:b").storageKey,
+                          CalendarAccountKey(provider: .microsoft, subject: "a:b").storageKey)
+        XCTAssertThrowsError(try CalendarDateNormalizer.instant("2026-11-01T01:30:00"))
+        let first = try CalendarDateNormalizer.instant("2026-11-01T01:30:00-05:00")
+        let second = try CalendarDateNormalizer.instant("2026-11-01T01:30:00-06:00")
+        XCTAssertEqual(second.timeIntervalSince(first), 3600)
+        XCTAssertThrowsError(try CalendarDateNormalizer.day("2026-02-30", timeZoneID: "America/Chicago"))
+        XCTAssertThrowsError(try CalendarDateNormalizer.day("2026-02-01", timeZoneID: "invalid"))
+        XCTAssertEqual(String(reflecting: CalendarSecret(data: Data("private".utf8))), "<calendar credential>")
+    }
+
+    func testKeychainPerAccountRoundTrip() throws {
+        let store = KeychainCalendarCredentials(service: "test.calendar.\(UUID().uuidString)")
+        let a = CalendarAccountKey(provider: .google, subject: "a")
+        let b = CalendarAccountKey(provider: .google, subject: "b")
+        defer { try? store.remove(a); try? store.remove(b) }
+        do { try store.write(CalendarSecret(data: Data("first".utf8)), for: a) }
+        catch let error as CalendarKeychainFailure where error.status == -34018 {
+            XCTAssertNil(try? store.read(a))
+            throw XCTSkip("Unsigned simulator has no Keychain entitlement; run the documented ad-hoc signed validation.")
+        }
+        try store.write(CalendarSecret(data: Data("second".utf8)), for: b)
+        try store.write(CalendarSecret(data: Data("updated".utf8)), for: a)
+        XCTAssertEqual(try store.read(a)?.data, Data("updated".utf8))
+        try store.remove(a)
+        try store.remove(a)
+        XCTAssertNil(try store.read(a))
+        XCTAssertEqual(try store.read(b)?.data, Data("second".utf8))
+    }
+}
+
+final class FailingCalendarWriter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    private let failAfter: Int
+    init(failAfter: Int = 1) { self.failAfter = failAfter }
+    func write(_ data: Data, _ url: URL) throws {
+        try lock.withLock {
+            count += 1
+            if count > failAfter { throw CalendarFailure.storage }
+            try data.write(to: url, options: .atomic)
+        }
+    }
+}

--- a/apps/mobile-native/docs/calendar-contract.md
+++ b/apps/mobile-native/docs/calendar-contract.md
@@ -1,0 +1,46 @@
+# Calendar account contract (ONY-254)
+
+This is the shared native account/cache/credential implementation for the Google (ONY-255) and Microsoft (ONY-256) adapters. It is independent of DoodleNote sync. No OAuth registration, actual provider login, event writing, or production account UI is enabled by this change. The DEBUG SwiftUI preview provides an interactive, entirely local fixture.
+
+## Adapter boundary
+
+Implement `CalendarProviderAdapter` in a provider-specific file. `authorize(existing:)` must use the native authorization flow, support task cancellation, enforce state/PKCE, and return the verified provider subject. Use Google's stable subject and Microsoft's tenant/object identity, not email or display name. Reauthentication must return the same key. The host serializes the pending attempt per provider; cancellation or replacement prevents late results from persisting credentials.
+
+`renewCredential` returns the current or rotated opaque credential envelope. The account actor checks its generation and persists the result before calling `calendars` and `events`. Never put tokens in snapshots, logs, error strings, event IDs or pagination cursors. If rotation succeeds remotely but local Keychain persistence fails, surface storage failure and require retry/reauthentication; never report a successful refresh. Concrete adapters must encode refresh/access token and expiry into the private envelope and return typed safe failures. OAuth client registration and minimum read scopes remain provider-specific delivery gates.
+
+Read methods must not perform event writes or send invitations. Return calendar descriptors and complete pages of occurrences. Normalize event occurrences with the existing `EventOccurrenceKey`: provider, account subject, calendar, event, original stable occurrence identity. Rescheduling changes displayed start/end, not the original occurrence key. `LibraryRepository.beginEventNote` separately scopes that key to a chosen library. Calendar disconnect never signs out a DoodleNote library and this store cannot access note directories.
+
+Calendar lists have a 1,000-item bound; event refreshes have a 20,000-item/100-page bound and explicit errors, never truncation. Provider adapters must paginate calendar discovery within that bound. Repeated cursors and conflicting duplicate events are rejected. Retain the last complete cache on any partial failure. Nil calendar selection chooses defaults; empty selection explicitly hides all. Missing selected calendar IDs remain preferences, so temporary provider disappearance does not silently select other calendars.
+
+## Time and retries
+
+`CalendarDateNormalizer.instant` requires an explicit UTC/offset timestamp, rejecting device-timezone inference. `day` validates exact Gregorian date plus originating IANA zone. Adapters convert provider timezone aliases and handle provider recurrence expansion. All-day end dates remain exclusive. Refresh accepts bounded date windows of at most 32 days, suitable for the 14-day upcoming view, validates event overlap and retains timezone metadata.
+
+One refresh runs per account. A generation change from selection, disconnect or reauthentication invalidates older results. A unique refresh ticket prevents the old task's cleanup from clearing a newer task's busy state. Cross-account requests can proceed independently. Rate-limit failures carry a provider retry date and block premature retry. Transient failures set an exponential 2-to-256-second retry date; callers schedule the next attempt, rather than the store running an invisible background loop. Offline/reauthentication failures preserve cached events with explicit status.
+
+## Persistence, protection and recovery
+
+Cache JSON is atomically replaced with complete-until-first-authentication file protection in a backup-excluded directory. Credentials use nonsynchronizing Keychain generic-password items scoped by service plus unambiguous encoded account key, accessible after first unlock on this device only. No shared credentials or account identity moves are implicit. Caller supplies a dedicated calendar cache directory, outside notes/archives. Future archive code must not include it.
+
+New connections persist a disconnecting cleanup intent before writing Keychain, then commit connected metadata. If credential/cache commit and cleanup fail, the intent remains for `finishPendingDisconnects()` on next launch. Reauthentication preserves the existing account and fresh credentials if cache update fails, exposing failure rather than rolling back a possibly rotated refresh token. Disconnect first invalidates in-flight work, persists a cleared disconnecting snapshot, removes only that account's Keychain item, then removes the cache record. Retry is idempotent. Callers must expose failed cleanup and retry it on launch; disconnect is not successful until it returns successfully. No note/audio/ink/summary is deleted.
+
+Rollback: no existing note schema or cloud schema changed. Preserve the dedicated calendar cache until pending cleanup completes, then a previous build can continue local notes. Reconnecting providers is the recovery path if disposable calendar cache is lost; notes remain independent.
+
+## Verification and Check this:
+
+Run normal unsigned regression coverage:
+
+```sh
+xcodegen generate --spec apps/mobile-native/project.yml
+xcodebuild test -project apps/mobile-native/DoodleNoteNative.xcodeproj -scheme DoodleNoteNative -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' -derivedDataPath /tmp/ony254-derived CODE_SIGNING_ALLOWED=NO
+```
+
+Unsigned simulator hosts lack Keychain entitlements (`-34018`); the actual Keychain roundtrip explicitly skips only that environment, while the mock isolation/failure tests run. For actual OS Keychain validation, create a temporary plist with `application-identifier` and `keychain-access-groups` set to `TEST.ai.doodlenote.native.prototype`, then run the calendar suite with `CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=- CODE_SIGN_ENTITLEMENTS=/absolute/path/to/test.entitlements`. This is simulator-only ad-hoc test signing, not a production entitlement or provisioning change.
+
+1. Open the generated project in Xcode, open `Sources/Calendar/CalendarPreview.swift`, and start the `CalendarContractPreview` Canvas on iPhone and iPad. Connect fixture accounts, then Refresh. Expect two independent accounts with one fixture event each and no network requests.
+2. Simulate offline refresh on one account. Expect `offline` result with cached events retained and the other account unchanged.
+3. Require reauthentication, then Reauthenticate on that account. Expect its stable account restored without duplicating it. Refresh again to recover normal state.
+4. Disconnect one account. Expect only that account removed; the other remains. Production note creation is deliberately outside this fixture and remains unchanged.
+5. Inspect credential failure/restart and cancellation tests, and run signed Keychain validation before connecting real providers. Physical device Keychain and actual provider consent/revocation are additional gates in 255/256.
+
+References checked 2026-09-06: [Apple Keychain accessibility](https://developer.apple.com/documentation/security/ksecattraccessibleafterfirstunlockthisdeviceonly), [Google native OAuth](https://developers.google.com/identity/protocols/oauth2/native-app), [Microsoft calendar view](https://learn.microsoft.com/en-us/graph/api/calendar-list-calendarview?view=graph-rest-1.0). Google documents mobile loopback redirects as deprecated; native adapters must not copy desktop loopback authorization.


### PR DESCRIPTION
## Linear Issue
[ONY-254](https://linear.app/onyxdevlabs/issue/ONY-254/add-native-multi-account-calendar-contracts-and-secure-credentials)

## Outcome
Adds the native multi-account calendar foundation so Google and Microsoft adapters can implement independent accounts without sharing credentials or overwriting another account's cache. Existing local notes remain independent of calendar authorization.

## What Changed
- Read-only adapter contract with explicit credential renewal, stable subject/occurrence identities and bounded pagination.
- Actor-owned account/cache lifecycle, account-specific calendar selection, offline results, safe errors, retry dates and late-response protection.
- Device-only Keychain credentials and durable cleanup intent for interrupted connect/disconnect.
- DEBUG-only interactive mock Canvas, reusable provider test fixtures and integration documentation.

## Acceptance Criteria Evidence
- [x] Collision-safe account/occurrence/library boundary: existing EventOccurrenceKey plus encoded provider/subject keys; identity and multi-account tests.
- [x] Protected per-account credentials/preferences/cache: actual ad-hoc-signed simulator Keychain roundtrip, cache/token exclusion and account isolation tests.
- [x] Connect/cancel/reauthenticate/disconnect: cancellation, stale refresh, failed cleanup/restart and failed reauth rotation regressions.
- [x] Read-only operations, refresh concurrency, retries and dates: ticket/generation control, rate-limit fixture, offset/DST validation and invalid cache preservation.
- [x] Shared mock adapters: same contract fixture runs Google and Microsoft account scenarios; DEBUG Canvas permits manual mock review.

## Verification
- `xcodegen generate --spec apps/mobile-native/project.yml` passed.
- Full signed iPhone and iPad suites each passed: 46 unit cases (45 passed, one optional speaker-model skip) plus three UI tests passed. All ten calendar tests, including actual OS Keychain operations, passed without skips.
- iPhone result bundle: `/tmp/ony254-derived/Logs/Test/Test-DoodleNoteNative-2026.09.06_17-24-13--0500.xcresult`. iPad: `/tmp/ony254-derived/Logs/Test/Test-DoodleNoteNative-2026.09.06_17-25-57--0500.xcresult`.
- Full command: `xcodebuild test -project apps/mobile-native/DoodleNoteNative.xcodeproj -scheme DoodleNoteNative -destination platform=iOS\ Simulator,id=SIMULATOR_UUID -derivedDataPath /tmp/ony254-derived CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=- CODE_SIGN_ENTITLEMENTS=/tmp/ony254-test.entitlements`. UUIDs: iPhone `1C6357E6-EA56-428B-B9FF-3DB9E920291D`, iPad `31922860-D8A2-42AC-BFD7-3A8345FA9C9F`.
- All remote checks passed on `26908ee7272dbdf0237a86a8908fd76beb23b5ca`: Native mobile, CI checks, Windows packaging, CodeQL and Vercel. [Native run](https://github.com/Onyx-Dev-Labs/doodle-note/actions/runs/34063989308).
- `git diff --check` passed. Root agent reviewed all six files and requested fixes are covered by regressions.
- Simulator signing arguments: `CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=- CODE_SIGN_ENTITLEMENTS=/tmp/ony254-test.entitlements`, with temporary test-only application/keychain identifiers. No production entitlement or registration changed.
- Routine unsigned CI explicitly skips actual Keychain only when OS returns missing entitlement -34018. Optional speaker-model inference skips when no model is supplied; neither skip is accuracy coverage.

## Local QA / Check this:
1. Generate/open `apps/mobile-native/DoodleNoteNative.xcodeproj`. Open `Sources/Calendar/CalendarPreview.swift` and start its Canvas on iPhone/iPad. Connect fixtures and refresh; expect two separate accounts and one cached event each, without network access.
2. Simulate offline refresh; expect a safe offline result and retained cached events. Require reauthentication and reconnect; expect the same account with no duplicate.
3. Disconnect one fixture account; expect only that account removed. The other account and ordinary local note editing remain independent.
4. Run documented signed Keychain validation and inspect failure/restart fixtures before real provider integration. Actual provider consent/revocation is handled by ONY-255/256.

## Risks and Release Notes
No production OAuth, provider writes, note schema changes, cloud changes or deployment. Callers must retry persisted disconnect intents on launch. Calendar cache is disposable and excluded from backup; credentials never enter snapshots. Read `apps/mobile-native/docs/calendar-contract.md` for rollout/rollback and provider integration requirements.

## Follow-ups
ONY-255/256 implement actual native provider adapters and consent; ONY-257 wires upcoming meetings and event notes. No merge/release authority assumed.
