### PR TITLE
[ONY-258] Version cloud sync for mobile conflicts, summaries, and Trash

### DIFF
--- a/apps/web/app/api/sync/push/route.ts
+++ b/apps/web/app/api/sync/push/route.ts
@@ -8,8 +8,11 @@ import {
   meetings,
   notes,
   transcriptSegments,
+  writeLegacy,
+  syncNotes,
 } from "@repo/db";
 
+import { syncV2Enabled, readBoundedJSON } from "@/lib/sync-v2";
 import { authenticateEntitledSyncRequest } from "@/lib/sync-auth";
 
 const UUID_RE =
@@ -70,7 +73,8 @@ export async function POST(request: Request) {
 
   let body: { meetings?: unknown; folders?: unknown };
   try {
-    body = await request.json();
+    body = await readBoundedJSON(request) as typeof body;
+    if (!body || typeof body !== "object") throw new Error("invalid_body");
   } catch {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
@@ -78,9 +82,9 @@ export async function POST(request: Request) {
     ? (body.meetings as PushMeeting[])
     : [];
   const folderItems = Array.isArray(body.folders)
-    ? (body.folders as PushFolder[]).slice(0, 100)
+    ? (body.folders as PushFolder[])
     : [];
-  if (items.length + folderItems.length === 0 || items.length > 20) {
+  if (items.length + folderItems.length === 0 || items.length > 20 || folderItems.length > 100) {
     return NextResponse.json(
       { error: "Expected 1-20 meetings per push" },
       { status: 400 },
@@ -90,19 +94,21 @@ export async function POST(request: Request) {
   const db = getDb();
   const results: Array<{ id: string; ok: boolean; error?: string }> = [];
 
+  const folderResults: Array<{id:string;ok:boolean;error?:string}>=[];
   // Folders first — meetings in this batch may point at them.
   for (const item of folderItems) {
-    const id = String(item.id ?? "");
+    const id = String(item?.id ?? "");
     if (!UUID_RE.test(id) || typeof item.name !== "string" || !item.name.trim()) {
-      continue; // malformed folder — meetings degrade to unfiled
+      folderResults.push({id,ok:false,error:"invalid_folder"});continue;
     }
+    try {
     const existing = await db
       .select({ organizationId: folders.organizationId })
       .from(folders)
       .where(eq(folders.id, id))
       .limit(1);
     if (existing[0] && existing[0].organizationId !== device.organizationId) {
-      continue; // id owned by another workspace
+      folderResults.push({id,ok:false,error:"write_rejected"});continue;
     }
     const row = {
       organizationId: device.organizationId,
@@ -116,7 +122,10 @@ export async function POST(request: Request) {
       .onConflictDoUpdate({
         target: folders.id,
         set: { name: row.name, updatedAt: row.updatedAt },
+        setWhere: eq(folders.organizationId, device.organizationId),
       });
+    folderResults.push({id,ok:true});
+    } catch {folderResults.push({id,ok:false,error:"write_rejected"});}
   }
 
   // Folder assignments must reference folders this workspace owns.
@@ -130,7 +139,7 @@ export async function POST(request: Request) {
   );
 
   for (const item of items) {
-    const id = String(item.id ?? "");
+    const id = String(item?.id ?? "");
     if (!UUID_RE.test(id)) {
       results.push({ id, ok: false, error: "meeting id must be a UUID" });
       continue;
@@ -140,6 +149,38 @@ export async function POST(request: Request) {
       results.push({ id, ok: false, error: "createdAt must be ISO date" });
       continue;
     }
+
+    if (!Array.isArray(item.segments) || item.segments.length > 20_000 || item.segments.some(s =>
+      !s || (s.channel !== 'mic' && s.channel !== 'system') || typeof s.text !== 'string' || s.text.length > 10_000 ||
+      !Number.isSafeInteger(s.startMs) || !Number.isSafeInteger(s.endMs) || s.startMs < 0 || s.endMs < s.startMs || s.endMs > 2147483647 ||
+      (s.absoluteStartMs !== undefined && !Number.isSafeInteger(s.absoluteStartMs)) ||
+      (s.confidence !== undefined && (!Number.isFinite(s.confidence) || s.confidence < 0 || s.confidence > 1)))) {
+      results.push({id,ok:false,error:'invalid_or_oversized_segments'}); continue;
+    }
+
+      const segments = (Array.isArray(item.segments) ? item.segments : [])
+        .filter(
+          (s) =>
+            (s.channel === "mic" || s.channel === "system") &&
+            typeof s.text === "string" &&
+            Number.isFinite(s.startMs) &&
+            Number.isFinite(s.endMs),
+        )
+        .map((s) => ({
+          meetingId: id,
+          channel: s.channel,
+          speaker:
+            String(s.speaker ?? "").slice(0, 40) || (s.channel === "mic" ? "You" : "Them"),
+          text: s.text.slice(0, 10_000),
+          startMs: Math.round(s.startMs),
+          endMs: Math.round(s.endMs),
+          absoluteStartMs:
+            typeof s.absoluteStartMs === "number" &&
+            Number.isFinite(s.absoluteStartMs)
+              ? Math.round(s.absoluteStartMs)
+              : null,
+          confidence: Number.isFinite(s.confidence) ? s.confidence : null,
+        }));
 
     try {
       // Ownership guard: an id that exists under another workspace is not ours.
@@ -171,39 +212,20 @@ export async function POST(request: Request) {
         createdAt,
         updatedAt: new Date(),
       };
-      await db
+      if (syncV2Enabled()) {
+        await writeLegacy(db, device.organizationId, {id,...row,
+          rawContent:markdownEnvelope(item.rawNotesMarkdown), enhancedContent:markdownEnvelope(item.enhancedMarkdown),
+          segments:segments.map(s=>({channel:s.channel,speaker:s.speaker,text:s.text,startMs:s.startMs,endMs:s.endMs,absoluteStartMs:s.absoluteStartMs,confidence:s.confidence}))});
+        results.push({id,ok:true});continue;
+      }
+      const written = await db
         .insert(meetings)
         .values({ id, ...row })
-        .onConflictDoUpdate({ target: meetings.id, set: row });
+        .onConflictDoUpdate({ target: meetings.id, set: row, setWhere:eq(meetings.organizationId,device.organizationId) }).returning();
+      if (!written.length) {results.push({id,ok:false,error:"write_rejected"});continue;}
 
-      // Segments: full replace keeps the cloud copy exactly mirroring local.
-      await db
-        .delete(transcriptSegments)
-        .where(eq(transcriptSegments.meetingId, id));
-      const segments = (Array.isArray(item.segments) ? item.segments : [])
-        .filter(
-          (s) =>
-            (s.channel === "mic" || s.channel === "system") &&
-            typeof s.text === "string" &&
-            Number.isFinite(s.startMs) &&
-            Number.isFinite(s.endMs),
-        )
-        .slice(0, 5000)
-        .map((s) => ({
-          meetingId: id,
-          channel: s.channel,
-          speaker:
-            String(s.speaker ?? "").slice(0, 40) || (s.channel === "mic" ? "You" : "Them"),
-          text: s.text.slice(0, 10_000),
-          startMs: Math.round(s.startMs),
-          endMs: Math.round(s.endMs),
-          absoluteStartMs:
-            typeof s.absoluteStartMs === "number" &&
-            Number.isFinite(s.absoluteStartMs)
-              ? Math.round(s.absoluteStartMs)
-              : null,
-          confidence: Number.isFinite(s.confidence) ? s.confidence : null,
-        }));
+      // All validation precedes the atomic replacement when v2 rollout is enabled.
+      await db.delete(transcriptSegments).where(eq(transcriptSegments.meetingId, id));
       if (segments.length > 0) {
         await db.insert(transcriptSegments).values(segments);
       }
@@ -219,16 +241,16 @@ export async function POST(request: Request) {
         });
 
       results.push({ id, ok: true });
-    } catch (error) {
+    } catch {
       results.push({
         id,
         ok: false,
-        error: error instanceof Error ? error.message : "write failed",
+        error: "write_rejected",
       });
     }
   }
 
-  return NextResponse.json({ results });
+  return NextResponse.json({ results,folderResults });
 }
 
 /** Meeting deletions propagate too: ids the desktop trashed or removed. */
@@ -238,28 +260,36 @@ export async function DELETE(request: Request) {
   const device = authed.device;
   let body: { ids?: unknown; folderIds?: unknown };
   try {
-    body = await request.json();
+    body = await readBoundedJSON(request) as typeof body;
+    if (!body || typeof body !== "object") throw new Error("invalid_body");
   } catch {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
   const ids = (Array.isArray(body.ids) ? body.ids : [])
     .map(String)
     .filter((id) => UUID_RE.test(id))
-    .slice(0, 100);
+;
   const folderIds = (Array.isArray(body.folderIds) ? body.folderIds : [])
     .map(String)
     .filter((id) => UUID_RE.test(id))
-    .slice(0, 100);
+;
 
+  if ((Array.isArray(body.ids) && body.ids.length > 100) || (Array.isArray(body.folderIds) && body.folderIds.length > 100)) return NextResponse.json({error:'delete_batch_limit'},{status:400});
   const db = getDb();
+  const failures: string[]=[];
   for (const id of ids) {
-    await db
+    try {
+      if(syncV2Enabled()) { const protectedRows=await db.select().from(syncNotes).where(and(eq(syncNotes.id,id),eq(syncNotes.organizationId,device.organizationId)));
+        if(protectedRows.some(r=>r.state!=="purged")){failures.push(id);continue;} }
+      await db
       .delete(meetings)
       .where(
         and(eq(meetings.id, id), eq(meetings.organizationId, device.organizationId)),
       );
+    } catch { failures.push(id); }
   }
   if (folderIds.length > 0) {
+    try {
     // FK is ON DELETE SET NULL — meetings inside fall back to unfiled.
     await db
       .delete(folders)
@@ -269,6 +299,7 @@ export async function DELETE(request: Request) {
           eq(folders.organizationId, device.organizationId),
         ),
       );
+    } catch {failures.push(...folderIds);}
   }
-  return NextResponse.json({ ok: true, deleted: ids.length + folderIds.length });
+  return NextResponse.json({ ok: failures.length===0, deleted: ids.length-failures.length + folderIds.length, failures }, {status:failures.length?409:200});
 }

--- a/apps/web/app/api/sync/v2/route.ts
+++ b/apps/web/app/api/sync/v2/route.ts
@@ -1,0 +1,14 @@
+import { getDb } from '@repo/db';
+import { authenticateEntitledSyncRequest } from '@/lib/sync-auth';
+import { handleSyncV2, syncV2Enabled } from '@/lib/sync-v2';
+
+async function handle(request:Request) {
+  // Gate before DB initialization. Deploying source does not activate the protocol.
+  if(!syncV2Enabled())return Response.json({error:'protocol_unavailable'},{status:404});
+  const auth=await authenticateEntitledSyncRequest(request);
+  if(auth.response)return auth.response;
+  try { return await handleSyncV2(request,getDb(),auth.device.organizationId); }
+  catch { return Response.json({error:'sync_unavailable'},{status:503}); }
+}
+export const GET=handle;
+export const POST=handle;

--- a/apps/web/lib/cloud-data-purge.ts
+++ b/apps/web/lib/cloud-data-purge.ts
@@ -73,11 +73,19 @@ export async function purgePersonalCloudData({
 
   let meetingCount = 0;
   for (const workspace of personalWorkspaces) {
-    const deletedMeetings = await db
-      .delete(meetings)
-      .where(eq(meetings.organizationId, workspace.id))
-      .returning();
-    meetingCount += deletedMeetings.length;
+    // Catalog lookup is safe before migration and during a flag-off rollback.
+    // Once installed, the function also erases native-only/history content and
+    // retains minimal resurrection barriers before old projections are deleted.
+    const capability = await db.execute(sql`select to_regprocedure('sync_purge_workspace(text)') is not null as available`);
+    const capabilityRows = Array.isArray(capability) ? capability : capability.rows;
+    if(capabilityRows[0]?.available) {
+      const result=await db.execute(sql`select sync_purge_workspace(${workspace.id}) as count`);
+      const rows=Array.isArray(result)?result:result.rows;
+      meetingCount+=Number(rows[0]?.count??0);
+    } else {
+      const deletedMeetings = await db.delete(meetings).where(eq(meetings.organizationId, workspace.id)).returning();
+      meetingCount += deletedMeetings.length;
+    }
     await db.delete(folders).where(eq(folders.organizationId, workspace.id));
     await db
       .delete(meetingTags)

--- a/apps/web/lib/sync-v2.ts
+++ b/apps/web/lib/sync-v2.ts
@@ -1,0 +1,57 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { applySync, pullSync, SYNC_CAPABILITIES, SYNC_MAX_BYTES, type Db } from '@repo/db';
+
+export function syncV2Enabled(env=process.env): boolean { return env.DOODLENOTE_SYNC_V2_ENABLED==='true'; }
+function secret(env=process.env): string {
+  const value=env.DOODLENOTE_SYNC_CURSOR_SECRET;
+  if(!value||value.length<32) throw new Error('sync_configuration');
+  return value;
+}
+export function encodeCursor(organizationId:string, libraryId:string, after:string, key=secret()) {
+  const data=Buffer.from(JSON.stringify({v:2,organizationId,libraryId,after})).toString('base64url');
+  return data+'.'+createHmac('sha256',key).update(data).digest('base64url');
+}
+export function decodeCursor(cursor:string, organizationId:string, libraryId:string, key=secret()):string {
+  if(cursor.length>1000)throw new Error('invalid_cursor');
+  const [data,signature,...extra]=cursor.split('.');
+  const expected=createHmac('sha256',key).update(data).digest();
+  const actual=Buffer.from(signature??'','base64url');
+  if(extra.length||actual.length!==expected.length||!timingSafeEqual(actual,expected))throw new Error('invalid_cursor');
+  const decoded=JSON.parse(Buffer.from(data,'base64url').toString());
+  if(decoded.v!==2||decoded.organizationId!==organizationId||decoded.libraryId!==libraryId||!/^\d{1,16}$/.test(decoded.after))throw new Error('invalid_cursor');
+  return decoded.after;
+}
+export async function readBoundedJSON(request:Request) {
+  const reader=request.body?.getReader(); if(!reader)throw new Error('invalid_body');
+  const chunks:Uint8Array[]=[];let size=0;
+  for(;;) { const {done,value}=await reader.read();if(done)break;size+=value.length;
+    if(size>SYNC_MAX_BYTES){await reader.cancel();throw new Error('payload_limit');}chunks.push(value); }
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+}
+export async function handleSyncV2(request:Request, db:Db, organizationId:string) {
+  // Validate configuration before data mutations, including empty-cursor requests.
+  const key=secret();
+  const url=new URL(request.url);
+  if(request.method==='GET' && !url.searchParams.has('libraryId')) return Response.json({protocolVersion:2,capabilities:SYNC_CAPABILITIES,maxBatchItems:20,maxPayloadBytes:SYNC_MAX_BYTES});
+  if(request.method==='GET') {
+    const libraryId=url.searchParams.get('libraryId')!;
+    let after='0';
+    try { if(url.searchParams.has('cursor')) after=decodeCursor(url.searchParams.get('cursor')!,organizationId,libraryId,key); }
+    catch { return Response.json({error:'invalid_cursor'},{status:400}); }
+    try {
+      const result=await pullSync(db,organizationId,libraryId,after);
+      return Response.json({protocolVersion:2,...result,cursor:encodeCursor(organizationId,libraryId,result.after,key)});
+    } catch { return Response.json({error:'invalid_library_or_cursor'},{status:400}); }
+  }
+  let body:unknown;
+  try { body=await readBoundedJSON(request); } catch { return Response.json({error:'invalid_or_oversized_body'},{status:400}); }
+  if(!body||typeof body!=='object'||Array.isArray(body)||Object.keys(body).some(k=>k!=='operations'))return Response.json({error:'invalid_batch'},{status:400});
+  const operations=(body as {operations?:unknown}).operations;
+  if(!Array.isArray(operations)||operations.length<1||operations.length>20)return Response.json({error:'invalid_batch'},{status:400});
+  const results=[];
+  for(let index=0;index<operations.length;index++) {
+    try {results.push({index,receipt:await applySync(db,organizationId,operations[index])});}
+    catch {results.push({index,error:'invalid_or_rejected_operation'});}
+  }
+  return Response.json({protocolVersion:2,results});
+}

--- a/apps/web/tests/cloud-data-purge.test.ts
+++ b/apps/web/tests/cloud-data-purge.test.ts
@@ -148,3 +148,29 @@ describe("personal Cloud Sync data purge", () => {
     assert.equal((await mem.db.select().from(subscriptions).where(eq(subscriptions.userId, userId))).length, 1);
   });
 });
+
+describe('versioned sync purge compatibility',()=>{
+  it('erases adopted and native-only personal snapshots, preserves shared content and purge receipts',async()=>{
+    const {randomUUID}=await import('node:crypto');
+    const {applySync,sql}=await import('@repo/db');
+    const local=await createInMemoryDb();
+    try {
+      await local.db.insert(user).values({id:'owner',name:'Owner',email:'owner@example.test',createdAt:new Date(),updatedAt:new Date()});
+      await local.db.insert(organization).values([{id:'personal',name:'Personal',slug:'personal-test',createdAt:new Date()},{id:'team',name:'Team',slug:'team-test',createdAt:new Date()}]);
+      await local.db.insert(member).values([{id:'p',userId:'owner',organizationId:'personal',role:'owner',createdAt:new Date()},{id:'t',userId:'owner',organizationId:'team',role:'member',createdAt:new Date()}]);
+      const personalLibrary=randomUUID(),teamLibrary=randomUUID();
+      function operation(libraryId:string,noteId=randomUUID()) {
+        const source=randomUUID();return {protocolVersion:2,libraryId,noteId,operationId:randomUUID(),expectedRevision:null,expectedLifecycleGeneration:null,kind:'upsert',snapshot:{title:'note',kind:'note',createdAt:'2026-09-06',language:'en-US',text:'private',passages:[],speakers:[],sourceRevisionId:source,sourceVersions:[{id:source,title:'note',text:'private',passages:[],speakers:[]}],summaries:[],selectedSummaryId:null,inkAttachments:[]}};
+      }
+      const adopted=operation(personalLibrary),native=operation(personalLibrary),shared=operation(teamLibrary);
+      await local.db.insert(meetings).values({id:adopted.noteId,organizationId:'personal',title:'legacy'});
+      await applySync(local.db,'personal',adopted);await applySync(local.db,'personal',native);await applySync(local.db,'team',shared);
+      const result=await purgePersonalCloudData({userId:'owner',db:local.db,deleteAttachmentPrefix:async()=>{}});
+      assert.equal(result.meetingCount,2);
+      const personal=await local.db.execute(sql`select state from sync_notes where organization_id='personal'`);assert.ok(personal.rows.every(r=>r.state==='purged'));
+      const payload=await local.db.execute(sql`select snapshot from sync_revisions where organization_id='personal'`);assert.ok(payload.rows.every(r=>r.snapshot===null));
+      const team=await local.db.execute(sql`select snapshot from sync_revisions where organization_id='team'`);assert.ok(team.rows.some(r=>r.snapshot!==null));
+      assert.equal((await applySync(local.db,'personal',native) as {status:string}).status,'purged');
+    }finally{await local.close();}
+  });
+});

--- a/apps/web/tests/sync-v2.test.ts
+++ b/apps/web/tests/sync-v2.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import {randomUUID} from 'node:crypto';
+import test from 'node:test';
+import {createInMemoryDb} from '@repo/db/testing';
+import {sql, type SyncOperation, type SyncSnapshot} from '@repo/db';
+import {decodeCursor,encodeCursor,handleSyncV2,readBoundedJSON,syncV2Enabled} from '../lib/sync-v2';
+
+const key='synthetic-test-key-at-least-32-bytes';
+function op():SyncOperation {
+ const source=randomUUID(); const snapshot:SyncSnapshot={title:'note',kind:'note',createdAt:'2026-09-06',language:'en-US',text:'text',passages:[],speakers:[],sourceRevisionId:source,sourceVersions:[{id:source,title:'note',text:'text',passages:[],speakers:[]}],selectedSummaryId:null,summaries:[],inkAttachments:[]};
+ return {protocolVersion:2,libraryId:randomUUID(),noteId:randomUUID(),operationId:randomUUID(),expectedRevision:null,expectedLifecycleGeneration:null,kind:'upsert',snapshot};
+}
+test('cursor rejects cross-workspace, cross-library, tampering and newer versions',()=>{
+ const cursor=encodeCursor('a','library','50',key);assert.equal(decodeCursor(cursor,'a','library',key),'50');
+ assert.throws(()=>decodeCursor(cursor,'b','library',key));assert.throws(()=>decodeCursor(cursor,'a','other',key));
+ assert.throws(()=>decodeCursor(cursor+'x','a','library',key));
+ assert.equal(syncV2Enabled({} as NodeJS.ProcessEnv),false);
+});
+test('bounded request reader rejects oversized bodies',async()=>{
+ await assert.rejects(readBoundedJSON(new Request('https://local/',{method:'POST',body:'x'.repeat(2_000_001)})));
+});
+test('per-item failures isolate valid operations and replay; pull cursor stays scoped',async()=>{
+ const old=process.env.DOODLENOTE_SYNC_CURSOR_SECRET;process.env.DOODLENOTE_SYNC_CURSOR_SECRET=key;
+ const {db,close}=await createInMemoryDb();try {
+  await db.execute(sql`insert into organization(id,name,slug,created_at) values('a','a','a',now()),('b','b','b',now())`);
+  const operation=op();
+  const push=()=>handleSyncV2(new Request('https://local/api/sync/v2',{method:'POST',body:JSON.stringify({operations:[{...operation,snapshot:{...operation.snapshot,audio:'no'}},operation]})}),db,'a');
+  const first=await (await push()).json();assert.equal(first.results[0].error,'invalid_or_rejected_operation');assert.equal(first.results[1].receipt.status,'ok');
+  const retry=await (await push()).json();assert.deepEqual(retry.results[1],first.results[1]);
+  const page=await (await handleSyncV2(new Request('https://local/api/sync/v2?libraryId='+operation.libraryId),db,'a')).json();assert.equal(page.changes.length,1);
+  const cross=await handleSyncV2(new Request('https://local/api/sync/v2?libraryId='+operation.libraryId+'&cursor='+page.cursor),db,'b');assert.equal(cross.status,400);
+ }finally {await close();if(old===undefined)delete process.env.DOODLENOTE_SYNC_CURSOR_SECRET;else process.env.DOODLENOTE_SYNC_CURSOR_SECRET=old;}
+});
+
+test('disabled v2 touches no database and legacy DELETE failures return non-2xx for old clients',async()=>{
+ const previous=process.env.DOODLENOTE_SYNC_V2_ENABLED;
+ const globalDb=globalThis as {__repoDbClient?:unknown};const previousDb=globalDb.__repoDbClient;
+ const {db,close}=await createInMemoryDb();
+ try {
+  delete process.env.DOODLENOTE_SYNC_V2_ENABLED;
+  globalDb.__repoDbClient=new Proxy({}, {get(){throw new Error('database must not be touched');}});
+  const route=await import('../app/api/sync/v2/route');
+  assert.equal((await route.GET(new Request('https://local/api/sync/v2'))).status,404);
+  globalDb.__repoDbClient=db;
+  const {createHash}=await import('node:crypto');const token='dnsy_'+('ab'.repeat(32));
+  await db.execute(sql`insert into "user"(id,name,email,email_verified,created_at,updated_at) values('u','User','u@example.test',true,now(),now())`);
+  await db.execute(sql`insert into organization(id,name,slug,created_at) values('a','a','a',now())`);
+  await db.execute(sql`insert into sync_devices(id,token_hash,user_id,organization_id) values(${randomUUID()}::uuid,${createHash('sha256').update(token).digest('hex')},'u','a')`);
+  await db.execute(sql`insert into subscriptions(user_id,grandfathered) values('u',true)`);
+  const operation=op();const {applySync}=await import('@repo/db');await applySync(db,'a',operation);
+  const legacy=randomUUID();await db.execute(sql`insert into meetings(id,organization_id,title)values(${legacy}::uuid,'a','legacy')`);
+  process.env.DOODLENOTE_SYNC_V2_ENABLED='true';
+  const legacyRoute=await import('../app/api/sync/push/route');
+  const response=await legacyRoute.DELETE(new Request('https://local/api/sync/push',{method:'DELETE',headers:{authorization:'Bearer '+token},body:JSON.stringify({ids:[legacy,operation.noteId]})}));
+  assert.equal(response.status,409); // a protected native note must not be acknowledged as deleted
+  const remaining=await db.execute(sql`select id from sync_notes where id=${operation.noteId}::uuid`);assert.equal(remaining.rows.length,1);
+ } finally {globalDb.__repoDbClient=previousDb;if(previous===undefined)delete process.env.DOODLENOTE_SYNC_V2_ENABLED;else process.env.DOODLENOTE_SYNC_V2_ENABLED=previous;await close();}
+});
+
+test('legacy push and pull operate with flag off against the actual pre-v2 schema',async()=>{
+ const old=process.env.DOODLENOTE_SYNC_V2_ENABLED;delete process.env.DOODLENOTE_SYNC_V2_ENABLED;
+ const globalDb=globalThis as {__repoDbClient?:unknown};const previous=globalDb.__repoDbClient;
+ const {db,close}=await createInMemoryDb({throughMigration:12});globalDb.__repoDbClient=db;
+ try {
+  const {createHash}=await import('node:crypto');const token='dnsy_'+('cd'.repeat(32));
+  await db.execute(sql`insert into "user"(id,name,email,email_verified,created_at,updated_at) values('legacy-user','User','legacy@example.test',true,now(),now())`);
+  await db.execute(sql`insert into organization(id,name,slug,created_at) values('legacy-org','Org','legacy',now())`);
+  await db.execute(sql`insert into sync_devices(id,token_hash,user_id,organization_id) values(${randomUUID()}::uuid,${createHash('sha256').update(token).digest('hex')},'legacy-user','legacy-org')`);
+  await db.execute(sql`insert into subscriptions(user_id,grandfathered) values('legacy-user',true)`);
+  const {POST}=await import('../app/api/sync/push/route');const {GET}=await import('../app/api/sync/pull/route');
+  const id=randomUUID();const headers={authorization:'Bearer '+token};
+  const push=await POST(new Request('https://local/api/sync/push',{method:'POST',headers,body:JSON.stringify({meetings:[{id,title:'legacy',createdAt:'2026-09-06',segments:[{channel:'mic',speaker:'You',text:'complete',startMs:0,endMs:10}]}]})}));
+  assert.equal((await push.json()).results[0].ok,true);
+  const pull=await GET(new Request('https://local/api/sync/pull',{headers}));assert.equal((await pull.json()).changed[0].segments[0].text,'complete');
+  const tables=await db.execute(sql`select to_regclass('sync_notes') is null as absent`);assert.equal(tables.rows[0]!.absent,true);
+ }finally{globalDb.__repoDbClient=previous;if(old===undefined)delete process.env.DOODLENOTE_SYNC_V2_ENABLED;else process.env.DOODLENOTE_SYNC_V2_ENABLED=old;await close();}
+});

--- a/docs/sync/protocol-v2.md
+++ b/docs/sync/protocol-v2.md
@@ -1,0 +1,79 @@
+# ONY-258: opt-in versioned synchronization
+
+Status: source implementation for review. No production migration, rollout flag, secret, client upgrade or live data mutation has been performed. Source deployment does not activate v2.
+
+## Wire and compatibility
+
+Enable only after migration `0013_same_abomination.sql` and staged verification: `DOODLENOTE_SYNC_V2_ENABLED=true` plus a server-only `DOODLENOTE_SYNC_CURSOR_SECRET` of at least 32 characters, provisioned through the approved secret manager. An absent/false flag returns 404 before the v2 route initializes the database. Missing secret fails closed. Existing bearer-device authentication and paid-sync entitlement checks apply to every enabled request. Workspace identity comes exclusively from the authenticated device, never request JSON.
+
+`GET /api/sync/v2` returns protocol version, capabilities and limits. `POST /api/sync/v2` accepts `{operations: [...]}`; the complete streamed request is bounded to 2,000,000 bytes and 20 items. Each operation is independently atomic. Successful siblings survive invalid/rejected siblings; retry the exact failed/unacknowledged operations with their original IDs. An operation contains:
+
+- All UUID identity strings must be canonical lowercase, including nested source/summary/speaker/attachment IDs. The native adapter lowercases UUID serialization; uppercase aliases are rejected before hashing/storage to preserve immutable identity.
+- `protocolVersion: 2`, `libraryId`, `noteId`, `operationId`: explicit UUID identities.
+- `expectedRevision`: last acknowledged cloud content revision UUID, null only for first creation/concurrent first-create. Arbitrary or foreign-note base revisions are rejected.
+- `expectedLifecycleGeneration`: independent opaque lifecycle generation. This changes for Trash/restore/purge and cannot be inferred from a content timestamp or revision. Initial creation uses null.
+- `kind`: `upsert`, `trash`, `restore` or `purge`. Only upsert contains `snapshot`. Restore and purge require the current `deletionId`; every lifecycle mutation requires current content and lifecycle preconditions. Purge requires Trash.
+
+`SyncSnapshot` and strict validation live in `packages/db/src/sync-contract.ts`. Unsupported fields are rejected recursively; no generic extension object, embedded audio, voice embeddings, API credential or arbitrary blob URL is accepted. Ink is represented only by attachment/version IDs; actual private asset ownership, storage and readers are ONY-259/261. No audio data is transferred.
+
+| Native ONY-242 domain | v2 mapping |
+|---|---|
+| LibraryIdentity + LibraryRecord | Bearer workspace authorization plus explicit library UUID. First note creates that workspace-owned library; IDs cannot move across workspaces/libraries. Local-only library is not automatically uploaded |
+| NoteRecord title/text/language/passages | Snapshot retains original text and stable passage UUIDs; millisecond ranges are source-audio offsets, not wall-clock playback guesses |
+| NoteMetadata.revisionID | `sourceRevisionId`, distinct from server synchronization head revision |
+| NoteRevision | `sourceVersions[]` retains immutable title, typed text, passages and speaker annotation data needed by source anchors. Current source version must exactly match current content |
+| SourceAnchor | Explicit library/note/revision plus `personalParagraph` zero-based newline index or `transcript` passage UUID. Every referenced source revision/content must be in the snapshot's immutable source bundle |
+| SummaryVersion | UUID, optional parent UUID, createdAt, generated/edited origin, format, language, markdown and full source anchors; selected summary UUID retained. Missing parents, cycles, dangling sources and foreign scope rejected |
+| SpeakerAnnotations | Stable speaker UUIDs, ordered speaker array, optional session UUID/slot and time-aligned provisional/final turns. Adapter must persist a stable session-slot-to-UUID mapping; calendar names do not establish identity |
+| EventOccurrenceKey / folder | Provider/account/calendar/event/original-occurrence fields preserved. Optional folder must reference an existing folder owned by this workspace; library-specific folder presentation remains a client adapter concern |
+| Ink | Attachment UUID/version references; drawing bytes/private storage contract follows in ONY-259 |
+
+A snapshot must include sources needed by its summaries even when the cited typed text is older than current text. Existing version IDs cannot be changed in later snapshots. Prior cloud snapshots remain immutable until permanent deletion. The explicit payload/20,000-passage limits reject oversized histories instead of truncating them. A future chunk-upload protocol is required for larger snapshots; clients must surface the error and preserve local originals. Do not silently prune history or original text to fit the limit.
+
+## Conflicts, replay and ordering
+
+The database function `sync_apply` runs each operation as one PostgreSQL statement/transaction, supported by the existing Neon HTTP driver and PGlite. A workspace clock row serializes mutation commit order. Opaque revision UUIDs identify content; monotonically allocated sequence values order the feed. Gaps from rejected operations are harmless. Unlike timestamps, equal wall-clock times cannot skip a change.
+
+An upsert based on a known stale content revision stores the complete alternate snapshot as an immutable `conflict` revision and leaves the accepted head unchanged. Conflict revisions appear in the feed. Resolving a conflict means sending the chosen/merged full snapshot with a new operation ID, current head and lifecycle generation; retained sources and summaries remain immutable. Stale lifecycle state cannot create a hidden alternate active note.
+
+Operation receipts are bound to organization, note and canonical payload SHA-256. Exact retry returns the same receipt; reusing an operation UUID for different content is rejected. Receipts contain only identifiers, state, timestamps and sequence, never note text. After purge, replay returns `purged`, not an old active result.
+
+`GET /api/sync/v2?libraryId=UUID[&cursor=opaque]` returns ordered revision events, `hasMore`, and a new cursor. The HMAC-signed cursor binds version, organization, library and sequence; another library/workspace or a modified cursor is rejected. Pull currently limits 20 revisions per page (each accepted snapshot is bounded by the request limit). Persist cursor only after every event is durably applied. Retry the page after an interrupted local transaction. Fresh clients begin without a cursor and receive retained history/tombstones, not an unbounded allIds deletion inference. Empty pages preserve the existing position.
+
+Legacy payloads and timestamps are not used as v2 cursors. On adoption of an existing meeting, the server captures the complete meeting row, note envelopes and all segments into an immutable `legacy` revision before preserving the incoming mobile candidate as a conflict. A client must resolve that initial comparison explicitly. No old data is silently converted away. Existing clients retain their old endpoints; migrated database triggers reject legacy writes/deletes to protected IDs, including direct note/segment writes. Legacy delete batches with any rejection return HTTP 409 because installed clients clear their pending queue on HTTP success. Retried already-deleted siblings are harmless.
+
+The legacy push path rejects oversized/invalid segments rather than silently filtering or taking only the first 5,000. With v2 rollout enabled it uses an atomic full-item SQL function and ownership guards. Before migration/while disabled, the old schema path remains available with validation and race-safe ownership upsert. Its historical multi-statement legacy replacement remains a rollback limitation; do not resume rich-data writes through it. Triggers remain installed during an application rollback to protect adopted records. Legacy timestamps on subsequent writes are made strictly increasing per workspace at millisecond precision; pre-existing timestamp ties are not a v2 migration cursor and require an explicit client full refresh when adopting v2.
+
+## Trash, expiry and purge
+
+State is `active`, `trashed` or `purged`. Trash assigns server deletion UUID, server deletedAt and 30-day expiresAt; user device clocks cannot extend server retention. Restore is explicit before expiry and requires matching deletion identity, content revision and lifecycle generation. Local provisional clocks from ONY-260 must be reconciled with these acknowledged server values by ONY-262. Removing downloaded audio remains local and does not change cloud lifecycle.
+
+Expiry processing occurs when the service handles applicable writes or library pulls; each pull cleans up at most 50 expired notes. All expired snapshot payloads are withheld even while bounded cleanup continues. There is no claim of execution while the service is idle. A periodic cleanup schedule requires a separately authorized operational rollout if wall-clock physical erasure at the deadline is required. Restoring expired content is forbidden even before cleanup has run.
+
+Purge nulls every retained snapshot/conflict payload, removes any legacy projection and keeps minimal note/revision/operation identity receipts to reject stale clients permanently. Attachment-object cleanup follows ONY-259 and must be completed in rollout before storing ink. Old legacy deletions also create durable barriers; an offline client cannot recreate the same ID. A deliberate new local copy must use a new note identity and explicit sync selection, never spoof a restore.
+
+The existing personal-billing purge service detects the installed purge function through the PostgreSQL catalog, so it works both before migration and during flag-off rollback. It erases native-only and adopted personal records/history while retaining minimal barriers. Shared-workspace data remains untouched. Organization deletion cascades cleanly without triggers recreating data. No HTTP endpoint exposes workspace-wide purge.
+
+## Migration, rollback and verification
+
+1. Back up the target database and test restore in an isolated staging environment. Record row counts/hashes and representative old-client fixtures. No production commands are run by this PR.
+2. Deploy source with v2 flag absent. Validate existing clients against the old schema. Provision the cursor secret only through normal protected configuration, never commit it.
+3. Apply the additive migration in an approved maintenance stage. It adds tables/functions/guards without rewriting existing note/segment data. Legacy content is snapshotted lazily and atomically at adoption; default legacy tombstone libraries are deterministically named from workspace identity.
+4. Validate isolated mixed-client adoption, old edits rejected, complete long transcript transfer, two offline edits, repeated operation, multi-page pull, Trash/restore, expiration, permanent deletion and personal billing purge. Only then enable v2 for the intended environment and compatible client rollout. ONY-261/262 readers/adapters must follow before users rely on new data presentation.
+5. Application rollback: turn the v2 flag off; retain additive schema, guards and purge adapter. Do not drop tables/functions/receipts after v2 writes because that would lose history and permit resurrection. A schema down-migration is safe only before any adoption/write and with verified backup; otherwise prefer a forward fix. No automatic destructive down script is supplied.
+
+Commands from the repository root:
+
+```sh
+pnpm install --frozen-lockfile --ignore-scripts
+pnpm --filter @repo/db test
+pnpm --filter @repo/db typecheck
+pnpm --filter web test
+pnpm --filter web typecheck
+pnpm --filter web build
+python3 packages/db/scripts/verify-sync-postgres.py
+```
+
+The Python command uses local PostgreSQL binaries (default `/opt/homebrew/bin`, configurable via `POSTGRES_BIN`), a disposable `/tmp` cluster and private Unix socket with TCP disabled. It never reads DATABASE_URL and stops/deletes the cluster on completion. It tests rollback/reapply plus genuinely concurrent cross-workspace library creation and stale-base edits. PGlite integration tests exercise the real migration/functions, 6,001-segment final-sentinel round trips, replay, conflicts, strict source anchors, purge and organization cascade. Web tests exercise signed cursor isolation, per-item failures, bounded bodies, disabled v2 without a database, and old-client DELETE failure semantics.
+
+Check this: use only a disposable test workspace. Edit the same note offline in two clients; both versions must appear. Retry the same operation; no duplicate revision should appear. Trash then restore with the exact deletion generation; after purge, replay must return purged and all payloads must be absent. Try the cursor in another library; expect a sanitized rejection. Review old-client upgrade messaging in ONY-261/262 before rollout.

--- a/packages/db/drizzle/0013_same_abomination.sql
+++ b/packages/db/drizzle/0013_same_abomination.sql
@@ -1,0 +1,259 @@
+CREATE TABLE "sync_clocks" (
+	"organization_id" text PRIMARY KEY NOT NULL,
+	"sequence" bigint DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "sync_libraries" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "sync_notes" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"library_id" uuid NOT NULL,
+	"organization_id" text NOT NULL,
+	"head_revision" uuid,
+	"lifecycle_generation" uuid DEFAULT gen_random_uuid() NOT NULL,
+	"state" text DEFAULT 'active' NOT NULL,
+	"deletion_id" uuid,
+	"deleted_at" timestamp with time zone,
+	"expires_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "sync_operations" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"note_id" uuid NOT NULL,
+	"payload_hash" text NOT NULL,
+	"receipt" jsonb NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "sync_revisions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"note_id" uuid NOT NULL,
+	"organization_id" text NOT NULL,
+	"sequence" bigint NOT NULL,
+	"parent_id" uuid,
+	"kind" text NOT NULL,
+	"snapshot" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "sync_clocks" ADD CONSTRAINT "sync_clocks_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sync_libraries" ADD CONSTRAINT "sync_libraries_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sync_notes" ADD CONSTRAINT "sync_notes_library_id_sync_libraries_id_fk" FOREIGN KEY ("library_id") REFERENCES "public"."sync_libraries"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sync_notes" ADD CONSTRAINT "sync_notes_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sync_operations" ADD CONSTRAINT "sync_operations_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sync_operations" ADD CONSTRAINT "sync_operations_note_id_sync_notes_id_fk" FOREIGN KEY ("note_id") REFERENCES "public"."sync_notes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sync_revisions" ADD CONSTRAINT "sync_revisions_note_id_sync_notes_id_fk" FOREIGN KEY ("note_id") REFERENCES "public"."sync_notes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sync_revisions" ADD CONSTRAINT "sync_revisions_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "sync_revisions_org_sequence" ON "sync_revisions" USING btree ("organization_id","sequence");--> statement-breakpoint
+CREATE FUNCTION sync_next_sequence(org text) RETURNS bigint LANGUAGE plpgsql AS $$
+DECLARE result bigint;
+BEGIN
+  INSERT INTO sync_clocks(organization_id,sequence) VALUES(org,0) ON CONFLICT DO NOTHING;
+  UPDATE sync_clocks SET sequence=sequence+1 WHERE organization_id=org RETURNING sequence INTO result;
+  RETURN result;
+END $$;
+--> statement-breakpoint
+CREATE FUNCTION sync_apply(org text, operation jsonb, payload_hash text) RETURNS jsonb LANGUAGE plpgsql AS $$
+DECLARE
+  lib uuid := (operation->>'libraryId')::uuid;
+  nid uuid := (operation->>'noteId')::uuid;
+  opid uuid := (operation->>'operationId')::uuid;
+  expected uuid := (operation->>'expectedRevision')::uuid;
+  generation uuid := (operation->>'expectedLifecycleGeneration')::uuid;
+  action text := operation->>'kind';
+  n sync_notes%ROWTYPE; previous sync_operations%ROWTYPE;
+  revision uuid := gen_random_uuid(); seq bigint; result jsonb; legacy jsonb; event_kind text;
+BEGIN
+  -- Clock lock is also the workspace mutation mutex, held until transaction commit.
+  seq := sync_next_sequence(org);
+  IF EXISTS(SELECT 1 FROM sync_libraries WHERE id=lib AND organization_id<>org)
+    OR EXISTS(SELECT 1 FROM sync_notes WHERE id=nid AND (organization_id<>org OR library_id<>lib))
+    OR EXISTS(SELECT 1 FROM meetings WHERE id=nid AND organization_id<>org) THEN
+    RETURN jsonb_build_object('status','not_found');
+  END IF;
+  SELECT * INTO previous FROM sync_operations WHERE id=opid;
+  IF FOUND THEN
+    IF previous.organization_id<>org OR previous.note_id<>nid OR previous.payload_hash<>payload_hash THEN
+      RETURN jsonb_build_object('status','operation_reused');
+    END IF;
+    IF EXISTS(SELECT 1 FROM sync_notes WHERE id=nid AND state='purged') THEN
+      RETURN jsonb_build_object('status','purged','noteId',nid);
+    END IF;
+    RETURN previous.receipt;
+  END IF;
+  IF action='upsert' THEN
+    IF operation->'snapshot'->>'folderId' IS NOT NULL AND NOT EXISTS(SELECT 1 FROM folders WHERE id=(operation->'snapshot'->>'folderId')::uuid AND organization_id=org) THEN RETURN jsonb_build_object('status','invalid_folder'); END IF;
+  END IF;
+  SELECT * INTO n FROM sync_notes WHERE id=nid;
+  IF NOT FOUND THEN
+    IF action<>'upsert' OR expected IS NOT NULL OR generation IS NOT NULL THEN
+      RETURN jsonb_build_object('status','not_found');
+    END IF;
+    INSERT INTO sync_libraries(id,organization_id) VALUES(lib,org) ON CONFLICT DO NOTHING;
+    IF NOT EXISTS(SELECT 1 FROM sync_libraries WHERE id=lib AND organization_id=org) THEN RETURN jsonb_build_object('status','not_found'); END IF;
+    -- Snapshot every old-client field and every segment before claiming this record.
+    SELECT jsonb_build_object('legacyMeeting',to_jsonb(m),'legacyNotes',
+      (SELECT to_jsonb(nt) FROM notes nt WHERE nt.meeting_id=m.id),'legacySegments',
+      COALESCE((SELECT jsonb_agg(to_jsonb(t) ORDER BY start_ms,id) FROM transcript_segments t WHERE meeting_id=m.id),'[]'::jsonb))
+      INTO legacy FROM meetings m WHERE id=nid AND organization_id=org FOR UPDATE;
+    INSERT INTO sync_notes(id,library_id,organization_id) VALUES(nid,lib,org) RETURNING * INTO n;
+    IF legacy IS NOT NULL THEN
+      INSERT INTO sync_revisions(id,note_id,organization_id,sequence,kind,snapshot) VALUES(revision,nid,org,seq,'legacy',legacy);
+      UPDATE sync_notes SET head_revision=revision WHERE id=nid RETURNING * INTO n;
+      revision:=gen_random_uuid(); seq:=sync_next_sequence(org);
+      generation:=n.lifecycle_generation;
+    ELSE
+      generation:=n.lifecycle_generation;
+    END IF;
+  END IF;
+  -- Server clock alone decides expiration. Purge also removes all retained content.
+  IF n.state='trashed' AND n.expires_at<=clock_timestamp() THEN
+    UPDATE sync_notes SET state='purged',lifecycle_generation=gen_random_uuid() WHERE id=nid RETURNING * INTO n;
+    UPDATE sync_revisions SET snapshot=NULL WHERE note_id=nid;
+    DELETE FROM meetings WHERE id=nid AND organization_id=org;
+    INSERT INTO sync_revisions(id,note_id,organization_id,sequence,kind) VALUES(revision,nid,org,seq,'purge');
+  END IF;
+  IF n.state='purged' THEN RETURN jsonb_build_object('status','purged','noteId',nid); END IF;
+  IF generation IS DISTINCT FROM n.lifecycle_generation THEN
+    RETURN jsonb_build_object('status','lifecycle_conflict','headRevision',n.head_revision,'lifecycleGeneration',n.lifecycle_generation);
+  END IF;
+  IF expected IS NOT NULL AND NOT EXISTS(SELECT 1 FROM sync_revisions WHERE id=expected AND note_id=nid AND organization_id=org) THEN RETURN jsonb_build_object('status','unknown_revision'); END IF;
+  IF action='upsert' THEN
+    IF n.state<>'active' THEN RETURN jsonb_build_object('status','trashed'); END IF;
+    IF EXISTS(SELECT 1 FROM sync_revisions r,
+      LATERAL jsonb_array_elements(COALESCE(r.snapshot->'sourceVersions','[]'::jsonb)) old,
+      LATERAL jsonb_array_elements(operation->'snapshot'->'sourceVersions') incoming
+      WHERE r.note_id=nid AND old->>'id'=incoming->>'id' AND old<>incoming)
+      OR EXISTS(SELECT 1 FROM sync_revisions r,
+      LATERAL jsonb_array_elements(COALESCE(r.snapshot->'summaries','[]'::jsonb)) old,
+      LATERAL jsonb_array_elements(operation->'snapshot'->'summaries') incoming
+      WHERE r.note_id=nid AND old->>'id'=incoming->>'id' AND old<>incoming) THEN
+      RETURN jsonb_build_object('status','immutable_version_conflict');
+    END IF;
+    event_kind:=CASE WHEN expected IS DISTINCT FROM n.head_revision THEN 'conflict' ELSE 'upsert' END;
+    INSERT INTO sync_revisions(id,note_id,organization_id,sequence,parent_id,kind,snapshot)
+      VALUES(revision,nid,org,seq,expected,event_kind,operation->'snapshot');
+    IF event_kind='upsert' THEN UPDATE sync_notes SET head_revision=revision WHERE id=nid RETURNING * INTO n; END IF;
+  ELSE
+    IF expected IS DISTINCT FROM n.head_revision THEN RETURN jsonb_build_object('status','revision_conflict','headRevision',n.head_revision); END IF;
+    IF action='trash' AND n.state='active' THEN
+      UPDATE sync_notes SET state='trashed',deletion_id=gen_random_uuid(),deleted_at=clock_timestamp(),
+        expires_at=clock_timestamp()+interval '30 days',lifecycle_generation=gen_random_uuid() WHERE id=nid RETURNING * INTO n;
+    ELSIF action='restore' AND n.state='trashed' AND n.deletion_id=(operation->>'deletionId')::uuid THEN
+      UPDATE sync_notes SET state='active',deletion_id=NULL,deleted_at=NULL,expires_at=NULL,lifecycle_generation=gen_random_uuid() WHERE id=nid RETURNING * INTO n;
+    ELSIF action='purge' AND n.state='trashed' AND n.deletion_id=(operation->>'deletionId')::uuid THEN
+      UPDATE sync_notes SET state='purged',lifecycle_generation=gen_random_uuid() WHERE id=nid RETURNING * INTO n;
+      UPDATE sync_revisions SET snapshot=NULL WHERE note_id=nid;
+      DELETE FROM meetings WHERE id=nid AND organization_id=org;
+    ELSE RETURN jsonb_build_object('status','lifecycle_conflict'); END IF;
+    event_kind:=action;
+    INSERT INTO sync_revisions(id,note_id,organization_id,sequence,parent_id,kind) VALUES(revision,nid,org,seq,n.head_revision,event_kind);
+  END IF;
+  result:=jsonb_build_object('status',CASE WHEN event_kind='conflict' THEN 'conflict' ELSE 'ok' END,
+    'noteId',nid,'revision',revision,'headRevision',n.head_revision,'lifecycleGeneration',n.lifecycle_generation,
+    'state',n.state,'deletionId',n.deletion_id,'deletedAt',n.deleted_at,'expiresAt',n.expires_at,'sequence',seq::text);
+  INSERT INTO sync_operations(id,organization_id,note_id,payload_hash,receipt) VALUES(opid,org,nid,payload_hash,result);
+  RETURN result;
+END $$;
+--> statement-breakpoint
+-- Guard older endpoints and web writes even when a previous application version runs.
+CREATE FUNCTION sync_guard_legacy() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE org text; nid uuid; seq bigint; lib uuid;
+BEGIN
+  IF TG_OP='DELETE' THEN org:=OLD.organization_id; nid:=OLD.id; ELSE org:=NEW.organization_id; nid:=NEW.id; END IF;
+  IF TG_OP='DELETE' AND NOT EXISTS(SELECT 1 FROM organization WHERE id=org) THEN RETURN OLD; END IF;
+  seq:=sync_next_sequence(org);
+  IF TG_OP='UPDATE' AND OLD.organization_id<>NEW.organization_id THEN RAISE EXCEPTION 'sync_owner_immutable'; END IF;
+  IF EXISTS(SELECT 1 FROM sync_notes WHERE id=nid) THEN
+    IF TG_OP='DELETE' AND EXISTS(SELECT 1 FROM sync_notes WHERE id=nid AND organization_id=org AND state='purged') THEN RETURN OLD; END IF;
+    RAISE EXCEPTION 'sync_upgrade_required';
+  END IF;
+  IF TG_OP='DELETE' THEN
+    lib:=md5('doodlenote-legacy:'||org)::uuid;
+    INSERT INTO sync_libraries(id,organization_id) VALUES(lib,org) ON CONFLICT DO NOTHING;
+    IF NOT EXISTS(SELECT 1 FROM sync_libraries WHERE id=lib AND organization_id=org) THEN RAISE EXCEPTION 'sync_library_conflict'; END IF;
+    INSERT INTO sync_notes(id,library_id,organization_id,state) VALUES(nid,lib,org,'purged');
+    INSERT INTO sync_revisions(note_id,organization_id,sequence,kind) VALUES(nid,org,seq,'purge');
+    RETURN OLD;
+  END IF;
+  NEW.updated_at:=date_trunc('milliseconds',greatest(clock_timestamp(),COALESCE((SELECT max(updated_at)+interval '1 millisecond' FROM meetings WHERE organization_id=org),clock_timestamp())));
+  RETURN NEW;
+END $$;
+--> statement-breakpoint
+CREATE TRIGGER sync_guard_legacy BEFORE INSERT OR UPDATE OR DELETE ON meetings FOR EACH ROW EXECUTE FUNCTION sync_guard_legacy();
+--> statement-breakpoint
+-- Atomic full legacy item replacement, suitable for the Neon HTTP one-statement driver.
+CREATE FUNCTION sync_legacy_write(org text, item jsonb) RETURNS void LANGUAGE plpgsql AS $$
+DECLARE nid uuid:=(item->>'id')::uuid;
+BEGIN
+  PERFORM sync_next_sequence(org);
+  IF EXISTS(SELECT 1 FROM meetings WHERE id=nid AND organization_id<>org) THEN RAISE EXCEPTION 'sync_owner_conflict'; END IF;
+  INSERT INTO meetings(id,organization_id,title,kind,status,calendar_event_id,folder_id,started_at,ended_at,created_at,updated_at)
+    VALUES(nid,org,item->>'title',item->>'kind','complete',item->>'calendarEventId',
+      CASE WHEN EXISTS(SELECT 1 FROM folders WHERE id=(item->>'folderId')::uuid AND organization_id=org) THEN (item->>'folderId')::uuid END,
+      (item->>'startedAt')::timestamptz,(item->>'endedAt')::timestamptz,(item->>'createdAt')::timestamptz,clock_timestamp())
+    ON CONFLICT(id) DO UPDATE SET title=excluded.title,kind=excluded.kind,calendar_event_id=excluded.calendar_event_id,
+      folder_id=excluded.folder_id,started_at=excluded.started_at,ended_at=excluded.ended_at,updated_at=excluded.updated_at
+      WHERE meetings.organization_id=org;
+  IF NOT FOUND THEN RAISE EXCEPTION 'sync_owner_conflict'; END IF;
+  DELETE FROM transcript_segments WHERE meeting_id=nid;
+  INSERT INTO transcript_segments(meeting_id,channel,speaker,text,start_ms,end_ms,absolute_start_ms,confidence)
+    SELECT nid,s->>'channel',s->>'speaker',s->>'text',(s->>'startMs')::integer,(s->>'endMs')::integer,(s->>'absoluteStartMs')::bigint,(s->>'confidence')::real
+    FROM jsonb_array_elements(item->'segments') s;
+  INSERT INTO notes(meeting_id,raw_content,enhanced_content,updated_at)
+    VALUES(nid,item->'rawContent',item->'enhancedContent',clock_timestamp()) ON CONFLICT(meeting_id)
+    DO UPDATE SET raw_content=excluded.raw_content,enhanced_content=excluded.enhanced_content,updated_at=excluded.updated_at;
+END $$;
+--> statement-breakpoint
+CREATE FUNCTION sync_expire(org text, lib uuid) RETURNS integer LANGUAGE plpgsql AS $$
+DECLARE n sync_notes%ROWTYPE; seq bigint; count integer:=0;
+BEGIN
+  PERFORM sync_next_sequence(org);
+  FOR n IN SELECT * FROM sync_notes WHERE organization_id=org AND library_id=lib AND state='trashed' AND expires_at<=clock_timestamp() ORDER BY expires_at LIMIT 50 FOR UPDATE LOOP
+    seq:=sync_next_sequence(org);
+    UPDATE sync_notes SET state='purged',lifecycle_generation=gen_random_uuid() WHERE id=n.id;
+    UPDATE sync_revisions SET snapshot=NULL WHERE note_id=n.id;
+    DELETE FROM meetings WHERE id=n.id AND organization_id=org;
+    INSERT INTO sync_revisions(note_id,organization_id,sequence,kind) VALUES(n.id,org,seq,'purge');
+    count:=count+1;
+  END LOOP;
+  RETURN count;
+END $$;
+--> statement-breakpoint
+CREATE FUNCTION sync_guard_legacy_content() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE nid uuid; org text;
+BEGIN
+  IF TG_OP='DELETE' THEN nid:=OLD.meeting_id; ELSE nid:=NEW.meeting_id; END IF;
+  SELECT organization_id INTO org FROM meetings WHERE id=nid;
+  IF TG_OP='DELETE' AND (org IS NULL OR NOT EXISTS(SELECT 1 FROM organization WHERE id=org)) THEN RETURN OLD; END IF;
+  IF org IS NOT NULL THEN PERFORM sync_next_sequence(org); END IF;
+  IF EXISTS(SELECT 1 FROM sync_notes WHERE id=nid) THEN
+    IF TG_OP='DELETE' AND EXISTS(SELECT 1 FROM sync_notes WHERE id=nid AND state='purged') THEN RETURN OLD; END IF;
+    RAISE EXCEPTION 'sync_upgrade_required';
+  END IF;
+  IF TG_OP='UPDATE' AND OLD.meeting_id<>NEW.meeting_id THEN RAISE EXCEPTION 'sync_owner_immutable'; END IF;
+  IF TG_OP='DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+END $$;
+--> statement-breakpoint
+CREATE TRIGGER sync_guard_legacy_notes BEFORE INSERT OR UPDATE OR DELETE ON notes FOR EACH ROW EXECUTE FUNCTION sync_guard_legacy_content();
+--> statement-breakpoint
+CREATE TRIGGER sync_guard_legacy_segments BEFORE INSERT OR UPDATE OR DELETE ON transcript_segments FOR EACH ROW EXECUTE FUNCTION sync_guard_legacy_content();
+--> statement-breakpoint
+-- Internal billing/account service only; no sync route exposes workspace-wide purge.
+CREATE FUNCTION sync_purge_workspace(org text) RETURNS integer LANGUAGE plpgsql AS $$
+DECLARE n sync_notes%ROWTYPE; seq bigint; total integer;
+BEGIN
+  PERFORM sync_next_sequence(org);
+  SELECT count(*) INTO total FROM (SELECT id FROM meetings WHERE organization_id=org UNION SELECT id FROM sync_notes WHERE organization_id=org AND state<>'purged') ids;
+  FOR n IN SELECT * FROM sync_notes WHERE organization_id=org AND state<>'purged' FOR UPDATE LOOP
+    seq:=sync_next_sequence(org);
+    UPDATE sync_notes SET state='purged',lifecycle_generation=gen_random_uuid() WHERE id=n.id;
+    UPDATE sync_revisions SET snapshot=NULL WHERE note_id=n.id;
+    INSERT INTO sync_revisions(note_id,organization_id,sequence,kind) VALUES(n.id,org,seq,'purge');
+  END LOOP;
+  DELETE FROM meetings WHERE organization_id=org;
+  RETURN total;
+END $$;

--- a/packages/db/drizzle/meta/0013_snapshot.json
+++ b/packages/db/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,2381 @@
+{
+  "id": "04ec360c-d905-4a91-b5ba-6a83b8314667",
+  "prevId": "25069405-5ba9-4ae8-9f7d-ee14f4bf4fb0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_tokens": {
+      "name": "agent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Agent'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tokens_user_id_idx": {
+          "name": "agent_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tokens_user_id_user_id_fk": {
+          "name": "agent_tokens_user_id_user_id_fk",
+          "tableFrom": "agent_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tokens_organization_id_organization_id_fk": {
+          "name": "agent_tokens_organization_id_organization_id_fk",
+          "tableFrom": "agent_tokens",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tokens_token_hash_unique": {
+          "name": "agent_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_data_deletions": {
+      "name": "billing_data_deletions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_data_deletions_due_idx": {
+          "name": "billing_data_deletions_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_data_deletions_user_id_user_id_fk": {
+          "name": "billing_data_deletions_user_id_user_id_fk",
+          "tableFrom": "billing_data_deletions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_notifications": {
+      "name": "billing_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_notifications_dedupe_key_uidx": {
+          "name": "billing_notifications_dedupe_key_uidx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_notifications_pending_idx": {
+          "name": "billing_notifications_pending_idx",
+          "columns": [
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_notifications_user_id_user_id_fk": {
+          "name": "billing_notifications_user_id_user_id_fk",
+          "tableFrom": "billing_notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.folders": {
+      "name": "folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "folders_organization_id_idx": {
+          "name": "folders_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "folders_organization_id_organization_id_fk": {
+          "name": "folders_organization_id_organization_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_stars": {
+      "name": "meeting_stars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meeting_stars_meeting_user_uidx": {
+          "name": "meeting_stars_meeting_user_uidx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meeting_stars_user_id_idx": {
+          "name": "meeting_stars_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meeting_stars_meeting_id_meetings_id_fk": {
+          "name": "meeting_stars_meeting_id_meetings_id_fk",
+          "tableFrom": "meeting_stars",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meeting_stars_user_id_user_id_fk": {
+          "name": "meeting_stars_user_id_user_id_fk",
+          "tableFrom": "meeting_stars",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_tag_links": {
+      "name": "meeting_tag_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meeting_tag_links_meeting_tag_uidx": {
+          "name": "meeting_tag_links_meeting_tag_uidx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meeting_tag_links_meeting_id_idx": {
+          "name": "meeting_tag_links_meeting_id_idx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meeting_tag_links_meeting_id_meetings_id_fk": {
+          "name": "meeting_tag_links_meeting_id_meetings_id_fk",
+          "tableFrom": "meeting_tag_links",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meeting_tag_links_tag_id_meeting_tags_id_fk": {
+          "name": "meeting_tag_links_tag_id_meeting_tags_id_fk",
+          "tableFrom": "meeting_tag_links",
+          "tableTo": "meeting_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_tags": {
+      "name": "meeting_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meeting_tags_organization_name_uidx": {
+          "name": "meeting_tags_organization_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meeting_tags_organization_id_idx": {
+          "name": "meeting_tags_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meeting_tags_organization_id_organization_id_fk": {
+          "name": "meeting_tags_organization_id_organization_id_fk",
+          "tableFrom": "meeting_tags",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetings": {
+      "name": "meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled meeting'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'meeting'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_expires_at": {
+          "name": "share_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_include_transcript": {
+          "name": "share_include_transcript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetings_organization_id_idx": {
+          "name": "meetings_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetings_organization_id_organization_id_fk": {
+          "name": "meetings_organization_id_organization_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_folder_id_folders_id_fk": {
+          "name": "meetings_folder_id_folders_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meetings_share_token_unique": {
+          "name": "meetings_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notes": {
+      "name": "notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_content": {
+          "name": "raw_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enhanced_content": {
+          "name": "enhanced_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notes_meeting_id_meetings_id_fk": {
+          "name": "notes_meeting_id_meetings_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notes_meeting_id_unique": {
+          "name": "notes_meeting_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meeting_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grandfathered": {
+          "name": "grandfathered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_user_id_user_id_fk": {
+          "name": "subscriptions_user_id_user_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_customer_id_unique": {
+          "name": "subscriptions_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_clocks": {
+      "name": "sync_clocks",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_clocks_organization_id_organization_id_fk": {
+          "name": "sync_clocks_organization_id_organization_id_fk",
+          "tableFrom": "sync_clocks",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_devices": {
+      "name": "sync_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Desktop'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_devices_user_id_idx": {
+          "name": "sync_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_devices_user_id_user_id_fk": {
+          "name": "sync_devices_user_id_user_id_fk",
+          "tableFrom": "sync_devices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_devices_organization_id_organization_id_fk": {
+          "name": "sync_devices_organization_id_organization_id_fk",
+          "tableFrom": "sync_devices",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sync_devices_token_hash_unique": {
+          "name": "sync_devices_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_libraries": {
+      "name": "sync_libraries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_libraries_organization_id_organization_id_fk": {
+          "name": "sync_libraries_organization_id_organization_id_fk",
+          "tableFrom": "sync_libraries",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_notes": {
+      "name": "sync_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_revision": {
+          "name": "head_revision",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_generation": {
+          "name": "lifecycle_generation",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "deletion_id": {
+          "name": "deletion_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_notes_library_id_sync_libraries_id_fk": {
+          "name": "sync_notes_library_id_sync_libraries_id_fk",
+          "tableFrom": "sync_notes",
+          "tableTo": "sync_libraries",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_notes_organization_id_organization_id_fk": {
+          "name": "sync_notes_organization_id_organization_id_fk",
+          "tableFrom": "sync_notes",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_operations": {
+      "name": "sync_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt": {
+          "name": "receipt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_operations_organization_id_organization_id_fk": {
+          "name": "sync_operations_organization_id_organization_id_fk",
+          "tableFrom": "sync_operations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_operations_note_id_sync_notes_id_fk": {
+          "name": "sync_operations_note_id_sync_notes_id_fk",
+          "tableFrom": "sync_operations",
+          "tableTo": "sync_notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_revisions": {
+      "name": "sync_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_revisions_org_sequence": {
+          "name": "sync_revisions_org_sequence",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_revisions_note_id_sync_notes_id_fk": {
+          "name": "sync_revisions_note_id_sync_notes_id_fk",
+          "tableFrom": "sync_revisions",
+          "tableTo": "sync_notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_revisions_organization_id_organization_id_fk": {
+          "name": "sync_revisions_organization_id_organization_id_fk",
+          "tableFrom": "sync_revisions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcript_segments": {
+      "name": "transcript_segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker": {
+          "name": "speaker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "absolute_start_ms": {
+          "name": "absolute_start_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcript_segments_meeting_id_idx": {
+          "name": "transcript_segments_meeting_id_idx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transcript_segments_meeting_id_meetings_id_fk": {
+          "name": "transcript_segments_meeting_id_meetings_id_fk",
+          "tableFrom": "transcript_segments",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verified_caller_ids": {
+      "name": "verified_caller_ids",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "outgoing_caller_id_sid": {
+          "name": "outgoing_caller_id_sid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "verified_caller_ids_user_id_user_id_fk": {
+          "name": "verified_caller_ids_user_id_user_id_fk",
+          "tableFrom": "verified_caller_ids",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_issuer_accountId_uidx": {
+          "name": "account_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1788184190594,
       "tag": "0012_perfect_pretty_boy",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1788733073040,
+      "tag": "0013_same_abomination",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/scripts/verify-sync-postgres.py
+++ b/packages/db/scripts/verify-sync-postgres.py
@@ -1,0 +1,76 @@
+"""Disposable local PostgreSQL concurrency and migration rollback check. No DATABASE_URL use."""
+import concurrent.futures
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import uuid
+
+ROOT = Path(__file__).resolve().parents[1]
+BIN = Path(os.environ.get('POSTGRES_BIN', '/opt/homebrew/bin'))
+
+
+def uid():
+    return str(uuid.uuid4())
+
+
+def operation(library, note):
+    source = uid()
+    snapshot = dict(title='synthetic', kind='note', createdAt='2026-09-06', language='en-US', text='synthetic',
+                    passages=[], speakers=[], sourceRevisionId=source, selectedSummaryId=None,
+                    sourceVersions=[dict(id=source, title='synthetic', text='synthetic', passages=[], speakers=[])],
+                    summaries=[], inkAttachments=[])
+    return dict(protocolVersion=2, libraryId=library, noteId=note, operationId=uid(), kind='upsert',
+                expectedRevision=None, expectedLifecycleGeneration=None, snapshot=snapshot)
+
+
+def main():
+    for binary in ('initdb', 'pg_ctl', 'psql'):
+        if not (BIN / binary).exists():
+            raise SystemExit('Set POSTGRES_BIN to a local PostgreSQL installation; no server was contacted.')
+    with tempfile.TemporaryDirectory(prefix='dnpg-', dir='/tmp') as temporary:
+        data = str(Path(temporary) / 'data')
+        subprocess.run([str(BIN/'initdb'), '-D', data, '-A', 'trust', '--no-locale'], check=True, capture_output=True)
+        subprocess.run([str(BIN/'pg_ctl'), '-D', data, '-l', str(Path(temporary)/'server.log'), '-o',
+                        f"-k {temporary} -p 55458 -c listen_addresses=''", '-w', 'start'], check=True, capture_output=True)
+        def sql(query):
+            return subprocess.run([str(BIN/'psql'), '-h', temporary, '-p', '55458', '-d', 'postgres',
+                                   '-X', '-A', '-t', '-v', 'ON_ERROR_STOP=1', '-c', query],
+                                  check=True, capture_output=True, text=True).stdout.strip()
+        def apply(org, op):
+            payload = json.dumps(op).replace("'", "''")
+            return json.loads(sql(f"SELECT sync_apply('{org}','{payload}'::jsonb,'synthetic-{op['operationId']}');"))
+        try:
+            journal=json.loads((ROOT/'drizzle/meta/_journal.json').read_text())['entries']
+            for entry in journal:
+                migration=(ROOT/'drizzle'/f"{entry['tag']}.sql").read_text()
+                if entry['idx']==13:
+                    sql('BEGIN;'+migration+'ROLLBACK;')
+                    assert sql("SELECT to_regclass('sync_notes') IS NULL;")=='t'
+                    sql('BEGIN;'+migration+'COMMIT;')
+                else:
+                    sql(migration)
+            sql("INSERT INTO organization(id,name,slug,created_at) VALUES('a','A','a',now()),('b','B','b',now());")
+            lib=uid()
+            with concurrent.futures.ThreadPoolExecutor(2) as pool:
+                outcomes=list(pool.map(lambda args:apply(*args), [('a',operation(lib,uid())),('b',operation(lib,uid()))]))
+            assert sorted(r['status'] for r in outcomes)==['not_found','ok'], outcomes
+            assert sql('SELECT count(*) FROM sync_notes n JOIN sync_libraries l ON n.library_id=l.id WHERE n.organization_id<>l.organization_id;')=='0'
+            lib,note=uid(),uid()
+            first=apply('a',operation(lib,note))
+            edits=[operation(lib,note),operation(lib,note)]
+            for op in edits:
+                op.update(expectedRevision=first['headRevision'], expectedLifecycleGeneration=first['lifecycleGeneration'])
+            with concurrent.futures.ThreadPoolExecutor(2) as pool:
+                outcomes=list(pool.map(lambda op:apply('a',op),edits))
+            assert sorted(r['status'] for r in outcomes)==['conflict','ok'], outcomes
+            assert sql(f"SELECT count(*) FROM sync_revisions WHERE note_id='{note}';")=='3'
+            print('PASS: migration rollback/reapply, cross-workspace library race, concurrent same-base edits preserve conflict')
+        finally:
+            subprocess.run([str(BIN/'pg_ctl'), '-D', data, '-m', 'fast', '-w', 'stop'], check=True, capture_output=True)
+
+
+if __name__=='__main__':
+    main()

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17,3 +17,5 @@ export {
   or,
   sql,
 } from "drizzle-orm";
+export * from './sync-contract';
+export * from './sync-service';

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -303,3 +303,42 @@ export const verifiedCallerIds = pgTable("verified_caller_ids", {
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
 });
+
+/** V2 sequence is allocated while holding the workspace clock row until commit. */
+export const syncClocks = pgTable('sync_clocks', {
+  organizationId: text('organization_id').primaryKey().references(() => organization.id, {onDelete:'cascade'}),
+  sequence: bigint('sequence', {mode:'number'}).notNull().default(0),
+});
+export const syncLibraries = pgTable('sync_libraries', {
+  id: uuid('id').primaryKey(),
+  organizationId: text('organization_id').notNull().references(() => organization.id, {onDelete:'cascade'}),
+});
+/** Purged rows remain as minimal durable resurrection barriers. */
+export const syncNotes = pgTable('sync_notes', {
+  id: uuid('id').primaryKey(),
+  libraryId: uuid('library_id').notNull().references(() => syncLibraries.id, {onDelete:'cascade'}),
+  organizationId: text('organization_id').notNull().references(() => organization.id, {onDelete:'cascade'}),
+  headRevision: uuid('head_revision'),
+  lifecycleGeneration: uuid('lifecycle_generation').notNull().defaultRandom(),
+  state: text('state').notNull().default('active'),
+  deletionId: uuid('deletion_id'),
+  deletedAt: timestamp('deleted_at',{withTimezone:true}),
+  expiresAt: timestamp('expires_at',{withTimezone:true}),
+});
+export const syncRevisions = pgTable('sync_revisions', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  noteId: uuid('note_id').notNull().references(() => syncNotes.id, {onDelete:'cascade'}),
+  organizationId: text('organization_id').notNull().references(() => organization.id, {onDelete:'cascade'}),
+  sequence: bigint('sequence',{mode:'number'}).notNull(),
+  parentId: uuid('parent_id'),
+  kind: text('kind').notNull(),
+  snapshot: jsonb('snapshot'),
+  createdAt: timestamp('created_at',{withTimezone:true}).notNull().defaultNow(),
+}, t => [uniqueIndex('sync_revisions_org_sequence').on(t.organizationId,t.sequence)]);
+export const syncOperations = pgTable('sync_operations', {
+  id: uuid('id').primaryKey(),
+  organizationId: text('organization_id').notNull().references(() => organization.id, {onDelete:'cascade'}),
+  noteId: uuid('note_id').notNull().references(() => syncNotes.id, {onDelete:'cascade'}),
+  payloadHash: text('payload_hash').notNull(),
+  receipt: jsonb('receipt').notNull(),
+});

--- a/packages/db/src/sync-contract.ts
+++ b/packages/db/src/sync-contract.ts
@@ -1,0 +1,124 @@
+export function canonical(value: unknown): string {
+  if(Array.isArray(value)) return '['+value.map(canonical).join(',')+']';
+  if(value && typeof value==='object') return '{'+Object.entries(value).filter(([,v])=>v!==undefined).sort(([a],[b])=>a.localeCompare(b)).map(([k,v])=>JSON.stringify(k)+':'+canonical(v)).join(',')+'}';
+  return JSON.stringify(value);
+}
+/** Version 2 is opt-in. These JSON types contain no audio, credentials or voice embeddings. */
+export interface SyncSnapshot {
+  title: string;
+  kind: 'note' | 'meeting';
+  createdAt: string;
+  language: 'en-US' | 'da-DK' | 'es-ES' | 'fr-FR' | 'de-DE';
+  text: string;
+  sourceRevisionId: string;
+  sourceVersions: Array<{id: string; title: string; text: string; passages: SyncSnapshot['passages']; speakers: SyncSnapshot['speakers']; speakerTurns?: SyncSnapshot['speakerTurns']}>;
+  selectedSummaryId: string | null;
+  folderId?: string;
+  event?: {provider: string; accountId: string; calendarId: string; eventId: string; occurrenceId: string};
+  passages: Array<{ id: string; sourceId: string; startMs: number; endMs: number; text: string; speakerId?: string }>;
+  speakers: Array<{ id: string; displayName: string; sessionId?: string; slot?: number }>;
+  speakerTurns?: Array<{speakerId:string;startMs:number;endMs:number;isFinal:boolean}>;
+  summaries: Array<{ id: string; parentId?: string; createdAt: string; origin: 'generated' | 'edited'; format: string; language: string; markdown: string; sources: Array<{libraryId:string; noteId:string; revisionId:string; kind:'personalParagraph'|'transcript'; paragraphIndex?:number; passageId?:string}> }>;
+  inkAttachments: Array<{ id: string; versionId: string }>;
+}
+export interface SyncOperation {
+  protocolVersion: 2;
+  libraryId: string;
+  noteId: string;
+  operationId: string;
+  expectedRevision: string | null;
+  expectedLifecycleGeneration: string | null;
+  kind: 'upsert' | 'trash' | 'restore' | 'purge';
+  deletionId?: string;
+  snapshot?: SyncSnapshot;
+}
+export const SYNC_CAPABILITIES = ['immutable-conflicts', 'explicit-libraries', 'stable-sources', 'summary-revisions', 'trash-30-days', 'durable-purge', 'sequence-cursor'] as const;
+export const SYNC_MAX_BYTES = 2_000_000;
+export const SYNC_MAX_SEGMENTS = 20_000;
+const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+function object(value: unknown, allowed: string[]): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('invalid_object');
+  const row = value as Record<string, unknown>;
+  if (Object.keys(row).some(k => !allowed.includes(k))) throw new Error('unsupported_field');
+  return row;
+}
+function id(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || !uuid.test(value)) throw new Error('invalid_id');
+}
+function text(value: unknown, limit: number): asserts value is string {
+  if (typeof value !== 'string' || value.length > limit) throw new Error('invalid_text');
+}
+function array(value: unknown, limit: number): unknown[] {
+  if (!Array.isArray(value) || value.length > limit) throw new Error('array_limit');
+  return value;
+}
+function unique(rows: unknown[], check: (value: unknown) => Record<string, unknown>) {
+  const ids = new Set();
+  for (const value of rows) { const row = check(value); id(row.id); if (ids.has(row.id)) throw new Error('duplicate_id'); ids.add(row.id); }
+}
+function validateTurns(turns:unknown,speakers:Array<{id:string}>) {
+  if(turns===undefined)return;
+  for(const value of array(turns,SYNC_MAX_SEGMENTS)) {const r=object(value,['speakerId','startMs','endMs','isFinal']);
+    if(!speakers.some(s=>s.id===r.speakerId)||!Number.isSafeInteger(r.startMs)||!Number.isSafeInteger(r.endMs)||Number(r.startMs)<0||Number(r.endMs)<=Number(r.startMs)||typeof r.isFinal!=='boolean')throw new Error('invalid_speaker_turn');}
+}
+export function validateSyncOperation(value: unknown): SyncOperation {
+  const row = object(value, ['protocolVersion','libraryId','noteId','operationId','expectedRevision','expectedLifecycleGeneration','kind','deletionId','snapshot']);
+  if (row.protocolVersion !== 2 || !['upsert','trash','restore','purge'].includes(String(row.kind))) throw new Error('unsupported_protocol');
+  for (const key of ['libraryId','noteId','operationId']) id(row[key]);
+  for (const key of ['expectedRevision','expectedLifecycleGeneration']) if (row[key] !== null) id(row[key]);
+  if (row.deletionId !== undefined) id(row.deletionId);
+  if (Buffer.byteLength(JSON.stringify(row)) > SYNC_MAX_BYTES) throw new Error('payload_limit');
+  if (row.kind !== 'upsert') {
+    if (row.snapshot !== undefined) throw new Error('unexpected_snapshot');
+    if (row.expectedRevision === null || row.expectedLifecycleGeneration === null) throw new Error('precondition_required');
+    if ((row.kind === 'restore' || row.kind === 'purge') && row.deletionId === undefined) throw new Error('deletion_required');
+    return row as unknown as SyncOperation;
+  }
+  const s = object(row.snapshot, ['title','kind','createdAt','language','text','passages','speakers','summaries','inkAttachments','sourceRevisionId','sourceVersions','selectedSummaryId','folderId','event','speakerTurns']);
+  text(s.title,500); text(s.text,500_000); text(s.createdAt,40);
+  if (!Number.isFinite(Date.parse(s.createdAt)) || !['note','meeting'].includes(String(s.kind)) || !['en-US','da-DK','es-ES','fr-FR','de-DE'].includes(String(s.language))) throw new Error('invalid_snapshot');
+  const speakers = array(s.speakers, 100);
+  unique(speakers, v => { const r=object(v,['id','displayName','sessionId','slot']); text(r.displayName,200); if(r.sessionId!==undefined)id(r.sessionId);if(r.slot!==undefined&&(!Number.isInteger(r.slot)||Number(r.slot)<0||Number(r.slot)>3))throw new Error('invalid_slot');return r; });
+  const speakerIds = new Set(speakers.map(v => (v as {id:string}).id));
+  unique(array(s.passages,SYNC_MAX_SEGMENTS), v => {
+    const r=object(v,['id','sourceId','startMs','endMs','text','speakerId']); id(r.sourceId); text(r.text,10_000);
+    if (!Number.isSafeInteger(r.startMs) || !Number.isSafeInteger(r.endMs) || Number(r.startMs)<0 || Number(r.endMs)<Number(r.startMs)) throw new Error('invalid_anchor');
+    if (r.speakerId !== undefined && !speakerIds.has(String(r.speakerId))) throw new Error('unknown_speaker');
+    return r;
+  });
+  id(s.sourceRevisionId);
+  if(s.folderId!==undefined) id(s.folderId);
+  if(s.event!==undefined) { const e=object(s.event,['provider','accountId','calendarId','eventId','occurrenceId']); for(const key of ['provider','accountId','calendarId','eventId','occurrenceId']) text(e[key],512); }
+  const versions = array(s.sourceVersions,100);
+  unique(versions, v => {
+    const r=object(v,['id','title','text','passages','speakers','speakerTurns']); text(r.title,500); text(r.text,500_000);
+    unique(array(r.speakers,100), value=>{const speaker=object(value,['id','displayName','sessionId','slot']);text(speaker.displayName,200);if(speaker.sessionId!==undefined)id(speaker.sessionId);if(speaker.slot!==undefined&&(!Number.isInteger(speaker.slot)||Number(speaker.slot)<0||Number(speaker.slot)>3))throw new Error('invalid_slot');return speaker;});
+    unique(array(r.passages,SYNC_MAX_SEGMENTS), value=>{const passage=object(value,['id','sourceId','startMs','endMs','text','speakerId']);id(passage.sourceId);text(passage.text,10_000);
+      if(!Number.isSafeInteger(passage.startMs)||!Number.isSafeInteger(passage.endMs)||Number(passage.startMs)<0||Number(passage.endMs)<Number(passage.startMs)) throw new Error('invalid_anchor');
+      if(passage.speakerId!==undefined&&!(r.speakers as Array<{id:string}>).some((speaker: {id:string})=>speaker.id===passage.speakerId)) throw new Error('unknown_speaker');return passage;});
+    validateTurns(r.speakerTurns,r.speakers as Array<{id:string}>);
+    return r;
+  });
+  validateTurns(s.speakerTurns,s.speakers as Array<{id:string}>);
+  const sources = new Map(versions.map(v=>[(v as {id:string}).id,v as Record<string,unknown>]));
+  const current = sources.get(s.sourceRevisionId);
+  if(!current||current.title!==s.title||current.text!==s.text||canonical(current.passages)!==canonical(s.passages)||canonical(current.speakers)!==canonical(s.speakers)||canonical(current.speakerTurns)!==canonical(s.speakerTurns)) throw new Error('current_source_mismatch');
+  const summaries=array(s.summaries,100);
+  unique(summaries, v => { const r=object(v,['id','parentId','createdAt','origin','format','language','markdown','sources']);
+    if(r.parentId!==undefined) id(r.parentId); text(r.createdAt,40); if(!Number.isFinite(Date.parse(r.createdAt))||!['generated','edited'].includes(String(r.origin))) throw new Error('invalid_summary');
+    text(r.format,100); text(r.language,40); text(r.markdown,500_000);
+    for(const value of array(r.sources,SYNC_MAX_SEGMENTS)) { const anchor=object(value,['libraryId','noteId','revisionId','kind','paragraphIndex','passageId']);
+      if(anchor.libraryId!==row.libraryId||anchor.noteId!==row.noteId) throw new Error('source_scope'); id(anchor.revisionId);
+      const source=sources.get(anchor.revisionId); if(!source) throw new Error('missing_source');
+      if(anchor.kind==='personalParagraph') { if(anchor.passageId!==undefined||!Number.isInteger(anchor.paragraphIndex)||Number(anchor.paragraphIndex)<0||Number(anchor.paragraphIndex)>=String(source.text).split('\n').length) throw new Error('missing_paragraph'); }
+      else if(anchor.kind==='transcript') { if(anchor.paragraphIndex!==undefined)throw new Error('invalid_anchor'); id(anchor.passageId); if(!(source.passages as Array<{id:string}>).some(p=>p.id===anchor.passageId)) throw new Error('missing_passage'); }
+      else throw new Error('invalid_anchor');
+    } return r; });
+  const summaryMap=new Map(summaries.map(v=>[(v as {id:string}).id,v as {id:string;parentId?:string}]));
+  for(const summary of summaryMap.values()) { const seen=new Set<string>(); let node:typeof summary|undefined=summary;
+    while(node) { if(seen.has(node.id))throw new Error('cyclic_summary');seen.add(node.id);if(node.parentId&&!summaryMap.has(node.parentId))throw new Error('missing_parent');node=node.parentId?summaryMap.get(node.parentId):undefined; }
+  }
+  if(s.selectedSummaryId!==null&&!summaryMap.has(String(s.selectedSummaryId)))throw new Error('missing_selected_summary');
+  unique(array(s.inkAttachments,1000), v => { const r=object(v,['id','versionId']); id(r.versionId); return r; });
+  return row as unknown as SyncOperation;
+}

--- a/packages/db/src/sync-service.test.ts
+++ b/packages/db/src/sync-service.test.ts
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import { sql } from 'drizzle-orm';
+import { createInMemoryDb } from './testing';
+import { applySync, pullSync, writeLegacy } from './sync-service';
+import { validateSyncOperation, type SyncOperation, type SyncSnapshot } from './sync-contract';
+
+function snapshot(text='original'):SyncSnapshot {
+  const id=randomUUID();
+  return {title:'Meeting',kind:'meeting',createdAt:'2026-09-06T00:00:00Z',language:'da-DK',text,
+    sourceRevisionId:id,sourceVersions:[{id,title:'Meeting',text,passages:[],speakers:[]}],selectedSummaryId:null,
+    passages:[],speakers:[],summaries:[],inkAttachments:[]};
+}
+function operation(libraryId:string=randomUUID(),noteId:string=randomUUID()):SyncOperation {
+  return {protocolVersion:2,libraryId,noteId,operationId:randomUUID(),expectedRevision:null,expectedLifecycleGeneration:null,kind:'upsert',snapshot:snapshot()};
+}
+interface Receipt {status:string;headRevision:string;revision:string;lifecycleGeneration:string;deletionId:string;state:string}
+async function setup() {
+  const instance=await createInMemoryDb();
+  await instance.db.execute(sql`insert into organization(id,name,slug,created_at) values ('a','A','a',now()),('b','B','b',now())`);
+  return instance;
+}
+function next(op:SyncOperation,r:Receipt,kind:SyncOperation['kind']='upsert'):SyncOperation {
+  return {...op,operationId:randomUUID(),kind,expectedRevision:r.headRevision,expectedLifecycleGeneration:r.lifecycleGeneration,
+    ...(kind==='upsert'?{snapshot:snapshot('edited')}:{snapshot:undefined}),...(r.deletionId?{deletionId:r.deletionId}:{})};
+}
+
+test('real migrated database: conflicts, replay, tenant and lineage barriers',async()=>{
+  const {db,close}=await setup();try {
+    const op=operation();const initial=await applySync(db,'a',op) as Receipt;assert.equal(initial.status,'ok');
+    assert.deepEqual(await applySync(db,'a',op),initial);
+    assert.equal((await applySync(db,'b',op) as Receipt).status,'not_found');
+    const edit=next(op,initial);const edited=await applySync(db,'a',edit) as Receipt;assert.equal(edited.status,'ok');
+    const stale=next(op,initial);const conflict=await applySync(db,'a',stale) as Receipt;assert.equal(conflict.status,'conflict');
+    assert.equal(conflict.headRevision,edited.headRevision);
+    assert.equal((await applySync(db,'a',{...stale,snapshot:snapshot('different')}) as Receipt).status,'operation_reused');
+    assert.equal((await applySync(db,'a',{...next(op,edited),expectedRevision:randomUUID()}) as Receipt).status,'unknown_revision');
+    const page1=await pullSync(db,'a',op.libraryId,'0',1);assert.equal(page1.changes.length,1);assert.equal(page1.hasMore,true);
+    const page2=await pullSync(db,'a',op.libraryId,page1.after,2);assert.equal(page2.changes.length,2);assert.equal(page2.changes[1]!.kind,'conflict');
+    await assert.rejects(pullSync(db,'b',op.libraryId));
+    const immutable=next(op,edited);immutable.snapshot={...edit.snapshot!,text:'changed',sourceVersions:[{...edit.snapshot!.sourceVersions[0]!,text:'changed'}]};
+    assert.equal((await applySync(db,'a',immutable) as Receipt).status,'immutable_version_conflict');
+  }finally {await close();}
+});
+test('Trash, explicit restore, expiry and purge erase all snapshots and block old replays',async()=>{
+  const {db,close}=await setup();try {
+    const op=operation();const initial=await applySync(db,'a',op) as Receipt;
+    assert.equal((await applySync(db,'a',{...next(op,initial,'purge'),deletionId:randomUUID()}) as Receipt).status,'lifecycle_conflict');
+    const trash=await applySync(db,'a',next(op,initial,'trash')) as Receipt;assert.equal(trash.state,'trashed');
+    assert.equal((await applySync(db,'a',next(op,initial)) as Receipt).status,'lifecycle_conflict');
+    const restored=await applySync(db,'a',next(op,trash,'restore')) as Receipt;assert.equal(restored.state,'active');
+    const again=await applySync(db,'a',next(op,restored,'trash')) as Receipt;
+    const purge=await applySync(db,'a',next(op,again,'purge')) as Receipt;assert.equal(purge.state,'purged');
+    assert.equal((await applySync(db,'a',op) as Receipt).status,'purged');
+    const feed=await pullSync(db,'a',op.libraryId);assert.ok(feed.changes.every(r=>r.snapshot===null&&r.state==='purged'));
+    const exp=operation(op.libraryId);const created=await applySync(db,'a',exp) as Receipt;
+    await applySync(db,'a',next(exp,created,'trash'));
+    await db.execute(sql`update sync_notes set expires_at=now()-interval '1 second' where id=${exp.noteId}::uuid`);
+    const expired=await pullSync(db,'a',op.libraryId);assert.ok(expired.changes.filter(r=>r.note_id===exp.noteId).every(r=>r.snapshot===null&&r.state==='purged'));
+  }finally {await close();}
+});
+test('legacy adoption retains full original; old writers/deletes cannot bypass protection',async()=>{
+  const {db,close}=await setup();try {
+    const op=operation();
+    const legacy={id:op.noteId,title:'Legacy',kind:'meeting',createdAt:'2026-09-06T00:00:00Z',segments:[{channel:'mic',speaker:'You',text:'old',startMs:0,endMs:10}],rawContent:{markdown:'notes'},enhancedContent:{markdown:'summary'}};
+    await writeLegacy(db,'a',legacy);
+    const receipt=await applySync(db,'a',op) as Receipt;assert.equal(receipt.status,'conflict');
+    const feed=await pullSync(db,'a',op.libraryId);assert.equal(feed.changes[0]!.kind,'legacy');
+    assert.equal((feed.changes[0]!.snapshot as {legacySegments:unknown[]}).legacySegments.length,1);
+    await assert.rejects(writeLegacy(db,'a',legacy));
+    await assert.rejects(db.execute(sql`update notes set raw_content='{}' where meeting_id=${op.noteId}::uuid`));
+    await assert.rejects(db.execute(sql`delete from meetings where id=${op.noteId}::uuid`));
+    const fresh=operation();await writeLegacy(db,'a',{...legacy,id:fresh.noteId});
+    await db.execute(sql`delete from meetings where id=${fresh.noteId}::uuid`);
+    assert.equal((await applySync(db,'a',fresh) as Receipt).status,'not_found'); // different library cannot move a purge receipt
+    await assert.rejects(writeLegacy(db,'a',{...legacy,id:fresh.noteId}));
+  }finally {await close();}
+});
+test('legacy SQL failure rolls back row, notes and transcript; cross-owner rejected',async()=>{
+  const {db,close}=await setup();try {
+    const id=randomUUID();const item={id,title:'before',kind:'meeting',createdAt:'2026-09-06',segments:[{channel:'mic',speaker:'You',text:'original',startMs:0,endMs:1}]};
+    await writeLegacy(db,'a',item);
+    await assert.rejects(writeLegacy(db,'a',{...item,title:'after',segments:[{channel:'mic',speaker:'x',text:'bad',startMs:'not-number',endMs:1}]}));
+    const row=await db.execute(sql`select title from meetings where id=${id}::uuid`);assert.equal(row.rows[0]!.title,'before');
+    await assert.rejects(writeLegacy(db,'b',item));
+    const segments=await db.execute(sql`select text from transcript_segments where meeting_id=${id}::uuid`);assert.equal(segments.rows[0]!.text,'original');
+  }finally {await close();}
+});
+test('strict payloads retain typed paragraph anchors and reject arbitrary fields, cycles, dangling sources, oversized transcripts',()=>{
+  const op=operation();const s=op.snapshot!;const sid=randomUUID();s.summaries=[{id:sid,createdAt:s.createdAt,origin:'generated',format:'meeting',language:'da-DK',markdown:'Summary',sources:[{libraryId:op.libraryId,noteId:op.noteId,revisionId:s.sourceRevisionId,kind:'personalParagraph',paragraphIndex:0}]}];s.selectedSummaryId=sid;
+  assert.equal(validateSyncOperation(op),op);
+  assert.throws(()=>validateSyncOperation({...op,snapshot:{...s,audio:'forbidden'}}));
+  assert.throws(()=>validateSyncOperation({...op,snapshot:{...s,summaries:[{...s.summaries[0],parentId:sid}]}}));
+  assert.throws(()=>validateSyncOperation({...op,snapshot:{...s,selectedSummaryId:randomUUID()}}));
+  assert.throws(()=>validateSyncOperation({...op,snapshot:{...s,passages:Array(20001).fill({})}}));
+});
+
+test('6001-segment legacy and v2 round trips preserve the final sentinel',async()=>{
+ const {db,close}=await setup();try {
+  const legacyId=randomUUID();const segments=Array.from({length:6001},(_,i)=>({channel:'mic',speaker:'You',text:i===6000?'final-sentinel':'word',startMs:i*10,endMs:i*10+9}));
+  await writeLegacy(db,'a',{id:legacyId,title:'long',kind:'meeting',createdAt:'2026-09-06',segments});
+  const stored=await db.execute(sql`select text from transcript_segments where meeting_id=${legacyId}::uuid order by start_ms`);assert.equal(stored.rows.length,6001);assert.equal(stored.rows[6000]!.text,'final-sentinel');
+  const operation=opLong();await applySync(db,'a',operation);const page=await pullSync(db,'a',operation.libraryId);
+  const restored=page.changes[0]!.snapshot as SyncSnapshot;assert.equal(restored.passages.length,6001);assert.equal(restored.passages[6000]!.text,'final-sentinel');
+ }finally{await close();}
+});
+function opLong(){const op=operation();const s=op.snapshot!;s.passages=Array.from({length:6001},(_,i)=>({id:randomUUID(),sourceId:op.noteId,startMs:i*10,endMs:i*10+9,text:i===6000?'final-sentinel':'word'}));s.sourceVersions[0]!.passages=s.passages;return op;}
+
+test('retained prior typed source resolves summary after a new text revision; dangling anchors rejected',()=>{
+ const op=operation();const s=op.snapshot!;const old=s.sourceVersions[0]!;
+ s.sourceRevisionId=randomUUID();s.text='new paragraph';s.sourceVersions.push({id:s.sourceRevisionId,title:s.title,text:s.text,passages:[],speakers:[]});
+ s.summaries=[{id:randomUUID(),createdAt:s.createdAt,origin:'generated',format:'meeting',language:s.language,markdown:'Old summary',sources:[{libraryId:op.libraryId,noteId:op.noteId,revisionId:old.id,kind:'personalParagraph',paragraphIndex:0}]}];
+ assert.equal(validateSyncOperation(op).snapshot!.sourceVersions[0]!.text,'original');
+ const bad=structuredClone(op);bad.snapshot!.summaries[0]!.sources[0]!.revisionId=randomUUID();assert.throws(()=>validateSyncOperation(bad));
+ const badParagraph=structuredClone(op);badParagraph.snapshot!.summaries[0]!.sources[0]!.paragraphIndex=4;assert.throws(()=>validateSyncOperation(badParagraph));
+ const badPassage=structuredClone(op);badPassage.snapshot!.summaries[0]!.sources=[{libraryId:op.libraryId,noteId:op.noteId,revisionId:old.id,kind:'transcript',passageId:randomUUID()}];assert.throws(()=>validateSyncOperation(badPassage));
+});
+
+test('organization cascade removes protected and legacy data without tombstone recreation',async()=>{
+ const {db,close}=await setup();try {
+  const op=operation();await applySync(db,'a',op);
+  await writeLegacy(db,'a',{id:randomUUID(),title:'legacy',kind:'note',createdAt:'2026-09-06',segments:[]});
+  await db.execute(sql`delete from organization where id='a'`);
+  const rows=await db.execute(sql`select count(*)::integer as count from sync_notes where organization_id='a'`);assert.equal(rows.rows[0]!.count,0);
+ }finally{await close();}
+});
+
+test('UUID case aliases cannot bypass immutable source identity or duplicate detection',()=>{
+ const op=operation();const upper=structuredClone(op);upper.snapshot!.sourceRevisionId=upper.snapshot!.sourceRevisionId.toUpperCase();upper.snapshot!.sourceVersions[0]!.id=upper.snapshot!.sourceRevisionId;
+ assert.throws(()=>validateSyncOperation(upper));
+ const duplicate=structuredClone(op);duplicate.snapshot!.sourceVersions.push({...duplicate.snapshot!.sourceVersions[0]!,id:duplicate.snapshot!.sourceVersions[0]!.id.toUpperCase()});
+ assert.throws(()=>validateSyncOperation(duplicate));
+});
+
+test('object key order does not alter retained source equality',()=>{
+ const op=operation();const p={id:randomUUID(),sourceId:op.noteId,startMs:0,endMs:10,text:'text'};
+ op.snapshot!.passages=[p];op.snapshot!.sourceVersions[0]!.passages=[{text:p.text,endMs:p.endMs,startMs:p.startMs,sourceId:p.sourceId,id:p.id}];
+ assert.equal(validateSyncOperation(op),op);
+});
+test('invalid initial folder creates no hidden note or legacy adoption',async()=>{
+ const {db,close}=await setup();try {
+  for(const adopted of [false,true]) {
+   const op=operation();op.snapshot!.folderId=randomUUID();
+   const item={id:op.noteId,title:'legacy',kind:'note',createdAt:'2026-09-06',segments:[]};
+   if(adopted)await writeLegacy(db,'a',item);
+   assert.equal((await applySync(db,'a',op) as Receipt).status,'invalid_folder');
+   const count=await db.execute(sql`select count(*)::integer as count from sync_notes where id=${op.noteId}::uuid`);assert.equal(count.rows[0]!.count,0);
+   if(adopted)await writeLegacy(db,'a',{...item,title:'still editable'});
+   delete op.snapshot!.folderId;
+   assert.equal((await applySync(db,'a',op) as Receipt).status,adopted?'conflict':'ok');
+  }
+ }finally{await close();}
+});

--- a/packages/db/src/sync-service.ts
+++ b/packages/db/src/sync-service.ts
@@ -1,0 +1,35 @@
+import { createHash } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import type { Db } from './client';
+import { validateSyncOperation, canonical } from './sync-contract';
+
+function rows(result: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(result) ? result : (result as {rows:Array<Record<string,unknown>>}).rows;
+}
+export async function applySync(db: Db, organizationId: string, value: unknown) {
+  const operation=validateSyncOperation(value);
+  const serialized=canonical(operation);
+  const hash=createHash('sha256').update(serialized).digest('hex');
+  const result=await db.execute(sql`select sync_apply(${organizationId},${serialized}::jsonb,${hash}) as receipt`);
+  return rows(result)[0]!.receipt;
+}
+export async function writeLegacy(db: Db, organizationId:string, item: unknown) {
+  await db.execute(sql`select sync_legacy_write(${organizationId},${JSON.stringify(item)}::jsonb)`);
+}
+/** Cursor ownership checked against authenticated org+library; no client tenant selection. */
+export async function pullSync(db: Db, organizationId:string, libraryId:string, after='0', limit=20) {
+  if(!/^[0-9a-f-]{36}$/i.test(libraryId)||!/^\d{1,16}$/.test(after)||!Number.isSafeInteger(Number(after))||limit<1||limit>50)throw new Error('invalid_cursor');
+  const library=rows(await db.execute(sql`select id from sync_libraries where id=${libraryId}::uuid and organization_id=${organizationId}`));
+  if(!library.length)throw new Error('not_found');
+  await db.execute(sql`select sync_expire(${organizationId},${libraryId}::uuid)`);
+  const result=rows(await db.execute(sql`select r.id,r.note_id,r.parent_id,r.sequence::text,r.kind,r.created_at,
+      case when n.state='purged' or (n.state='trashed' and n.expires_at<=clock_timestamp()) then null else r.snapshot end as snapshot,
+      n.head_revision,n.lifecycle_generation,
+      n.state,
+      n.deletion_id,n.deleted_at,n.expires_at
+    from sync_revisions r join sync_notes n on n.id=r.note_id
+    where r.organization_id=${organizationId} and n.organization_id=${organizationId} and n.library_id=${libraryId}::uuid and r.sequence>${after}::bigint
+    order by r.sequence limit ${limit+1}`));
+  const page=result.slice(0,limit);
+  return {changes:page,hasMore:result.length>limit,after:page.length?String(page.at(-1)!.sequence):after};
+}

--- a/packages/db/src/testing.ts
+++ b/packages/db/src/testing.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import {readFile} from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 import { PGlite } from "@electric-sql/pglite";
@@ -19,9 +20,16 @@ export interface InMemoryDb {
  * Creates a fresh in-memory PGlite database and applies every migration in
  * packages/db/drizzle. Nothing touches disk — intended for smoke tests.
  */
-export async function createInMemoryDb(): Promise<InMemoryDb> {
+export async function createInMemoryDb(options: {throughMigration?: number} = {}): Promise<InMemoryDb> {
   const client = new PGlite();
   const db = drizzle(client, { schema: fullSchema });
-  await migrate(db, { migrationsFolder: path.join(packageRoot, "drizzle") });
+  if(options.throughMigration===undefined) {
+    await migrate(db, { migrationsFolder: path.join(packageRoot, "drizzle") });
+  } else {
+    const journal=JSON.parse(await readFile(path.join(packageRoot,'drizzle/meta/_journal.json'),'utf8')) as {entries:Array<{idx:number;tag:string}>};
+    for(const entry of journal.entries.filter(e=>e.idx<=options.throughMigration!)) {
+      await client.exec(await readFile(path.join(packageRoot,'drizzle',entry.tag+'.sql'),'utf8'));
+    }
+  }
   return { db, close: () => client.close() };
 }


### PR DESCRIPTION
## Linear Issue

[ONY-258](https://linear.app/onyxdevlabs/issue/ONY-258/version-cloud-sync-for-mobile-conflicts-summaries-and-trash)

## Outcome

Adds an explicitly disabled v2 sync contract that preserves concurrent mobile versions, original source anchors, summary history and permanent deletion barriers. Existing clients keep their endpoints; an adopted richer record cannot be overwritten or resurrected by old/offline writes. No production migration, flag/secret change or client rollout is included.

## What Changed

- Strict lowercase UUID wire identities, complete immutable source revisions, full typed/transcript citations, summary origin/parent/selection, stable speakers/turns, event metadata and ink references. Audio/voice data and unknown payload fields are rejected.
- PostgreSQL atomic per-item operations, known-base conflict retention, immutable history checks, payload-bound replay receipts and workspace-serialized sequence feed with signed scoped cursors.
- Explicit Trash/restore/purge, server-clock expiry cleanup and permanent minimal receipts. Personal billing purge clears adopted/native-only snapshots while preserving shared data; organization cascade remains safe.
- Additive migration and guards protecting old meeting/note/segment writers. Enabled legacy push is atomic and complete; oversized input fails explicitly instead of silently truncating at 5,000 segments. Partial legacy deletion failure returns HTTP409 so installed clients retain pending deletes.
- Protocol/native mapping and staged rollout/rollback guidance in `docs/sync/protocol-v2.md`. V2 is unavailable before explicit flag and cursor-secret configuration; tests verify legacy push/pull against the actual pre-v2 schema.

## Acceptance Criteria Evidence

- [x] Version/capability negotiation and full mobile source/summary/library/lifecycle contract: strict validation, retained old paragraph references, dangling/cyclic/case-alias rejection fixtures.
- [x] Both concurrent edited versions retained; replay idempotent; stale lifecycle/foreign base/old writer resurrection rejected: real migrated PGlite SQL and simultaneous local PostgreSQL connections.
- [x] Complete long transcript or explicit error: 6,001-segment legacy and v2 round trips retain final sentinel; >20,000 passages and >2MB bodies reject.
- [x] Authenticated workspace scope and cursor binding; per-item safe retries: route fixtures and concurrent foreign-library creation tests.
- [x] Migration rollback/reapply, old-schema operation, mixed-client adoption, personal purge/cascade fixtures and staged rollout documented.
- [ ] Accountable human product QA on the PR and approved staging rollout remain before merge/release completion. No production behavior is claimed from source tests.

## Verification

- `pnpm --filter @repo/db test`: 18 passed, including SQL rollback, conflicts, lifecycle, 6,001-segment transfer and source identity edge cases.
- `pnpm --filter @repo/db typecheck`: passed.
- `pnpm --filter web test`: all 99 passed at the PR head in CI; targeted `tsx --test tests/sync-v2.test.ts`: all 5 passed locally including old-schema compatibility.
- `pnpm --filter web typecheck`, `pnpm --filter web lint`, `pnpm --filter web build`: passed.
- `pnpm --filter desktop test`: 163 passed, 6 existing environment-dependent tests skipped; `pnpm --filter desktop typecheck`: passed.
- `python3 packages/db/scripts/verify-sync-postgres.py`: passed using a disposable local PostgreSQL cluster, Unix socket only; rollback/reapply and true concurrent ownership/conflict cases. Root independently reproduced this and reviewed the final fixes.
- `git diff --check`: passed.
- All remote checks passed at `06ad7fe705e564646e986bafecc53af8d3187c42`: [CI including database 18/web 99 and Windows packaging](https://github.com/Onyx-Dev-Labs/doodle-note/actions/runs/34064531928), [CodeQL](https://github.com/Onyx-Dev-Labs/doodle-note/actions/runs/34064531860), and Vercel preview. Required human review remains pending. Native CI is not triggered because this PR changes no native source.

## Local QA

Check this:
1. Run `pnpm --filter @repo/db test` and the isolated PostgreSQL command above. In the conflict fixture, verify accepted and alternate versions both remain and a replay produces no duplicate.
2. In a disposable workspace using the documented v2 setup, trash and restore a note with the matching deletion identity. Purge it, then replay an old write: expect `purged` and no retained snapshot payload.
3. Use a pull cursor in a different workspace/library or modify it: expect a sanitized rejection. Interrupt a multi-item push and retry original operation IDs; successful siblings must remain unchanged.
4. Review the pre-v2-schema/old-client route tests and rollout document. With the flag absent, v2 must be unavailable and old push/pull usable; a protected deletion failure must be non-2xx to an installed old client.
5. Review an edited summary still citing older typed text. It must resolve against the retained source revision, not the latest text. Ink object access/readers and native sync UI follow ONY-259/261/262.

## Risks and Release Notes

The additive migration installs database guards; do not remove them or purge receipts after adoption. Flag-off rollback preserves data but richer records remain write-protected for old clients. Legacy flag-off replacement retains its historical multi-statement limitation. Expiry cleanup runs on service access in bounded batches; an idle service is not a guaranteed wall-clock cleanup scheduler. Any production migration, secrets/flag enablement and rollout require explicit authority. Merging into main automatically triggers the configured Vercel production deployment. That deploy activates the legacy API validation/compatibility and migration-aware purge-adapter code, while v2 remains disabled and migration 0013 is not applied by this PR. Before migration, recovery is redeploying the prior verified Vercel artifact. After migration/adoption, retain the guards and purge adapter and use a forward-compatible rollback. Merge approval must acknowledge this automatic production code deployment; do not treat it as permission to apply the migration or enable v2.

## Follow-ups

ONY-259 private ink storage/cleanup, ONY-261 compatible readers, ONY-262 native synchronization and provisional server lifecycle reconciliation. No new issues or production resources created. Keep issue In Review until its reviewed merge and required QA boundary are met.
