### PR TITLE
[ONY-260] Add mobile Trash, restoration, and local audio storage controls

### DIFF
--- a/apps/mobile-native/Sources/DoodleNoteApp.swift
+++ b/apps/mobile-native/Sources/DoodleNoteApp.swift
@@ -9,8 +9,14 @@ struct DoodleNoteApp: App {
     init() {
         let base = URL.applicationSupportDirectory.appendingPathComponent("DoodleNoteNative", isDirectory: true)
         #if DEBUG
-        let root = ProcessInfo.processInfo.arguments.contains("--ui-testing")
-            ? URL.applicationSupportDirectory.appendingPathComponent("DoodleNoteUITests", isDirectory: true) : base
+        let testing = ProcessInfo.processInfo.arguments.contains("--ui-testing")
+        let storageFixture = testing && ProcessInfo.processInfo.arguments.contains("--storage-fixture")
+        let fixtureArgument = ProcessInfo.processInfo.arguments.first(where: { $0.hasPrefix("--fixture-id=") })
+        let fixtureID = fixtureArgument.flatMap { UUID(uuidString: String($0.dropFirst("--fixture-id=".count))) } ?? UUID()
+        let testDirectory = storageFixture ? "DoodleNoteStorageUITests/" + fixtureID.uuidString : "DoodleNoteUITests"
+        let root = testing
+            ? URL.applicationSupportDirectory.appendingPathComponent(testDirectory, isDirectory: true) : base
+        if storageFixture { try? StorageUITestFixture.prepare(root: root) }
         #else
         let root = base
         #endif
@@ -20,8 +26,15 @@ struct DoodleNoteApp: App {
     var body: some Scene {
         WindowGroup {
             LibraryView(library: library, recording: recording)
+                .onChange(of: recording.busy) { _, busy in
+                    if !busy && recording.noteID == nil {
+                        Task { await library.processRetention(captureActive: recording.busy || recording.noteID != nil) }
+                    }
+                }
                 .onChange(of: scenePhase) { _, phase in
-                    if phase != .active {
+                    if phase == .active {
+                        Task { await library.processRetention(captureActive: recording.busy || recording.noteID != nil) }
+                    } else {
                         let task = SaveBackgroundLifetime()
                         Task {
                             await library.flush()
@@ -41,6 +54,7 @@ struct LibraryView: View {
     @State private var folderID: UUID?
     @State private var folderName = ""
     @State private var creatingFolder = false
+    @State private var showStorage = false
 
     private var visibleNotes: [NoteRecord] {
         library.visibleNotes.filter { note in
@@ -87,6 +101,7 @@ struct LibraryView: View {
                 }
             }
             .toolbar {
+                Button("Storage & Trash", systemImage: "trash") { showStorage = true }
                 Button("New folder", systemImage: "folder.badge.plus") { creatingFolder = true }
                 Button("New note", systemImage: "square.and.pencil") { selection = library.create() }
                     .disabled(library.disk == nil || library.loading).accessibilityIdentifier("newNote")
@@ -99,6 +114,7 @@ struct LibraryView: View {
                     description: Text("Your notes stay on this device. No account is required."))
             }
         }
+        .sheet(isPresented: $showStorage) { StorageView(library: library, recording: recording) }
         .alert("New folder", isPresented: $creatingFolder) {
             TextField("Folder name", text: $folderName)
             Button("Create") { let name = folderName; folderName = ""; Task { await library.addFolder(name) } }
@@ -113,7 +129,7 @@ struct LibraryView: View {
                     Button("Retry saving") { library.retrySaving() }.accessibilityIdentifier("retrySaving")
                 }.padding().background(.regularMaterial)
             }
-            if let problem = library.problem ?? recording.problem {
+            if let problem = library.problem ?? library.storageProblem ?? recording.problem {
                 Text(problem).font(.callout).foregroundStyle(.red)
                     .padding().frame(maxWidth: .infinity).background(.regularMaterial)
                     .accessibilityIdentifier("storageProblem")

--- a/apps/mobile-native/Sources/LibraryContracts.swift
+++ b/apps/mobile-native/Sources/LibraryContracts.swift
@@ -88,6 +88,7 @@ struct SummaryVersion: Codable, Identifiable, Equatable, Sendable {
 struct NoteMetadata: Codable, Equatable, Sendable {
     var libraryID = LibraryRecord.localID
     var folderID: UUID? = nil
+    var lifecycleGeneration: UUID? = nil
     var revisionID = UUID()
     var event: EventOccurrenceKey? = nil
     var summaries: [SummaryVersion] = []

--- a/apps/mobile-native/Sources/LibraryRepository.swift
+++ b/apps/mobile-native/Sources/LibraryRepository.swift
@@ -11,7 +11,7 @@ actor LibraryRepository {
         try disk.load()
     }
 
-    private func readCatalog() throws -> LibraryCatalog {
+    func readCatalog() throws -> LibraryCatalog {
         let url = disk.root.appendingPathComponent("libraries.json")
         guard FileManager.default.fileExists(atPath: url.path) else { return LibraryCatalog() }
         let value = try JSONDecoder().decode(LibraryCatalog.self, from: Data(contentsOf: url))
@@ -32,7 +32,7 @@ actor LibraryRepository {
         return value
     }
 
-    private func saveCatalog(_ value: LibraryCatalog) throws {
+    func saveCatalog(_ value: LibraryCatalog) throws {
         try disk.write(value, to: disk.root.appendingPathComponent("libraries.json"))
     }
 
@@ -76,6 +76,8 @@ actor LibraryRepository {
 
     func resolve(_ anchor: SourceAnchor, identities: Set<LibraryIdentity>) throws -> String? {
         try authorize(anchor.libraryID, identities: identities)
+        let lifecycle = try disk.lifecycle(noteID: anchor.noteID, libraryID: anchor.libraryID)
+        guard lifecycle.state == .active, !lifecycle.restorePending else { throw LifecycleError.unavailable }
         return try disk.revision(anchor).resolve(anchor)
     }
 

--- a/apps/mobile-native/Sources/NoteEditor.swift
+++ b/apps/mobile-native/Sources/NoteEditor.swift
@@ -11,14 +11,17 @@ struct NoteEditor: View {
     @State private var showSpeakers = false
     @State private var summaryText = ""
     @State private var editingSummary: SummaryVersion?
+    @State private var confirmAudioRemoval = false
 
     private var note: NoteRecord { library.note(id) ?? NoteRecord(id: id) }
     private var isActive: Bool { recording.noteID == id }
     private var audio: [URL] { library.disk?.audioFiles(for: id) ?? [] }
 
-    private func play(at seconds: TimeInterval = 0) {
-        guard recording.permitsPlayback else { return }
-        player.play(files: audio, at: seconds)
+    private var audioStart: TimeInterval { library.lifecycle[id]?.audioTimelineStart ?? 0 }
+    private func play(at seconds: TimeInterval? = nil) {
+        let sourceTime = seconds ?? audioStart
+        guard recording.permitsPlayback, sourceTime >= audioStart else { return }
+        player.play(files: audio, at: sourceTime - audioStart)
     }
 
     private func binding<Value>(_ keyPath: WritableKeyPath<NoteRecord, Value>) -> Binding<Value> {
@@ -70,6 +73,27 @@ struct NoteEditor: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            Menu("Note storage", systemImage: "ellipsis.circle") {
+                Button("Move to Trash", role: .destructive) {
+                    player.stop()
+                    Task { await library.performStorage(.trash, id: id,
+                        captureActive: recording.busy || recording.noteID != nil) }
+                }.accessibilityIdentifier("moveToTrash")
+                if !audio.isEmpty {
+                    Button("Remove local audio", role: .destructive) { player.stop(); confirmAudioRemoval = true }
+                }
+            }.disabled(recording.busy || recording.noteID != nil || library.storageBusy || note.schemaVersion != 2)
+        }
+        .alert("Remove this device's audio?", isPresented: $confirmAudioRemoval) {
+            Button("Remove audio", role: .destructive) {
+                player.stop()
+                Task { await library.performStorage(.removeAudio, id: id, confirmed: true,
+                    captureActive: recording.busy || recording.noteID != nil) }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: { Text("Your notes, transcript, ink and summary versions stay. Audio removal cannot be undone here.") }
+        .onChange(of: library.storageBusy) { _, busy in if busy { player.stop() } }
         .task(id: note.language) {
             if recording.noteID == nil && !recording.busy {
                 await recording.speech.check(note.language)
@@ -158,7 +182,7 @@ struct NoteEditor: View {
                             } label: {
                                 Text(Duration.seconds(passage.start), format: .time(pattern: .minuteSecond))
                                     .monospacedDigit().font(.caption)
-                            }.disabled(audio.isEmpty || !recording.permitsPlayback)
+                            }.disabled(audio.isEmpty || passage.start < audioStart || !recording.permitsPlayback)
                                 .accessibilityLabel("Play passage")
                         }
                         Text(passage.text).foregroundStyle(passage.isFinal ? .primary : .secondary)
@@ -196,7 +220,7 @@ struct NoteEditor: View {
                         else { await recording.start(id, library: library) }
                     }
                 }.buttonStyle(.borderedProminent).tint(isActive ? .red : .accentColor)
-                    .disabled(note.schemaVersion != 2 || recording.busy || (recording.noteID != nil && !isActive) || recording.speech.readiness == .downloading || recording.speakers.preparing)
+                    .disabled(library.storageBusy || note.schemaVersion != 2 || recording.busy || (recording.noteID != nil && !isActive) || recording.speech.readiness == .downloading || recording.speakers.preparing)
                     .accessibilityIdentifier("recordButton")
             }
             if recording.busy { ProgressView("Preparing or finalizing recording…").font(.caption) }

--- a/apps/mobile-native/Sources/NoteLifecycle.swift
+++ b/apps/mobile-native/Sources/NoteLifecycle.swift
@@ -1,0 +1,111 @@
+import Foundation
+import AVFoundation
+
+/// Durable event/receipt. Contains identities and state only, never note content or audio.
+struct NoteLifecycle: Codable, Equatable, Sendable, Identifiable {
+    enum State: String, Codable, Sendable { case active, trashed, purged }
+    enum Clock: String, Codable, Sendable { case device, provisionalAccount }
+    var schemaVersion = 1
+    let noteID: UUID
+    let libraryID: UUID
+    var generation: UUID
+    var operationID: UUID
+    var state: State
+    var deletionID: UUID?
+    var deletedAt: Date?
+    var expiresAt: Date?
+    var clock: Clock
+    var cleanupPending = false
+    var restorePending = false
+    var audioRemovalPending = false
+    var audioRemovedAt: Date?
+    var audioOperationID: UUID?
+    var audioTimelineStart: TimeInterval?
+    var id: UUID { noteID }
+
+    static func initial(noteID: UUID, libraryID: UUID) -> Self {
+        Self(noteID: noteID, libraryID: libraryID, generation: noteID, operationID: noteID,
+             state: .active, clock: libraryID == LibraryRecord.localID ? .device : .provisionalAccount)
+    }
+}
+
+enum LifecycleError: LocalizedError {
+    case stale, unavailable, confirmationRequired, expired, recordingActive
+    var errorDescription: String? {
+        switch self {
+        case .stale: "This note changed. Reopen it before trying again."
+        case .unavailable: "This note is in Trash or was permanently deleted."
+        case .confirmationRequired: "Confirm permanent deletion before continuing."
+        case .expired: "The 30-day recovery period has ended."
+        case .recordingActive: "Stop recording before changing storage for this note."
+        }
+    }
+}
+
+struct StorageUsage: Sendable, Equatable {
+    let notesBytes: Int64
+    let audioBytes: Int64
+    let availableBytes: Int64?
+    var totalBytes: Int64 { notesBytes + audioBytes }
+    var lowSpace: Bool { availableBytes.map { $0 < 500 * 1024 * 1024 } ?? false }
+}
+
+extension NoteDiskStore {
+    func lifecycleURL(_ id: UUID) -> URL {
+        root.appendingPathComponent("lifecycle", isDirectory: true).appendingPathComponent(id.uuidString + ".json")
+    }
+
+    func lifecycle(noteID: UUID, libraryID: UUID) throws -> NoteLifecycle {
+        let file = lifecycleURL(noteID)
+        guard FileManager.default.fileExists(atPath: file.path) else {
+            return .initial(noteID: noteID, libraryID: libraryID)
+        }
+        let record = try JSONDecoder().decode(NoteLifecycle.self, from: Data(contentsOf: file))
+        guard record.schemaVersion == 1, record.noteID == noteID, record.libraryID == libraryID else {
+            throw LibraryDataError.invalidOwnership
+        }
+        return record
+    }
+
+    func saveLifecycle(_ record: NoteLifecycle) throws {
+        let directory = lifecycleURL(record.noteID).deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try write(record, to: lifecycleURL(record.noteID))
+    }
+
+    func lifecycleRecords() throws -> [NoteLifecycle] {
+        let directory = root.appendingPathComponent("lifecycle", isDirectory: true)
+        guard FileManager.default.fileExists(atPath: directory.path) else { return [] }
+        return try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "json" }.map { file in
+                let record = try JSONDecoder().decode(NoteLifecycle.self, from: Data(contentsOf: file))
+                guard record.schemaVersion == 1, record.noteID.uuidString + ".json" == file.lastPathComponent else {
+                    throw LibraryDataError.invalidDocument
+                }
+                return record
+            }
+    }
+
+    func audioTimelineStart(for id: UUID) throws -> TimeInterval {
+        guard FileManager.default.fileExists(atPath: lifecycleURL(id).path) else { return 0 }
+        let record = try JSONDecoder().decode(NoteLifecycle.self, from: Data(contentsOf: lifecycleURL(id)))
+        guard record.schemaVersion == 1, record.noteID == id else { throw LibraryDataError.invalidDocument }
+        let start = record.audioTimelineStart ?? 0
+        guard start.isFinite, start >= 0 else { throw LibraryDataError.invalidDocument }
+        return start
+    }
+
+    func recordingOffset(for id: UUID) throws -> TimeInterval {
+        try audioFiles(for: id).reduce(audioTimelineStart(for: id)) { total, url in
+            let file = try AVAudioFile(forReading: url)
+            return total + Double(file.length) / file.processingFormat.sampleRate
+        }
+    }
+
+    func requireActive(_ note: NoteRecord) throws {
+        guard let metadata = note.metadata else { throw LibraryDataError.invalidDocument }
+        let record = try lifecycle(noteID: note.id, libraryID: metadata.libraryID)
+        guard record.state == .active, !record.restorePending else { throw LifecycleError.unavailable }
+        guard record.generation == (metadata.lifecycleGeneration ?? note.id) else { throw LifecycleError.stale }
+    }
+}

--- a/apps/mobile-native/Sources/NoteStore.swift
+++ b/apps/mobile-native/Sources/NoteStore.swift
@@ -14,13 +14,25 @@ struct NoteDiskStore: Sendable {
     func directory(for id: UUID) -> URL { root.appendingPathComponent(id.uuidString, isDirectory: true) }
 
     func audioDirectory(for id: UUID) throws -> URL {
+        if FileManager.default.fileExists(atPath: lifecycleURL(id).path) {
+            let record = try JSONDecoder().decode(NoteLifecycle.self, from: Data(contentsOf: lifecycleURL(id)))
+            guard record.schemaVersion == 1, record.noteID == id, record.state == .active, !record.restorePending, !record.audioRemovalPending else { throw LifecycleError.unavailable }
+        }
         let url = directory(for: id).appendingPathComponent("audio", isDirectory: true)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true,
             attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication])
         return url
     }
 
-    func save(_ note: NoteRecord, migrationOriginal: Data? = nil) throws {
+    func save(_ note: NoteRecord, migrationOriginal: Data? = nil, restoring: Bool = false) throws {
+        if note.schemaVersion == 2 {
+            if restoring {
+                guard let metadata = note.metadata else { throw LibraryDataError.invalidDocument }
+                let state = try lifecycle(noteID: note.id, libraryID: metadata.libraryID)
+                guard state.state == .active, state.restorePending,
+                      state.generation == metadata.lifecycleGeneration else { throw LifecycleError.stale }
+            } else { try requireActive(note) }
+        }
         let dir = directory(for: note.id)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let file = dir.appendingPathComponent("note.json")
@@ -129,6 +141,11 @@ struct NoteDiskStore: Sendable {
         var migrationProblems: [String] = []
         for dir in dirs where UUID(uuidString: dir.lastPathComponent) != nil {
             do {
+                if let id = UUID(uuidString: dir.lastPathComponent), FileManager.default.fileExists(atPath: lifecycleURL(id).path) {
+                    let state = try JSONDecoder().decode(NoteLifecycle.self, from: Data(contentsOf: lifecycleURL(id)))
+                    guard state.schemaVersion == 1, state.noteID == id else { throw LibraryDataError.invalidDocument }
+                    if state.state == .purged { continue }
+                }
                 let data = try Data(contentsOf: dir.appendingPathComponent("note.json"))
                 var note = try JSONDecoder().decode(NoteRecord.self, from: data)
                 guard (1...2).contains(note.schemaVersion), note.id.uuidString == dir.lastPathComponent else {
@@ -145,7 +162,8 @@ struct NoteDiskStore: Sendable {
                         continue
                     }
                 }
-                guard note.metadata != nil else { throw LibraryDataError.invalidDocument }
+                guard let metadata = note.metadata else { throw LibraryDataError.invalidDocument }
+                _ = try lifecycle(noteID: note.id, libraryID: metadata.libraryID)
                 let recovery = AudioRecovery.recover(directory: dir.appendingPathComponent("audio"))
                 audioProblems.append(contentsOf: recovery.unreadable)
                 if note.captureState == .recording {
@@ -162,6 +180,10 @@ struct NoteDiskStore: Sendable {
     }
 
     func audioFiles(for id: UUID) -> [URL] {
+        if FileManager.default.fileExists(atPath: lifecycleURL(id).path) {
+            guard let record = try? JSONDecoder().decode(NoteLifecycle.self, from: Data(contentsOf: lifecycleURL(id))),
+                  record.schemaVersion == 1, record.noteID == id, record.state != .purged, !record.audioRemovalPending else { return [] }
+        }
         let dir = directory(for: id).appendingPathComponent("audio", isDirectory: true)
         let files = (try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []
         return files.filter { $0.pathExtension == "caf" && !$0.lastPathComponent.hasSuffix(".recovered.caf") }
@@ -189,13 +211,25 @@ final class NoteLibrary {
     private(set) var saveProblem: String?
     private(set) var disk: NoteDiskStore?
     private var repository: LibraryRepository?
+    private(set) var lifecycle: [UUID: NoteLifecycle] = [:]
+    private(set) var lifecycleReadable = false
+    private(set) var storage: StorageUsage?
+    private(set) var storageBusy = false
+    private(set) var storageProblem: String?
+    private var invalidating: Set<UUID> = []
+    var trashNotes: [NoteRecord] {
+        notes.filter { lifecycleReadable && $0.metadata?.libraryID == selectedLibraryID && lifecycle[$0.id]?.state == .trashed }
+            .sorted { (lifecycle[$0.id]?.deletedAt ?? .distantPast) > (lifecycle[$1.id]?.deletedAt ?? .distantPast) }
+    }
+    var cleanupPending: Bool { lifecycle.values.contains { $0.cleanupPending || $0.restorePending || $0.audioRemovalPending } }
+
     private var saveTask: Task<Void, Never>?
 
     var libraries: [LibraryRecord] {
         catalog.libraries.filter { $0.id == LibraryRecord.localID || $0.identity.map(identities.contains) == true }
     }
     var visibleNotes: [NoteRecord] {
-        notes.filter { $0.metadata?.libraryID == selectedLibraryID }
+        notes.filter { lifecycleReadable && $0.metadata?.libraryID == selectedLibraryID && !invalidating.contains($0.id) && (lifecycle[$0.id]?.state ?? .active) == .active && lifecycle[$0.id]?.restorePending != true }
             .sorted { $0.updatedAt > $1.updatedAt }
     }
     var folders: [NoteFolder] { catalog.folders.filter { $0.libraryID == selectedLibraryID } }
@@ -210,6 +244,8 @@ final class NoteLibrary {
                     guard let repository else { return }
                     let result = try await repository.load()
                     notes = result.notes
+                    await refreshLifecycle()
+                    await processRetention(captureActive: false)
                     if !result.migrationProblems.isEmpty {
                         problem = "Some notes are read-only until their storage upgrade can finish. Free device storage and reopen the app. Original files are preserved."
                     } else if !result.unreadable.isEmpty {
@@ -239,6 +275,7 @@ final class NoteLibrary {
         _ = try await repository.addLibrary(name: name, identity: identity)
         identities.insert(identity)
         await refreshCatalog()
+        await refreshLifecycle()
     }
 
     /// Caller must stop active capture first; transport offline/paused is NOT sign-out.
@@ -248,6 +285,8 @@ final class NoteLibrary {
         guard pendingSaves == 0, unsavedIDs.isEmpty else { return false }
         identities.remove(identity)
         selectedLibraryID = LibraryRecord.localID
+        await refreshLifecycle()
+        storage = nil
         return true
     }
 
@@ -259,7 +298,7 @@ final class NoteLibrary {
     @discardableResult func create() -> UUID? {
         var note = NoteRecord()
         note.metadata?.libraryID = selectedLibraryID
-        guard disk != nil, !loading else { return nil }
+        guard disk != nil, !loading, lifecycleReadable else { return nil }
         notes.insert(note, at: 0)
         enqueue(note)
         return note.id
@@ -267,7 +306,8 @@ final class NoteLibrary {
 
     func note(_ id: UUID) -> NoteRecord? {
         notes.first { note in
-            note.id == id && libraries.contains(where: { $0.id == note.metadata?.libraryID })
+            lifecycleReadable && note.id == id && !invalidating.contains(id) && (lifecycle[id]?.state ?? .active) == .active
+                && lifecycle[id]?.restorePending != true && libraries.contains(where: { $0.id == note.metadata?.libraryID })
         }
     }
 
@@ -276,6 +316,7 @@ final class NoteLibrary {
         var note = original
         change(&note)
         guard note.id == original.id, note.metadata?.libraryID == original.metadata?.libraryID,
+              note.metadata?.lifecycleGeneration == original.metadata?.lifecycleGeneration,
               note.schemaVersion == 2 else { problem = LibraryDataError.invalidOwnership.localizedDescription; return false }
         if let folder = note.metadata?.folderID,
            !catalog.folders.contains(where: { $0.id == folder && $0.libraryID == note.metadata?.libraryID }) {
@@ -341,4 +382,99 @@ final class NoteLibrary {
             note.metadata?.selectedSummaryID = version.id
         }
     }
+    func refreshLifecycle() async {
+        guard let repository else { return }
+        do {
+            lifecycle = Dictionary(uniqueKeysWithValues: try await repository.lifecycleEvents(identities: identities).map { ($0.noteID, $0) })
+            lifecycleReadable = true
+        }
+        catch { lifecycleReadable = false; storageProblem = "Storage state could not be read. \(error.localizedDescription)" }
+    }
+
+    func refreshStorage() async {
+        guard let repository else { return }
+        let scope = selectedLibraryID
+        do {
+            let usage = try await repository.storageUsage(libraryID: scope, identities: identities)
+            if selectedLibraryID == scope { storage = usage }
+        }
+        catch { problem = error.localizedDescription }
+    }
+
+    func processRetention(captureActive: Bool) async {
+        guard !captureActive, !storageBusy, let repository else { return }
+        storageBusy = true
+        storageProblem = nil
+        defer { storageBusy = false }
+        do {
+            _ = try await repository.processRetention(now: Date(), identities: identities)
+            await refreshLifecycle()
+            notes.removeAll { lifecycle[$0.id]?.state == .purged }
+            for record in lifecycle.values where record.state == .active && !record.restorePending {
+                if let index = notes.firstIndex(where: { $0.id == record.noteID }),
+                   !unsavedIDs.contains(record.noteID),
+                   notes[index].metadata?.lifecycleGeneration != record.generation {
+                    let revision = notes[index].metadata?.revisionID
+                    let restored = try await repository.retainedNote(record.noteID, libraryID: record.libraryID, identities: identities)
+                    if let current = notes.firstIndex(where: { $0.id == record.noteID }),
+                       !unsavedIDs.contains(record.noteID), notes[current].metadata?.revisionID == revision {
+                        notes[current] = restored
+                    }
+                }
+            }
+        } catch {
+            await refreshLifecycle()
+            storageProblem = "Storage cleanup is incomplete. Retry when device storage is available. \(error.localizedDescription)"
+        }
+    }
+
+    enum StorageAction { case trash, restore, purge, removeAudio }
+    func performStorage(_ action: StorageAction, id: UUID, confirmed: Bool = false, captureActive: Bool) async {
+        guard !captureActive, !storageBusy, let repository else {
+            problem = LifecycleError.recordingActive.localizedDescription
+            return
+        }
+        guard let source = notes.first(where: { $0.id == id }), let libraryID = source.metadata?.libraryID,
+              libraries.contains(where: { $0.id == libraryID }) else { return }
+        storageBusy = true
+        storageProblem = nil
+        invalidating.insert(id)
+        defer { invalidating.remove(id); storageBusy = false }
+        await flush()
+        // Freeing audio or confirmed Trash payload must remain possible when another save hit ENOSPC.
+        if action == .trash && unsavedIDs.contains(id) { return }
+        do {
+            let state = lifecycle[id] ?? .initial(noteID: id, libraryID: libraryID)
+            switch action {
+            case .trash:
+                _ = try await repository.trash(noteID: id, libraryID: libraryID, expectedGeneration: state.generation,
+                    operationID: UUID(), now: Date(), identities: identities)
+            case .restore:
+                guard let deletionID = state.deletionID else { throw LifecycleError.stale }
+                _ = try await repository.restore(noteID: id, libraryID: libraryID, deletionID: deletionID,
+                    expectedGeneration: state.generation, operationID: UUID(), now: Date(), identities: identities)
+            case .purge:
+                _ = try await repository.permanentlyDelete(noteID: id, libraryID: libraryID, expectedGeneration: state.generation,
+                    operationID: UUID(), confirmed: confirmed, identities: identities)
+            case .removeAudio:
+                _ = try await repository.removeAudio(noteID: id, libraryID: libraryID, expectedGeneration: state.generation,
+                    operationID: UUID(), confirmed: confirmed, now: Date(), identities: identities)
+            }
+            await refreshLifecycle()
+            if lifecycle[id]?.state == .purged {
+                notes.removeAll { $0.id == id }
+                unsavedIDs.remove(id)
+                if unsavedIDs.isEmpty { saveProblem = nil }
+            }
+            else if action == .restore {
+                let restored = try await repository.retainedNote(id, libraryID: libraryID, identities: identities)
+                if let index = notes.firstIndex(where: { $0.id == id }) { notes[index] = restored }
+            }
+            await refreshStorage()
+        } catch {
+            await refreshLifecycle()
+            storageProblem = "Storage change is incomplete. \(error.localizedDescription)"
+        }
+    }
+
 }

--- a/apps/mobile-native/Sources/RecordingSession.swift
+++ b/apps/mobile-native/Sources/RecordingSession.swift
@@ -22,7 +22,7 @@ final class RecordingSession {
     }) { self.recordPermission = recordPermission }
 
     func start(_ id: UUID, library: NoteLibrary) async {
-        guard noteID == nil, !busy, let note = library.note(id), let disk = library.disk else { return }
+        guard noteID == nil, !busy, !library.storageBusy, !library.loading, let note = library.note(id), let disk = library.disk else { return }
         busy = true
         captureFailed = false
         defer { busy = false }
@@ -39,10 +39,7 @@ final class RecordingSession {
             let input = engine.inputNode
             let format = input.outputFormat(forBus: 0)
             guard format.sampleRate > 0, format.channelCount > 0 else { throw CaptureError.format }
-            let offset = try disk.audioFiles(for: id).reduce(0.0) { total, url in
-                let file = try AVAudioFile(forReading: url)
-                return total + Double(file.length) / file.processingFormat.sampleRate
-            }
+            let offset = try disk.recordingOffset(for: id)
             let speechFeed = await speech.start(language: note.language, offset: offset) { passage in
                 library.update(id) { $0.apply(passage) }
             }

--- a/apps/mobile-native/Sources/StorageUITestFixture.swift
+++ b/apps/mobile-native/Sources/StorageUITestFixture.swift
@@ -1,0 +1,21 @@
+#if DEBUG
+import AVFoundation
+import Foundation
+
+/// Synthetic, isolated UI-test data only. Never opens the normal application-support library.
+enum StorageUITestFixture {
+    static func prepare(root: URL) throws {
+        let disk = try NoteDiskStore(root: root)
+        var note = NoteRecord()
+        note.title = "Storage fixture"
+        note.text = "Synthetic personal notes retained after audio removal."
+        try disk.save(note)
+        let format = AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 16_000)!
+        buffer.frameLength = 16_000
+        memset(buffer.floatChannelData![0], 0, 16_000 * MemoryLayout<Float>.size)
+        let file = try AVAudioFile(forWriting: disk.audioDirectory(for: note.id).appendingPathComponent("synthetic.caf"), settings: format.settings)
+        try file.write(from: buffer)
+    }
+}
+#endif

--- a/apps/mobile-native/Sources/StorageView.swift
+++ b/apps/mobile-native/Sources/StorageView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct StorageView: View {
+    @Bindable var library: NoteLibrary
+    @Bindable var recording: RecordingSession
+    @Environment(\.dismiss) private var dismiss
+    @State private var deleting: NoteRecord?
+    private var blocked: Bool { recording.busy || recording.noteID != nil || library.storageBusy }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("On this device") {
+                    Text(library.libraries.first(where: { $0.id == library.selectedLibraryID })?.name ?? "Library")
+                    if let usage = library.storage {
+                        LabeledContent("Notes, ink and history", value: ByteCountFormatter.string(fromByteCount: usage.notesBytes, countStyle: .file))
+                        LabeledContent("Audio", value: ByteCountFormatter.string(fromByteCount: usage.audioBytes, countStyle: .file))
+                        if let free = usage.availableBytes {
+                            LabeledContent("Device space available", value: ByteCountFormatter.string(fromByteCount: free, countStyle: .file))
+                        }
+                        if usage.lowSpace { Text("Device space is low. Remove unneeded local audio or permanently delete items in Trash.").foregroundStyle(.orange) }
+                    } else { ProgressView("Checking storage…") }
+                    Text("Audio stays on its original device. Removing audio keeps your text, transcript, ink and summary versions.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+                Section("Trash") {
+                    if library.trashNotes.isEmpty { Text("Trash is empty").foregroundStyle(.secondary) }
+                    ForEach(library.trashNotes) { note in
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(note.title.isEmpty ? "Untitled note" : note.title).font(.headline)
+                            if let state = library.lifecycle[note.id] {
+                                if state.clock == .provisionalAccount {
+                                    Text("Recovery timing awaits cloud confirmation.").font(.caption)
+                                } else if let expiry = state.expiresAt {
+                                    Text("Recover until \(expiry.formatted(date: .abbreviated, time: .shortened))").font(.caption)
+                                }
+                            }
+                            HStack {
+                                Button("Restore") { Task { await library.performStorage(.restore, id: note.id, captureActive: blocked) } }
+                                    .buttonStyle(.bordered).accessibilityIdentifier("restore-\(note.title)")
+                                Spacer()
+                                Button("Delete permanently", role: .destructive) { deleting = note }
+                                    .buttonStyle(.bordered)
+                            }.disabled(blocked)
+                        }.padding(.vertical, 4)
+                    }
+                    Text("Trash retains notes and local audio for 30 days. Expired local items are removed when DoodleNote next runs. This does not erase exported backups or devices that are powered off.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+                if library.cleanupPending {
+                    Section {
+                        Text("Some local cleanup is pending.").foregroundStyle(.orange)
+                        Button("Retry cleanup") { Task { await library.processRetention(captureActive: blocked); await library.refreshStorage() } }
+                            .disabled(blocked)
+                    }
+                }
+                if let error = library.storageProblem ?? library.problem { Text(error).foregroundStyle(.red).font(.callout) }
+            }
+            .navigationTitle("Storage & Trash")
+            .toolbar { Button("Done") { dismiss() } }
+            .task { await library.refreshLifecycle(); await library.refreshStorage() }
+            .alert("Permanently delete this note and its local audio?", isPresented: Binding(
+                get: { deleting != nil }, set: { if !$0 { deleting = nil } })) {
+                if let note = deleting {
+                    Button("Delete permanently", role: .destructive) {
+                        Task { await library.performStorage(.purge, id: note.id, confirmed: true, captureActive: blocked) }
+                        deleting = nil
+                    }
+                }
+                Button("Cancel", role: .cancel) { deleting = nil }
+            } message: { Text("This removes this device's note, ink, history and audio. It cannot be undone here. Exported backups are not erased.") }
+        }
+    }
+}

--- a/apps/mobile-native/Sources/TrashRepository.swift
+++ b/apps/mobile-native/Sources/TrashRepository.swift
@@ -1,0 +1,196 @@
+import Foundation
+import AVFoundation
+
+extension LibraryRepository {
+    private func storedNote(_ id: UUID, libraryID: UUID) throws -> NoteRecord {
+        let note = try JSONDecoder().decode(NoteRecord.self,
+            from: Data(contentsOf: disk.directory(for: id).appendingPathComponent("note.json")))
+        guard note.schemaVersion == 2, note.id == id, note.metadata?.libraryID == libraryID else {
+            throw LibraryDataError.invalidOwnership
+        }
+        return note
+    }
+
+    func retainedNote(_ id: UUID, libraryID: UUID, identities: Set<LibraryIdentity>) throws -> NoteRecord {
+        try authorize(libraryID, identities: identities)
+        guard try disk.lifecycle(noteID: id, libraryID: libraryID).state != .purged else { throw LifecycleError.unavailable }
+        return try storedNote(id, libraryID: libraryID)
+    }
+
+    func lifecycleEvents(identities: Set<LibraryIdentity>) throws -> [NoteLifecycle] {
+        let allowed = try readCatalog().libraries.filter {
+            $0.id == LibraryRecord.localID || $0.identity.map(identities.contains) == true
+        }.map(\.id)
+        let records = try disk.lifecycleRecords()
+        for record in records where record.state != .purged {
+            _ = try storedNote(record.noteID, libraryID: record.libraryID)
+        }
+        return records.filter { allowed.contains($0.libraryID) }
+    }
+
+    func trash(noteID: UUID, libraryID: UUID, expectedGeneration: UUID, operationID: UUID,
+               now: Date, identities: Set<LibraryIdentity>) throws -> NoteLifecycle {
+        try authorize(libraryID, identities: identities)
+        var record = try disk.lifecycle(noteID: noteID, libraryID: libraryID)
+        if record.operationID == operationID, record.state == .trashed { return record }
+        guard record.state == .active, !record.restorePending, record.generation == expectedGeneration else { throw LifecycleError.stale }
+        let note = try storedNote(noteID, libraryID: libraryID)
+        guard note.captureState != .recording else { throw LifecycleError.recordingActive }
+        record.state = .trashed
+        record.generation = UUID()
+        record.operationID = operationID
+        record.deletionID = operationID
+        record.deletedAt = now
+        record.expiresAt = now.addingTimeInterval(30 * 24 * 60 * 60)
+        try disk.saveLifecycle(record)
+        return record
+    }
+
+    func restore(noteID: UUID, libraryID: UUID, deletionID: UUID, expectedGeneration: UUID,
+                 operationID: UUID, now: Date, identities: Set<LibraryIdentity>,
+                 beforeRestore: (@Sendable () throws -> Void)? = nil) throws -> NoteRecord {
+        try authorize(libraryID, identities: identities)
+        var record = try disk.lifecycle(noteID: noteID, libraryID: libraryID)
+        if record.operationID == operationID, record.state == .active {
+            if record.restorePending { try finishRestore(&record) }
+            return try storedNote(noteID, libraryID: libraryID)
+        }
+        guard record.state == .trashed, record.deletionID == deletionID,
+              record.generation == expectedGeneration else { throw LifecycleError.stale }
+        if record.clock == .device, let expiresAt = record.expiresAt, now >= expiresAt { throw LifecycleError.expired }
+        record.state = .active
+        record.generation = UUID()
+        record.operationID = operationID
+        record.restorePending = true
+        try disk.saveLifecycle(record)
+        try beforeRestore?()
+        try finishRestore(&record)
+        return try storedNote(noteID, libraryID: libraryID)
+    }
+
+    private func finishRestore(_ record: inout NoteLifecycle) throws {
+        var note = try storedNote(record.noteID, libraryID: record.libraryID)
+        note.metadata?.lifecycleGeneration = record.generation
+        if let folder = note.metadata?.folderID,
+           !(try readCatalog().folders.contains { $0.id == folder && $0.libraryID == record.libraryID }) {
+            note.metadata?.folderID = nil
+        }
+        try disk.save(note, restoring: true)
+        record.restorePending = false
+        try disk.saveLifecycle(record)
+    }
+
+    func permanentlyDelete(noteID: UUID, libraryID: UUID, expectedGeneration: UUID, operationID: UUID,
+                           confirmed: Bool, identities: Set<LibraryIdentity>,
+                           beforeRemoval: (@Sendable () throws -> Void)? = nil) throws -> NoteLifecycle {
+        guard confirmed else { throw LifecycleError.confirmationRequired }
+        try authorize(libraryID, identities: identities)
+        var record = try disk.lifecycle(noteID: noteID, libraryID: libraryID)
+        if record.state == .purged {
+            if record.cleanupPending { try finishPurge(&record, beforeRemoval: beforeRemoval) }
+            return record
+        }
+        guard record.state == .trashed, record.generation == expectedGeneration else { throw LifecycleError.stale }
+        record.state = .purged
+        record.operationID = operationID
+        record.generation = UUID()
+        record.cleanupPending = true
+        // Commit irreversible intent before touching payload; this receipt blocks old saves forever.
+        try disk.saveLifecycle(record)
+        try finishPurge(&record, beforeRemoval: beforeRemoval)
+        return record
+    }
+
+    private func finishPurge(_ record: inout NoteLifecycle, beforeRemoval: (@Sendable () throws -> Void)? = nil) throws {
+        try beforeRemoval?()
+        var catalog = try readCatalog()
+        catalog.jobs.removeAll { $0.noteID == record.noteID && $0.libraryID == record.libraryID }
+        try saveCatalog(catalog)
+        let directory = disk.directory(for: record.noteID)
+        if FileManager.default.fileExists(atPath: directory.path) { try FileManager.default.removeItem(at: directory) }
+        record.cleanupPending = false
+        record.restorePending = false
+        record.audioRemovalPending = false
+        try disk.saveLifecycle(record)
+    }
+
+    func removeAudio(noteID: UUID, libraryID: UUID, expectedGeneration: UUID, operationID: UUID,
+                     confirmed: Bool, now: Date, identities: Set<LibraryIdentity>,
+                     beforeRemoval: (@Sendable () throws -> Void)? = nil) throws -> NoteLifecycle {
+        guard confirmed else { throw LifecycleError.confirmationRequired }
+        try authorize(libraryID, identities: identities)
+        var record = try disk.lifecycle(noteID: noteID, libraryID: libraryID)
+        guard record.state == .active, !record.restorePending, record.generation == expectedGeneration else { throw LifecycleError.stale }
+        let note = try storedNote(noteID, libraryID: libraryID)
+        guard note.captureState != .recording else { throw LifecycleError.recordingActive }
+        if record.audioOperationID == operationID, !record.audioRemovalPending { return record }
+        if !record.audioRemovalPending {
+            let audioEnd = disk.audioFiles(for: noteID).reduce(record.audioTimelineStart ?? 0) { total, url in
+                guard let file = try? AVAudioFile(forReading: url) else { return total }
+                return total + Double(file.length) / file.processingFormat.sampleRate
+            }
+            record.audioTimelineStart = max(audioEnd, note.passages.map(\.end).max() ?? 0)
+        }
+        record.audioOperationID = operationID
+        record.audioRemovalPending = true
+        record.audioRemovedAt = now
+        try disk.saveLifecycle(record)
+        try beforeRemoval?()
+        try finishAudioRemoval(&record)
+        return record
+    }
+
+    private func finishAudioRemoval(_ record: inout NoteLifecycle) throws {
+        let directory = disk.directory(for: record.noteID).appendingPathComponent("audio")
+        if FileManager.default.fileExists(atPath: directory.path) { try FileManager.default.removeItem(at: directory) }
+        record.audioRemovalPending = false
+        try disk.saveLifecycle(record)
+    }
+
+    /// Local-only expiry. Account receipts need the future sync adapter's authoritative server decision.
+    func processRetention(now: Date, identities: Set<LibraryIdentity>) throws -> [NoteLifecycle] {
+        var results: [NoteLifecycle] = []
+        for var record in try lifecycleEvents(identities: identities) {
+            if record.restorePending { try finishRestore(&record) }
+            if record.audioRemovalPending && record.state == .active { try finishAudioRemoval(&record) }
+            if record.state == .purged && record.cleanupPending { try finishPurge(&record) }
+            if record.state == .trashed, record.clock == .device, let expiresAt = record.expiresAt, now >= expiresAt {
+                record = try permanentlyDelete(noteID: record.noteID, libraryID: record.libraryID,
+                    expectedGeneration: record.generation, operationID: UUID(), confirmed: true, identities: identities)
+            }
+            results.append(record)
+        }
+        return results
+    }
+
+    func storageUsage(libraryID: UUID, identities: Set<LibraryIdentity>) throws -> StorageUsage {
+        try authorize(libraryID, identities: identities)
+        var noteBytes: Int64 = 0
+        var audioBytes: Int64 = 0
+        let directories = try FileManager.default.contentsOfDirectory(at: disk.root, includingPropertiesForKeys: nil)
+        for directory in directories {
+            guard let id = UUID(uuidString: directory.lastPathComponent) else { continue }
+            if FileManager.default.fileExists(atPath: disk.lifecycleURL(id).path) {
+                let receipt = try JSONDecoder().decode(NoteLifecycle.self, from: Data(contentsOf: disk.lifecycleURL(id)))
+                guard receipt.schemaVersion == 1, receipt.noteID == id else { throw LibraryDataError.invalidDocument }
+                guard receipt.libraryID == libraryID else { continue }
+            } else {
+                guard let note = try? JSONDecoder().decode(NoteRecord.self,
+                    from: Data(contentsOf: directory.appendingPathComponent("note.json"))),
+                    note.id == id, note.metadata?.libraryID == libraryID else { continue }
+            }
+            guard let files = FileManager.default.enumerator(at: directory,
+                includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey], options: [.skipsHiddenFiles]) else { continue }
+            for case let file as URL in files {
+                let values = try file.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+                guard values.isRegularFile == true else { continue }
+                let size = Int64(values.fileSize ?? 0)
+                if file.path.hasPrefix(directory.appendingPathComponent("audio").path + "/") { audioBytes += size }
+                else { noteBytes += size }
+            }
+        }
+        let volume = try? disk.root.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        return StorageUsage(notesBytes: noteBytes, audioBytes: audioBytes,
+                            availableBytes: volume?.volumeAvailableCapacityForImportantUsage)
+    }
+}

--- a/apps/mobile-native/Tests/TrashTests.swift
+++ b/apps/mobile-native/Tests/TrashTests.swift
@@ -1,0 +1,280 @@
+import XCTest
+import AVFoundation
+@testable import DoodleNoteNative
+
+final class TrashTests: XCTestCase {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    func fixture() throws -> (NoteDiskStore, LibraryRepository, NoteRecord) {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        let disk = try NoteDiskStore(root: root)
+        var note = NoteRecord()
+        note.text = "Keep private text"
+        note.ink = Data([1, 2, 3])
+        note.passages = [TranscriptPassage(start: 0, end: 2, text: "Keep transcript", isFinal: true)]
+        note.metadata?.summaries = [SummaryVersion(id: UUID(), parentID: nil, createdAt: now, origin: .generated,
+            format: "meeting", language: .english, text: "Keep summary", sources: [])]
+        try disk.save(note)
+        try Data([7, 8, 9]).write(to: disk.audioDirectory(for: note.id).appendingPathComponent("001.caf"))
+        try Data("original migration backup".utf8).write(to: disk.directory(for: note.id).appendingPathComponent("note.schema1.original.json"))
+        return (disk, LibraryRepository(disk: disk), note)
+    }
+
+    func testTrashRetainsAudioAndSourcesAreUnavailableUntilRestore() async throws {
+        let (disk, repository, note) = try fixture()
+        let anchor = SourceAnchor(libraryID: LibraryRecord.localID, noteID: note.id,
+            revisionID: note.metadata!.revisionID, content: .personalParagraph(0))
+        let state = try await repository.trash(noteID: note.id, libraryID: LibraryRecord.localID,
+            expectedGeneration: note.id, operationID: UUID(), now: now, identities: [])
+        XCTAssertEqual(state.expiresAt, now.addingTimeInterval(30 * 86400))
+        XCTAssertEqual(try Data(contentsOf: disk.directory(for: note.id).appendingPathComponent("audio/001.caf")), Data([7, 8, 9]))
+        do { _ = try await repository.resolve(anchor, identities: []); XCTFail("Trash source leaked") } catch { }
+        let restored = try await repository.restore(noteID: note.id, libraryID: LibraryRecord.localID,
+            deletionID: state.deletionID!, expectedGeneration: state.generation, operationID: UUID(), now: now.addingTimeInterval(29 * 86400), identities: [])
+        XCTAssertEqual(restored.text, note.text)
+        XCTAssertEqual(restored.ink, note.ink)
+        XCTAssertEqual(restored.metadata?.summaries, note.metadata?.summaries)
+        XCTAssertNotEqual(restored.metadata?.lifecycleGeneration, note.metadata?.lifecycleGeneration)
+        let source = try await repository.resolve(anchor, identities: [])
+        XCTAssertEqual(source, note.text)
+        XCTAssertThrowsError(try disk.save(note), "Old pre-trash save must not resurrect or overwrite restored note")
+    }
+
+    func testExpiryRunsOnLaterExecutionAndPermanentPurgeCoversAllPayload() async throws {
+        let (disk, repository, note) = try fixture()
+        _ = try await repository.trash(noteID: note.id, libraryID: LibraryRecord.localID,
+            expectedGeneration: note.id, operationID: UUID(), now: now, identities: [])
+        _ = try await repository.processRetention(now: now.addingTimeInterval(30 * 86400 - 1), identities: [])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: disk.directory(for: note.id).path))
+        let restarted = LibraryRepository(disk: disk)
+        _ = try await restarted.processRetention(now: now.addingTimeInterval(31 * 86400), identities: [])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: disk.directory(for: note.id).path))
+        let receipt = try disk.lifecycle(noteID: note.id, libraryID: LibraryRecord.localID)
+        XCTAssertEqual(receipt.state, .purged)
+        XCTAssertFalse(receipt.cleanupPending)
+        _ = try await restarted.processRetention(now: now.addingTimeInterval(40 * 86400), identities: [])
+        XCTAssertThrowsError(try disk.save(note))
+        XCTAssertThrowsError(try disk.audioDirectory(for: note.id))
+        XCTAssertTrue(try disk.load().notes.isEmpty)
+    }
+
+    func testConfirmationAndFailedPurgeAreDurableAndRetryable() async throws {
+        let (disk, repository, note) = try fixture()
+        let state = try await repository.trash(noteID: note.id, libraryID: LibraryRecord.localID,
+            expectedGeneration: note.id, operationID: UUID(), now: now, identities: [])
+        do {
+            _ = try await repository.permanentlyDelete(noteID: note.id, libraryID: LibraryRecord.localID,
+                expectedGeneration: state.generation, operationID: UUID(), confirmed: false, identities: [])
+            XCTFail("Missing confirmation accepted")
+        } catch { }
+        XCTAssertEqual(try disk.lifecycle(noteID: note.id, libraryID: LibraryRecord.localID).state, .trashed)
+        do {
+            _ = try await repository.permanentlyDelete(noteID: note.id, libraryID: LibraryRecord.localID,
+                expectedGeneration: state.generation, operationID: UUID(), confirmed: true, identities: [],
+                beforeRemoval: { throw CocoaError(.fileWriteNoPermission) })
+            XCTFail("Injected failure ignored")
+        } catch { }
+        XCTAssertTrue(try disk.lifecycle(noteID: note.id, libraryID: LibraryRecord.localID).cleanupPending)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: disk.directory(for: note.id).path))
+        XCTAssertTrue(try disk.load().notes.isEmpty)
+        let usage = try await repository.storageUsage(libraryID: LibraryRecord.localID, identities: [])
+        XCTAssertGreaterThan(usage.notesBytes, 0)
+        XCTAssertEqual(usage.audioBytes, 3)
+        XCTAssertThrowsError(try disk.save(note))
+        _ = try await LibraryRepository(disk: disk).processRetention(now: now, identities: [])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: disk.directory(for: note.id).path))
+        XCTAssertFalse(try disk.lifecycle(noteID: note.id, libraryID: LibraryRecord.localID).cleanupPending)
+    }
+
+    func testRestoreIntentRecoversAfterRestartAndMissingFolderBecomesUnfiled() async throws {
+        let (disk, repository, original) = try fixture()
+        let folder = try await repository.addFolder(name: "Old folder", libraryID: LibraryRecord.localID, identities: [])
+        var note = original
+        note.metadata?.folderID = folder.id
+        try await repository.save(note, identities: [])
+        let state = try await repository.trash(noteID: note.id, libraryID: LibraryRecord.localID,
+            expectedGeneration: note.id, operationID: UUID(), now: now, identities: [])
+        var catalog = try await repository.catalog()
+        catalog.folders = []
+        try await repository.saveCatalog(catalog)
+        do {
+            _ = try await repository.restore(noteID: note.id, libraryID: LibraryRecord.localID,
+                deletionID: state.deletionID!, expectedGeneration: state.generation, operationID: UUID(), now: now, identities: [],
+                beforeRestore: { throw CocoaError(.fileWriteOutOfSpace) })
+            XCTFail("Injected failure ignored")
+        } catch { }
+        XCTAssertTrue(try disk.lifecycle(noteID: note.id, libraryID: LibraryRecord.localID).restorePending)
+        XCTAssertThrowsError(try disk.save(original))
+        _ = try await LibraryRepository(disk: disk).processRetention(now: now, identities: [])
+        let restored = try XCTUnwrap(disk.load().notes.first)
+        XCTAssertNil(restored.metadata?.folderID)
+        XCTAssertEqual(restored.text, note.text)
+        XCTAssertEqual(restored.metadata?.libraryID, LibraryRecord.localID)
+    }
+
+    func testFailedAudioCleanupRetainsPayloadUntilRetryAndUsageCountsPendingPurge() async throws {
+        let (disk, repository, note) = try fixture()
+        do {
+            _ = try await repository.removeAudio(noteID: note.id, libraryID: LibraryRecord.localID,
+                expectedGeneration: note.id, operationID: UUID(), confirmed: true, now: now, identities: [],
+                beforeRemoval: { throw CocoaError(.fileWriteNoPermission) })
+            XCTFail("Injected failure ignored")
+        } catch { }
+        let usage = try await repository.storageUsage(libraryID: LibraryRecord.localID, identities: [])
+        XCTAssertGreaterThan(usage.notesBytes, 0)
+        XCTAssertEqual(usage.audioBytes, 3)
+        XCTAssertTrue(disk.audioFiles(for: note.id).isEmpty)
+        _ = try await repository.processRetention(now: now, identities: [])
+        XCTAssertEqual(try disk.load().notes, [note])
+        let cleaned = try await repository.storageUsage(libraryID: LibraryRecord.localID, identities: [])
+        XCTAssertEqual(cleaned.audioBytes, 0)
+    }
+
+    func testAudioRemovalPreservesAllContentAndReplayDoesNotDeleteNewAudio() async throws {
+        let (disk, repository, note) = try fixture()
+        let operation = UUID()
+        _ = try await repository.removeAudio(noteID: note.id, libraryID: LibraryRecord.localID,
+            expectedGeneration: note.id, operationID: operation, confirmed: true, now: now, identities: [])
+        XCTAssertTrue(disk.audioFiles(for: note.id).isEmpty)
+        XCTAssertEqual(try disk.load().notes, [note])
+        let newAudio = try disk.audioDirectory(for: note.id).appendingPathComponent("new.caf")
+        try Data([5]).write(to: newAudio)
+        _ = try await repository.removeAudio(noteID: note.id, libraryID: LibraryRecord.localID,
+            expectedGeneration: note.id, operationID: operation, confirmed: true, now: now, identities: [])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: newAudio.path))
+    }
+
+    func testRecordingAfterAudioRemovalKeepsOriginalSourceTimeline() async throws {
+        let (disk, repository, note) = try fixture()
+        let format = AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 16_000)!
+        buffer.frameLength = 16_000
+        memset(buffer.floatChannelData![0], 0, 16_000 * MemoryLayout<Float>.size)
+        _ = try await repository.removeAudio(noteID: note.id, libraryID: LibraryRecord.localID,
+            expectedGeneration: note.id, operationID: UUID(), confirmed: true, now: now, identities: [])
+        XCTAssertEqual(try disk.recordingOffset(for: note.id), 2)
+        do {
+            let file = try AVAudioFile(forWriting: disk.audioDirectory(for: note.id).appendingPathComponent("new.caf"), settings: format.settings)
+            try file.write(from: buffer)
+        }
+        XCTAssertEqual(try disk.audioTimelineStart(for: note.id), 2)
+        XCTAssertEqual(try disk.recordingOffset(for: note.id), 3)
+        XCTAssertEqual(try disk.load().notes.first?.passages, note.passages)
+    }
+
+    func testAccountTrashDoesNotExpireFromDeviceClockAndOtherAccountCannotReadStorage() async throws {
+        let (_, repository, original) = try fixture()
+        let identity = LibraryIdentity(accountID: "a", workspaceID: "w")
+        let library = try await repository.addLibrary(name: "Work", identity: identity)
+        var note = NoteRecord()
+        note.metadata?.libraryID = library.id
+        note.text = original.text
+        try await repository.save(note, identities: [identity])
+        _ = try await repository.trash(noteID: note.id, libraryID: library.id,
+            expectedGeneration: note.id, operationID: UUID(), now: now, identities: [identity])
+        let events = try await repository.processRetention(now: now.addingTimeInterval(365 * 86400), identities: [identity])
+        XCTAssertEqual(events.first(where: { $0.noteID == note.id })?.state, .trashed)
+        let hidden = try await repository.lifecycleEvents(identities: [])
+        XCTAssertFalse(hidden.contains { $0.noteID == note.id })
+        do { _ = try await repository.storageUsage(libraryID: library.id, identities: []); XCTFail("Signed-out storage leaked") } catch { }
+    }
+
+    func testTrashReplayAndRestoreRejectWrongDeletionIdentity() async throws {
+        let (_, repository, note) = try fixture()
+        let operation = UUID()
+        let state = try await repository.trash(noteID: note.id, libraryID: LibraryRecord.localID,
+            expectedGeneration: note.id, operationID: operation, now: now, identities: [])
+        let replay = try await repository.trash(noteID: note.id, libraryID: LibraryRecord.localID,
+            expectedGeneration: note.id, operationID: operation, now: now.addingTimeInterval(100), identities: [])
+        XCTAssertEqual(state, replay)
+        do {
+            _ = try await repository.restore(noteID: note.id, libraryID: LibraryRecord.localID,
+                deletionID: UUID(), expectedGeneration: state.generation, operationID: UUID(), now: now, identities: [])
+            XCTFail("Wrong deletion accepted")
+        } catch { }
+    }
+}
+
+@MainActor final class TrashLibraryTests: XCTestCase {
+    func testActiveCaptureBlocksTrashAndOtherEditsSurviveStorageOperation() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let library = NoteLibrary(root: root)
+        await library.waitUntilLoaded()
+        let first = try XCTUnwrap(library.create())
+        let second = try XCTUnwrap(library.create())
+        await library.performStorage(.trash, id: first, captureActive: true)
+        XCTAssertNotNil(library.note(first))
+        let trash = Task { await library.performStorage(.trash, id: first, captureActive: false) }
+        await Task.yield()
+        for index in 0..<100 { library.update(second) { $0.text = "Concurrent edit \(index)" } }
+        await trash.value
+        await library.flush()
+        XCTAssertNil(library.note(first))
+        XCTAssertEqual(library.trashNotes.map(\.id), [first])
+        XCTAssertEqual(library.note(second)?.text, "Concurrent edit 99")
+        XCTAssertFalse(library.visibleNotes.contains { $0.id == first })
+        XCTAssertEqual(try library.disk?.load().notes.first(where: { $0.id == second })?.text, "Concurrent edit 99")
+    }
+
+    func testAudioRecoveryCanFreeSpaceWhileUnrelatedEditCannotSave() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let library = NoteLibrary(root: root)
+        await library.waitUntilLoaded()
+        let audioNote = try XCTUnwrap(library.create())
+        let other = try XCTUnwrap(library.create())
+        await library.flush()
+        let disk = try XCTUnwrap(library.disk)
+        try Data([1, 2, 3]).write(to: disk.audioDirectory(for: audioNote).appendingPathComponent("local.caf"))
+        let file = disk.directory(for: other).appendingPathComponent("note.json")
+        let bytes = try Data(contentsOf: file)
+        try FileManager.default.removeItem(at: file)
+        try FileManager.default.createDirectory(at: file, withIntermediateDirectories: false)
+        library.update(other) { $0.text = "Unsaved other note" }
+        let failed = await library.flush()
+        XCTAssertFalse(failed)
+        await library.performStorage(.removeAudio, id: audioNote, confirmed: true, captureActive: false)
+        XCTAssertTrue(disk.audioFiles(for: audioNote).isEmpty)
+        XCTAssertEqual(library.note(other)?.text, "Unsaved other note")
+        try FileManager.default.removeItem(at: file)
+        try bytes.write(to: file)
+        library.retrySaving()
+        let retried = await library.flush()
+        XCTAssertTrue(retried)
+    }
+
+    func testWrongLibraryReceiptCannotExposeLocalNote() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let disk = try NoteDiskStore(root: root)
+        let note = NoteRecord()
+        try disk.save(note)
+        var receipt = NoteLifecycle.initial(noteID: note.id, libraryID: UUID())
+        receipt.state = .trashed
+        try disk.saveLifecycle(receipt)
+        let loaded = try disk.load()
+        XCTAssertTrue(loaded.notes.isEmpty)
+        XCTAssertEqual(loaded.unreadable, [note.id.uuidString])
+        let library = NoteLibrary(root: root)
+        await library.waitUntilLoaded()
+        XCTAssertNil(library.note(note.id))
+        XCTAssertTrue(library.visibleNotes.isEmpty)
+    }
+
+    func testUnreadableLifecycleFailsClosedInsteadOfShowingTrashAsActive() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let disk = try NoteDiskStore(root: root)
+        let note = NoteRecord()
+        try disk.save(note)
+        try disk.saveLifecycle(.initial(noteID: note.id, libraryID: LibraryRecord.localID))
+        try Data("corrupt lifecycle".utf8).write(to: disk.lifecycleURL(note.id))
+        let library = NoteLibrary(root: root)
+        await library.waitUntilLoaded()
+        XCTAssertFalse(library.lifecycleReadable)
+        XCTAssertTrue(library.visibleNotes.isEmpty)
+        XCTAssertNil(library.note(note.id))
+        XCTAssertNotNil(library.problem)
+    }
+}

--- a/apps/mobile-native/UITests/NoteEditingTests.swift
+++ b/apps/mobile-native/UITests/NoteEditingTests.swift
@@ -1,6 +1,43 @@
 import XCTest
 
 @MainActor final class NoteEditingTests: XCTestCase {
+    func testTrashRestoreAndAudioConfirmationPreservePersonalNotes() {
+        let app = XCUIApplication()
+        app.launchArguments = ["--ui-testing", "--storage-fixture", "--fixture-id=\(UUID().uuidString)"]
+        app.launch()
+        let fixture = app.staticTexts["Storage fixture"].firstMatch
+        XCTAssertTrue(fixture.waitForExistence(timeout: 10))
+        fixture.tap()
+        XCTAssertTrue(app.buttons["Play recording"].waitForExistence(timeout: 5))
+        app.buttons["Note storage"].tap()
+        app.buttons["Remove local audio"].tap()
+        app.buttons["Cancel"].tap()
+        XCTAssertTrue(app.buttons["Play recording"].exists)
+        app.buttons["Note storage"].tap()
+        app.buttons["Remove local audio"].tap()
+        app.buttons["Remove audio"].tap()
+        XCTAssertTrue(app.textViews["personalNotes"].waitForExistence(timeout: 5))
+        XCTAssertEqual(app.textViews["personalNotes"].value as? String, "Synthetic personal notes retained after audio removal.")
+        XCTAssertFalse(app.buttons["Play recording"].exists)
+        app.buttons["Note storage"].tap()
+        app.buttons["Move to Trash"].tap()
+        if !app.buttons["Storage & Trash"].exists { app.navigationBars.buttons.firstMatch.tap() }
+        XCTAssertTrue(app.buttons["Storage & Trash"].waitForExistence(timeout: 5))
+        app.buttons["Storage & Trash"].tap()
+        let restore = app.buttons["restore-Storage fixture"].firstMatch
+        XCTAssertTrue(restore.waitForExistence(timeout: 5))
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Local storage and recoverable Trash"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+        app.buttons["Delete permanently"].firstMatch.tap()
+        app.buttons["Cancel"].tap()
+        XCTAssertTrue(restore.exists)
+        restore.tap()
+        app.buttons["Done"].tap()
+        XCTAssertTrue(app.staticTexts["Storage fixture"].firstMatch.waitForExistence(timeout: 5))
+    }
+
     func testSpeakerControlsAreAvailableWithoutDownloadingModels() {
         let app = XCUIApplication()
         app.launchArguments = ["--ui-testing"]

--- a/apps/mobile-native/docs/trash-storage.md
+++ b/apps/mobile-native/docs/trash-storage.md
@@ -1,0 +1,47 @@
+# Native Trash and local storage (ONY-260)
+
+The fresh native app exposes Storage & Trash for the selected library and a Note storage menu. Moving a note to Trash immediately excludes it from normal library/search access and `LibraryRepository.resolve` source retrieval. Trash retains the entire UUID directory, including ink, personal text, transcript, summary versions, revision/migration backups and local audio. Restore retains the same note/library identities; a missing folder becomes unfiled within that library.
+
+## Durable lifecycle and retries
+
+`lifecycle/<note UUID>.json` is the authoritative local lifecycle receipt. It contains only library/note/operation/generation/deletion identities, states and timestamps, pending-work flags and the removed-audio timeline origin. It contains no note or transcript text. States are active, trashed and purged. A missing receipt is the original active generation (the note UUID) only for an existing compatible note. Corrupt, future-version or misowned receipts fail closed instead of making Trash active.
+
+Every transition compares the expected generation. Restore also compares the deletion identity. Generic note saves must match the active lifecycle generation; a stale background save or processing result cannot reactivate a trashed/purged note or overwrite a restored generation. `lifecycleEvents` publishes scoped durable snapshots with operation identity for index invalidation and later sync integration. It is not a network sender or a substitute for the future sync adapter's operation queue.
+
+Permanent deletion requires confirmation and first writes a purged receipt with cleanup pending. Only then does it remove note-specific jobs and the whole payload directory. This removes revisions, migration originals and audio together. Failure retains the pending receipt, hides the payload from normal access and exposes Retry cleanup. On restart, cleanup resumes idempotently. Completed purge receipts remain to reject stale writes; a successful file removal is never inferred from a missing UI row. Restores similarly persist intent before updating the active note generation, and restart resumes incomplete intent.
+
+The interface blocks destructive storage actions during active recording or permission/model preparation. It stops playback before audio changes. Capture entry also refuses storage work in progress, and disk audio-directory creation refuses inactive/pending receipts. Per-note edit invalidation plus repository generation checks prevent queued edits from recreating deleted content. Concurrent edits to unrelated notes stay in memory; storage operations never reload the entire library over them.
+
+## Retention clock
+
+Local-only Trash expires after `30 * 86400` seconds from the persisted device timestamp. The app processes expiry during initial loading and on subsequent foreground execution when capture is idle. Backward clock changes delay expiry; forward device-clock changes can advance local-only expiry. No powered-off execution or secure-erasure guarantee is claimed.
+
+Account-bound libraries use provisional local Trash timestamps and do not auto-purge from device time. ONY-258 defines server-authoritative deletion identity/timestamps and expiry. ONY-262 must explicitly reconcile provisional receipts with server receipts and authoritative expiry before account-library automatic cleanup; this issue does not claim that cloud synchronization is connected. Explicit confirmed local permanent deletion remains available. Exported archives, other devices, filesystem snapshots and external backups are not erased by this app's local cleanup.
+
+## Remove audio independently
+
+Remove local audio has its own confirmation, pending intent and idempotency identity. It deletes only `audio/`, retaining notes, ink, transcripts, summaries and source revisions. Playback availability comes from current local assets; pending removal exposes no playable files. A replay of a completed audio-removal operation does not delete audio recorded later.
+
+Before removal the receipt retains the removed-through source timeline: the larger of the known audio end and retained transcript end. A subsequent recording starts after that origin. New audio playback subtracts the retained origin; transcript timestamps referring to deleted audio are disabled. This prevents an old transcript timestamp from accidentally playing a later recording beginning at zero. For damaged audio with unavailable duration, only known audio/transcript boundaries can be retained; no accuracy claim is made about an unreadable file.
+
+## Storage and low-space recovery
+
+Storage & Trash scans only the authorized selected library's known directories without running migration or recovery as a side effect. Notes/ink/history and audio are shown separately, including payload awaiting failed purge cleanup. Available device capacity is labeled as device-wide; the low-space notice uses a 500 MiB threshold. The scan is off the main actor and cached in the displayed view.
+
+Confirmed audio/purge cleanup can proceed even when an unrelated note failed to save. Its unsaved edit stays in memory for Retry saving. Moving an unsaved target into Trash still requires that target to persist first. Intent receipts need writable storage; if the device cannot persist even a small receipt, cleanup stops safely and reports failure rather than silently deleting data. Free space outside the app before retrying in that case.
+
+## Compatibility and rollback
+
+Schema-2 note metadata adds an optional lifecycle generation; existing active notes retain their initial generation. Once lifecycle operations exist, do not run an older build that ignores the ledger against the mutable directory. Preserve the entire application-support directory and receipt files when rolling back code. Restoring an exported archive is separate deliberate user work, not undeleting a permanently purged identity in place. No production/customer files were deleted during development; all destructive tests use generated temporary stores or the isolated DEBUG UI-test container.
+
+## Verification
+
+`TrashTests` covers clock boundaries, restore, original payload retention, explicit confirmation, failed purge intent/restart, source exclusion, stale-save rejection, audio independence and replay, delete/re-record timeline, account-clock deferral, account storage isolation and missing-folder recovery. `TrashLibraryTests` covers capture guards, concurrent edits, unreadable/misowned receipt exclusion and low-space cleanup with unrelated unsaved data. The UI test uses `--ui-testing --storage-fixture`, creates synthetic silent audio in a separate container, checks both confirmation cancellation and audio removal, then Trash/restore.
+
+Check this:
+
+1. Open a saved note and choose Note storage > Move to Trash. Expect disappearance from Home/search, with text and audio available after Restore in Storage & Trash.
+2. Cancel permanent deletion in Trash. Expect the note retained. Confirm deletion only on a disposable fixture; expect removal and no restored note after reopening.
+3. Cancel Remove local audio, then confirm it on a fixture. Expect notes/ink/transcript/summary retained and old playback unavailable. Record again; new source timestamps must start after removed audio rather than reuse zero.
+4. During recording or permission/model preparation, storage actions are disabled. With low space and an unrelated unsaved edit, remove disposable audio, retry saving, and verify the unrelated edit remains.
+5. Review iPhone/iPad storage usage, scrolling, restore labels and pending-cleanup messaging. Physical-device pressure and long-session qualification remain ONY-241/265.


### PR DESCRIPTION
## Linear Issue
- [ONY-260](https://linear.app/onyxdevlabs/issue/ONY-260/add-mobile-trash-restoration-and-local-audio-storage-controls)

## Outcome
The fresh native app now provides recoverable Trash, confirmed permanent deletion and separate local audio removal. Notes in Trash disappear from normal search and source retrieval immediately. Original content can be restored during retention, and failed cleanup remains visible and retryable.

## What Changed
- Durable local lifecycle receipts with explicit library/note/operation/generation and deletion identities; stale saves cannot resurrect deleted or restored content.
- Thirty-day local-only retention processed on later execution, with purge intent committed before deleting note payload, revisions, migration backups and local audio.
- Restorable Trash, permanent/audio-only confirmation dialogs, storage usage and low-space retry paths.
- Capture/preparation and playback guards; preserved removed-audio timeline so re-recording does not reuse earlier transcript timestamps.
- Scoped lifecycle/source access, readonly storage scanning and target-only in-memory updates that preserve concurrent edits elsewhere.
- Synthetic temporary-store and isolated UI-fixture tests; no user or production data deletion.

## Bug Evidence / Root Cause
Independent root review identified stale whole-library reloads overwriting unrelated edits, corrupt/misowned lifecycle records defaulting to active, global save failures blocking space recovery, and audio removal causing a later recording to reuse source timestamp zero. Focused regressions now verify those paths. Repeated UI fixtures were isolated by per-run UUID container to avoid ambiguous same-title matches.

## Acceptance Criteria Evidence
- [x] Thirty-day recoverable Trash and immediate search/source exclusion: clock-boundary, source-resolution, restore and UI fixtures.
- [x] Retained audio during Trash and independent audio removal: payload/history preservation, confirmation cancellation, failed-removal retry and re-recording timeline fixtures.
- [x] Explicit permanent confirmation and idempotent retry/expiry: missing-confirmation rejection, persisted purge intent, partial cleanup/restart, stale-write rejection and minimal retained receipt tests.
- [x] Expiry on later execution: injected-clock restart tests. UI/docs explicitly avoid powered-off-device or exported-backup erasure claims.
- [x] Storage usage, low-space recovery and lifecycle contracts: scoped readonly usage includes pending purge payload; unrelated unsaved-edit/audio cleanup regression; generation-bound lifecycle snapshots documented for future sync/index integration.
- [ ] Sean product QA and physical-device pressure/long-session qualification. This simulator-tested PR does not claim release qualification.

## Verification
- `xcodegen generate --spec apps/mobile-native/project.yml` passed.
- `git diff --check` passed.
- `TEST_RUNNER_DOODLENOTE_SPEAKER_MODEL=/tmp/doodlenote-sortformer-evaluation/Sortformer_v2.1.mlpackage xcodebuild test -project apps/mobile-native/DoodleNoteNative.xcodeproj -scheme DoodleNoteNative -destination 'platform=iOS Simulator,id=F6067793-A05A-4174-A892-AC5C0F7A2FCB' -derivedDataPath /tmp/ony260-derived CODE_SIGNING_ALLOWED=NO` and equivalent iPad destination `8EEF4C09-BF6B-4A1E-9416-BFD874E454FA`: both passed 53 tests (49 unit and 4 UI), zero failures/skips, including the synthetic model fixture. Final result bundles and fresh iPad screenshot are attached in Linear.
- Synthetic speaker-model inference is distinct from speech/speaker accuracy. Routine CI skips the opt-in model fixture explicitly.

- All seven remote checks passed. [Native CI](https://github.com/Onyx-Dev-Labs/doodle-note/actions/runs/34064532125): 52 passed, one opt-in model case skipped, zero failures (49 unit cases and four UI cases).

## Local QA
Generate the project and run `DoodleNoteNative` in Xcode on iPhone or iPad. For disposable synthetic audio, use DEBUG launch arguments `--ui-testing --storage-fixture --fixture-id=<fresh UUID>`. This uses a separate test container, not normal user storage.

Check this:
1. Move a saved disposable note to Trash. Expect disappearance from Home/search; restore in Storage & Trash and verify text, ink, transcript, summaries and local audio remain.
2. Cancel permanent deletion. Expect Trash retained. Confirm only for a disposable note; expect removal and no resurrection after relaunch.
3. Cancel then confirm Remove local audio. Expect personal/generated content retained and deleted-audio timestamps unavailable. A later recording must append after the old source timeline.
4. During recording or model/permission preparation, verify destructive controls are disabled. With an unrelated failed save, free disposable audio and retry saving without losing the other edit.
5. Review storage totals, Trash dates, scrolling and cleanup retry on iPhone/iPad.

## Risks and Release Notes
Account-library Trash timing remains provisional and is not auto-purged using device time. ONY-262 must reconcile server-authoritative ONY-258 receipts/expiry. This PR does not connect cloud deletion or sync. Local-only expiry uses persisted device time; backward changes delay and forward changes can advance local expiry.

Purge receipts remain after payload cleanup to reject stale writes. Do not open a lifecycle-mutated data directory with an older build that ignores these receipts. Preserve the whole directory/receipts for code rollback; exported backups and remote devices are not erased. Cleanup requires enough writable storage for its small intent receipt and reports failure when that cannot be saved.

No production migration, customer-data removal, release, or historical `apps/ios` edits are included. Physical pressure and long-session qualification remain separate gates.

## Follow-ups
Future sync/index adapters must consume explicit lifecycle identities and source availability. Full contracts, clock semantics, rollback and QA are documented in `apps/mobile-native/docs/trash-storage.md`.
