### PR TITLE
[ONY-255] Implement native Google Calendar authorization and reads

### DIFF
--- a/apps/mobile-native/Sources/Calendar/Google/GoogleCalendarAdapter.swift
+++ b/apps/mobile-native/Sources/Calendar/Google/GoogleCalendarAdapter.swift
@@ -1,0 +1,249 @@
+import Foundation
+
+actor GoogleCalendarAdapter: CalendarProviderAdapter {
+    nonisolated let provider = CalendarProvider.google
+    private let configuration: GoogleCalendarConfiguration
+    private let transport: any GoogleCalendarTransport
+    private let browser: @Sendable (URL, String) async throws -> URL
+    private var authorizationTicket: UUID?
+
+    init(configuration: GoogleCalendarConfiguration, transport: any GoogleCalendarTransport = GoogleURLTransport(),
+         browser: @escaping @Sendable (URL, String) async throws -> URL) {
+        self.configuration = configuration
+        self.transport = transport
+        self.browser = browser
+    }
+
+    struct Credential: Codable, Sendable {
+        let subject: String
+        let clientID: String
+        let accessToken: String
+        let refreshToken: String
+        let expiresAt: Date
+    }
+    private struct Token: Decodable {
+        let access_token: String
+        let token_type: String
+        let expires_in: Double
+        let refresh_token: String?
+        let scope: String?
+    }
+    private struct UserInfo: Decodable { let sub: String; let email: String?; let email_verified: Bool? }
+
+    func authorize(existing: CalendarAccountKey?) async throws -> CalendarAuthorization {
+        if let existing, existing.provider != .google { throw CalendarFailure.invalidResponse }
+        let ticket = UUID()
+        authorizationTicket = ticket
+        defer { if authorizationTicket == ticket { authorizationTicket = nil } }
+        do {
+            let attempt = try GoogleAuthorizationAttempt(configuration: configuration)
+            let callback = try await browser(attempt.url, configuration.redirectURI.scheme!)
+            try current(ticket)
+            let code = try attempt.code(from: callback)
+            let token: Token = try await request("https://oauth2.googleapis.com/token", form: [
+                "client_id": configuration.clientID, "redirect_uri": configuration.redirectURI.absoluteString,
+                "code": code, "code_verifier": attempt.verifier, "grant_type": "authorization_code"])
+            try current(ticket)
+            try validate(token)
+            guard let refresh = token.refresh_token, !refresh.isEmpty,
+                  Set(GoogleAuthorizationAttempt.readScopes).isSubset(of: grantedScopes(token.scope ?? "")) else {
+                throw CalendarFailure.reauthenticationRequired
+            }
+            let user: UserInfo = try await request("https://openidconnect.googleapis.com/v1/userinfo", bearer: token.access_token)
+            try current(ticket)
+            guard !user.sub.isEmpty, user.sub.count <= 2048,
+                  existing == nil || existing?.subject == user.sub else { throw CalendarFailure.invalidResponse }
+            let secret = Credential(subject: user.sub, clientID: configuration.clientID, accessToken: token.access_token,
+                refreshToken: refresh, expiresAt: Date().addingTimeInterval(token.expires_in))
+            return CalendarAuthorization(account: CalendarAccountKey(provider: .google, subject: user.sub), displayName: user.email_verified == true ? String((user.email ?? "Google account \(user.sub.prefix(16))").prefix(320)) : "Google account \(user.sub.prefix(16))",
+                                         credential: CalendarSecret(data: try JSONEncoder().encode(secret)))
+        } catch { throw CalendarFailure.safe(error) }
+    }
+    private func current(_ ticket: UUID) throws {
+        guard authorizationTicket == ticket, !Task.isCancelled else { throw CalendarFailure.cancelled }
+    }
+    private func credential(_ secret: CalendarSecret, for account: CalendarAccountKey) throws -> Credential {
+        guard account.provider == .google, let value = try? JSONDecoder().decode(Credential.self, from: secret.data),
+              value.subject == account.subject, value.clientID == configuration.clientID,
+              !value.accessToken.isEmpty, !value.refreshToken.isEmpty, value.expiresAt.timeIntervalSince1970.isFinite else {
+            throw CalendarFailure.reauthenticationRequired
+        }
+        return value
+    }
+    private func grantedScopes(_ scope: String) -> Set<String> {
+        Set(scope.split(separator: " ").map { $0 == "https://www.googleapis.com/auth/userinfo.email" ? "email" : String($0) })
+    }
+    private func validate(_ token: Token) throws {
+        guard token.token_type.lowercased() == "bearer", !token.access_token.isEmpty, token.access_token.count <= 32_768,
+              token.expires_in.isFinite, token.expires_in > 0, token.expires_in <= 86400 else { throw CalendarFailure.invalidResponse }
+    }
+    func renewCredential(account: CalendarAccountKey, credential secret: CalendarSecret) async throws -> CalendarSecret {
+        let old = try credential(secret, for: account)
+        guard old.expiresAt.timeIntervalSinceNow < 60 else { return secret }
+        let token: Token = try await request("https://oauth2.googleapis.com/token", form: ["client_id": configuration.clientID,
+            "refresh_token": old.refreshToken, "grant_type": "refresh_token"])
+        try Task.checkCancellation()
+        try validate(token)
+        if let scope = token.scope,
+           !Set(GoogleAuthorizationAttempt.readScopes).isSubset(of: grantedScopes(scope)) {
+            throw CalendarFailure.reauthenticationRequired
+        }
+        let value = Credential(subject: old.subject, clientID: old.clientID, accessToken: token.access_token,
+            refreshToken: token.refresh_token ?? old.refreshToken, expiresAt: Date().addingTimeInterval(token.expires_in))
+        return CalendarSecret(data: try JSONEncoder().encode(value))
+    }
+
+    private struct CalendarList: Decodable {
+        struct Item: Decodable { let id: String; let summary: String?; let primary: Bool?; let deleted: Bool?; let accessRole: String? }
+        let items: [Item]?
+        let nextPageToken: String?
+    }
+    func calendars(account: CalendarAccountKey, credential secret: CalendarSecret) async throws -> [CalendarDescriptor] {
+        let token = try credential(secret, for: account)
+        var result: [CalendarDescriptor] = []
+        var page: String? = nil
+        var seen: Set<String> = []
+        repeat {
+            var query = [URLQueryItem(name: "maxResults", value: "250"), URLQueryItem(name: "minAccessRole", value: "reader")]
+            if let page { query.append(URLQueryItem(name: "pageToken", value: page)) }
+            let response: CalendarList = try await request("https://www.googleapis.com/calendar/v3/users/me/calendarList", query: query, bearer: token.accessToken)
+            for item in response.items ?? [] where item.deleted != true && item.accessRole != "freeBusyReader" {
+                guard !item.id.isEmpty else { throw CalendarFailure.invalidResponse }
+                result.append(CalendarDescriptor(id: item.id, name: item.summary ?? "Calendar", isDefault: item.primary == true))
+            }
+            guard result.count <= 1000 else { throw CalendarFailure.invalidResponse }
+            page = response.nextPageToken
+            if let page { guard !page.isEmpty, seen.insert(page).inserted, seen.count < 100 else { throw CalendarFailure.invalidResponse } }
+        } while page != nil
+        return result
+    }
+
+    private struct Cursor: Codable {
+        let subject: String
+        let calendars: [String]
+        let window: CalendarWindow
+        let index: Int
+        let page: String?
+    }
+    private struct EventList: Decodable {
+        let timeZone: String?
+        let items: [Event]?
+        let nextPageToken: String?
+    }
+    private struct Event: Decodable {
+        struct Moment: Decodable { let dateTime: String?; let date: String?; let timeZone: String? }
+        let id: String
+        let status: String?
+        let summary: String?
+        let recurringEventId: String?
+        let originalStartTime: Moment?
+        let start: Moment?
+        let end: Moment?
+    }
+    func events(account: CalendarAccountKey, credential secret: CalendarSecret, calendarIDs: Set<String>,
+                window: CalendarWindow, cursor: String?) async throws -> CalendarPage {
+        let token = try credential(secret, for: account)
+        _ = try CalendarWindow(start: window.start, end: window.end)
+        let calendars = calendarIDs.sorted()
+        guard calendars.count <= 1000 else { throw CalendarFailure.invalidResponse }
+        guard !calendars.isEmpty else { return CalendarPage(events: [], next: nil) }
+        let position: Cursor
+        if let cursor {
+            guard cursor.count <= 16_384, let data = Data(base64Encoded: cursor),
+                  let value = try? JSONDecoder().decode(Cursor.self, from: data), value.subject == account.subject,
+                  value.calendars == calendars, value.window == window, calendars.indices.contains(value.index) else {
+                throw CalendarFailure.invalidResponse
+            }
+            position = value
+        } else { position = Cursor(subject: account.subject, calendars: calendars, window: window, index: 0, page: nil) }
+        let calendar = calendars[position.index]
+        let format = ISO8601DateFormatter()
+        var query = [URLQueryItem(name: "timeMin", value: format.string(from: window.start)),
+            URLQueryItem(name: "timeMax", value: format.string(from: window.end)), URLQueryItem(name: "singleEvents", value: "true"),
+            URLQueryItem(name: "showDeleted", value: "true"), URLQueryItem(name: "maxResults", value: "250")]
+        if let page = position.page { query.append(URLQueryItem(name: "pageToken", value: page)) }
+        guard let encoded = calendar.addingPercentEncoding(withAllowedCharacters: .alphanumerics) else { throw CalendarFailure.invalidResponse }
+        let response: EventList = try await request("https://www.googleapis.com/calendar/v3/calendars/\(encoded)/events", query: query, bearer: token.accessToken)
+        let events = try (response.items ?? []).filter { $0.status != "cancelled" }.map { event -> CalendarOccurrence in
+            guard let start = event.start, let end = event.end else { throw CalendarFailure.invalidResponse }
+            if start.date != nil, start.timeZone == nil && response.timeZone == nil { throw CalendarFailure.invalidResponse }
+            let zone = start.timeZone ?? response.timeZone ?? "UTC"
+            guard TimeZone(identifier: zone) != nil else { throw CalendarFailure.invalidResponse }
+            func instant(_ moment: Event.Moment) throws -> Date {
+                if let value = moment.dateTime, moment.date == nil { return try CalendarDateNormalizer.instant(value) }
+                if let value = moment.date, moment.dateTime == nil { return try CalendarDateNormalizer.day(value, timeZoneID: moment.timeZone ?? zone) }
+                throw CalendarFailure.invalidResponse
+            }
+            let beginning = try instant(start)
+            let ending = try instant(end)
+            guard ending > beginning, (start.date == nil) == (end.date == nil) else { throw CalendarFailure.invalidResponse }
+            let occurrence: String
+            if event.recurringEventId != nil {
+                guard let original = event.originalStartTime else { throw CalendarFailure.invalidResponse }
+                if let day = original.date {
+                    _ = try instant(original)
+                    occurrence = "date:\(day)"
+                } else { occurrence = "instant:\(try instant(original).timeIntervalSince1970)" }
+            } else { occurrence = event.id }
+            return CalendarOccurrence(key: EventOccurrenceKey(provider: "google", accountID: account.subject,
+                calendarID: calendar, eventID: event.recurringEventId ?? event.id, occurrenceID: occurrence),
+                title: event.summary ?? "Untitled event", start: beginning, end: ending, timeZoneID: zone, isAllDay: start.date != nil)
+        }
+        let nextPosition: Cursor?
+        if let page = response.nextPageToken {
+            guard !page.isEmpty, page != position.page, page.count <= 8192 else { throw CalendarFailure.invalidResponse }
+            nextPosition = Cursor(subject: account.subject, calendars: calendars, window: window, index: position.index, page: page)
+        } else if position.index + 1 < calendars.count {
+            nextPosition = Cursor(subject: account.subject, calendars: calendars, window: window, index: position.index + 1, page: nil)
+        } else { nextPosition = nil }
+        let next = try nextPosition.map { try JSONEncoder().encode($0).base64EncodedString() }
+        return CalendarPage(events: events, next: next)
+    }
+
+    private func request<T: Decodable>(_ endpoint: String, query: [URLQueryItem] = [], bearer: String? = nil,
+                                       form: [String: String]? = nil) async throws -> T {
+        try Task.checkCancellation()
+        var components = URLComponents(string: endpoint)!
+        components.queryItems = query.isEmpty ? nil : query
+        var request = URLRequest(url: components.url!)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let bearer { request.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization") }
+        if let form {
+            request.httpMethod = "POST"
+            request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+            let safe = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))
+            request.httpBody = form.sorted { $0.key < $1.key }.map {
+                "\($0.key.addingPercentEncoding(withAllowedCharacters: safe)!)=\($0.value.addingPercentEncoding(withAllowedCharacters: safe)!)"
+            }.joined(separator: "&").data(using: .utf8)
+        }
+        do {
+            let (data, response) = try await transport.send(request)
+            try Task.checkCancellation()
+            guard data.count <= 8 * 1024 * 1024, response.url?.host == request.url?.host else { throw CalendarFailure.invalidResponse }
+            if response.statusCode == 401 { throw CalendarFailure.reauthenticationRequired }
+            let errorObject = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+            let googleError = errorObject?["error"] as? [String: Any]
+            let reasons = (googleError?["errors"] as? [[String: Any]])?.compactMap { $0["reason"] as? String } ?? []
+            if response.statusCode == 429 || (response.statusCode == 403 && reasons.contains(where: {
+                ["rateLimitExceeded", "userRateLimitExceeded"].contains($0)
+            })) {
+                let retry = response.value(forHTTPHeaderField: "Retry-After") ?? ""
+                let formatter = DateFormatter()
+                formatter.locale = Locale(identifier: "en_US_POSIX")
+                formatter.timeZone = TimeZone(secondsFromGMT: 0)
+                formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
+                let seconds = Double(retry) ?? formatter.date(from: retry)?.timeIntervalSinceNow ?? 60
+                throw CalendarFailure.rateLimited(retryAt: Date().addingTimeInterval(seconds.isFinite ? min(max(seconds, 1), 86400) : 60))
+            }
+            if response.statusCode == 403 && reasons.contains(where: { ["authError", "insufficientPermissions"].contains($0) }) {
+                throw CalendarFailure.reauthenticationRequired
+            }
+            if response.statusCode >= 500 { throw CalendarFailure.transient }
+            if response.statusCode == 400, let error = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               error["error"] as? String == "invalid_grant" { throw CalendarFailure.reauthenticationRequired }
+            guard (200..<300).contains(response.statusCode) else { throw CalendarFailure.unavailable }
+            guard let value = try? JSONDecoder().decode(T.self, from: data) else { throw CalendarFailure.invalidResponse }
+            return value
+        } catch { throw CalendarFailure.safe(error) }
+    }
+}

--- a/apps/mobile-native/Sources/Calendar/Google/GoogleCalendarTransport.swift
+++ b/apps/mobile-native/Sources/Calendar/Google/GoogleCalendarTransport.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+protocol GoogleCalendarTransport: Sendable {
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse)
+}
+
+/// Fresh ephemeral requests: no disk cache, cookies or automatic redirect forwarding of credentials.
+final class GoogleURLTransport: NSObject, GoogleCalendarTransport, URLSessionTaskDelegate, @unchecked Sendable {
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.urlCache = nil
+        configuration.httpCookieStorage = nil
+        configuration.timeoutIntervalForRequest = 30
+        let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+        defer { session.invalidateAndCancel() }
+        do {
+            let (bytes, response) = try await session.bytes(for: request)
+            var data = Data()
+            for try await byte in bytes {
+                guard data.count < 8 * 1024 * 1024 else { throw CalendarFailure.invalidResponse }
+                data.append(byte)
+            }
+            guard let response = response as? HTTPURLResponse, data.count <= 8 * 1024 * 1024 else {
+                throw CalendarFailure.invalidResponse
+            }
+            return (data, response)
+        } catch let error as URLError {
+            if error.code == .cancelled { throw CalendarFailure.cancelled }
+            if [.notConnectedToInternet, .networkConnectionLost].contains(error.code) { throw CalendarFailure.offline }
+            throw CalendarFailure.transient
+        }
+    }
+    func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse,
+                    newRequest request: URLRequest, completionHandler: @escaping @Sendable (URLRequest?) -> Void) {
+        completionHandler(nil)
+    }
+}

--- a/apps/mobile-native/Sources/Calendar/Google/GoogleNativeAuthorization.swift
+++ b/apps/mobile-native/Sources/Calendar/Google/GoogleNativeAuthorization.swift
@@ -1,0 +1,116 @@
+import AuthenticationServices
+import Foundation
+import CryptoKit
+import Security
+
+struct GoogleCalendarConfiguration: Sendable {
+    let clientID: String
+    let redirectURI: URL
+    init(clientID: String, redirectURI: URL) throws {
+        let scheme = clientID.split(separator: ".").reversed().joined(separator: ".")
+        guard clientID.hasSuffix(".apps.googleusercontent.com"), clientID.count <= 512,
+              redirectURI.scheme == scheme, redirectURI.host == nil,
+              redirectURI.path == "/oauth2redirect", redirectURI.query == nil, redirectURI.fragment == nil else {
+            throw CalendarFailure.unavailable
+        }
+        self.clientID = clientID
+        self.redirectURI = redirectURI
+    }
+}
+
+struct GoogleAuthorizationAttempt: Sendable {
+    let state: String
+    let verifier: String
+    let configuration: GoogleCalendarConfiguration
+    static let readScopes = ["openid", "email", "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+                             "https://www.googleapis.com/auth/calendar.events.readonly"]
+    init(configuration: GoogleCalendarConfiguration) throws {
+        self.configuration = configuration
+        func random() throws -> String {
+            var bytes = [UInt8](repeating: 0, count: 32)
+            guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else { throw CalendarFailure.unavailable }
+            return Data(bytes).base64URL
+        }
+        state = try random()
+        verifier = try random()
+    }
+    var url: URL {
+        var components = URLComponents(string: "https://accounts.google.com/o/oauth2/v2/auth")!
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: configuration.clientID),
+            URLQueryItem(name: "redirect_uri", value: configuration.redirectURI.absoluteString),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "scope", value: Self.readScopes.joined(separator: " ")),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code_challenge", value: Data(SHA256.hash(data: Data(verifier.utf8))).base64URL),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "access_type", value: "offline"),
+            URLQueryItem(name: "prompt", value: "consent select_account")]
+        return components.url!
+    }
+    func code(from callback: URL) throws -> String {
+        guard var parsed = URLComponents(url: callback, resolvingAgainstBaseURL: false), parsed.fragment == nil else {
+            throw CalendarFailure.invalidResponse
+        }
+        let items = parsed.queryItems ?? []
+        parsed.query = nil
+        guard parsed.url == configuration.redirectURI, Set(items.map(\.name)).count == items.count,
+              items.first(where: { $0.name == "state" })?.value == state else { throw CalendarFailure.invalidResponse }
+        if items.contains(where: { $0.name == "error" }) { throw CalendarFailure.cancelled }
+        guard let code = items.first(where: { $0.name == "code" })?.value, !code.isEmpty, code.count <= 4096 else {
+            throw CalendarFailure.invalidResponse
+        }
+        return code
+    }
+}
+
+extension Data {
+    fileprivate var base64URL: String {
+        base64EncodedString().replacingOccurrences(of: "+", with: "-").replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+/// Retain one browser per visible presentation owner. Task cancellation terminates the browser session.
+@MainActor final class GoogleNativeAuthorization: NSObject, ASWebAuthenticationPresentationContextProviding {
+    private let anchor: @MainActor () -> ASPresentationAnchor
+    private var session: ASWebAuthenticationSession?
+    private var ticket: UUID?
+    private var pending: CheckedContinuation<URL, Error>?
+    init(anchor: @escaping @MainActor () -> ASPresentationAnchor) { self.anchor = anchor }
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor { anchor() }
+    func open(_ url: URL, callbackScheme: String) async throws -> URL {
+        guard pending == nil else { throw CalendarFailure.unavailable }
+        let current = UUID()
+        ticket = current
+        return try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            return try await withCheckedThrowingContinuation { continuation in
+                pending = continuation
+                let browser = ASWebAuthenticationSession(url: url, callbackURLScheme: callbackScheme) { [weak self] callback, error in
+                    Task { @MainActor in
+                        if let callback { self?.finish(.success(callback), ticket: current) }
+                        else { self?.finish(.failure(error == nil ? CalendarFailure.invalidResponse : CalendarFailure.cancelled), ticket: current) }
+                    }
+                }
+                browser.presentationContextProvider = self
+                browser.prefersEphemeralWebBrowserSession = true
+                session = browser
+                if !browser.start() { finish(.failure(CalendarFailure.unavailable), ticket: current) }
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                guard self?.ticket == current else { return }
+                self?.session?.cancel()
+                self?.finish(.failure(CalendarFailure.cancelled), ticket: current)
+            }
+        }
+    }
+    private func finish(_ result: Result<URL, Error>, ticket: UUID) {
+        guard self.ticket == ticket, let pending else { return }
+        self.pending = nil
+        self.ticket = nil
+        session = nil
+        pending.resume(with: result)
+    }
+}

--- a/apps/mobile-native/Tests/GoogleCalendarTests.swift
+++ b/apps/mobile-native/Tests/GoogleCalendarTests.swift
@@ -1,0 +1,178 @@
+import XCTest
+import CryptoKit
+@testable import DoodleNoteNative
+
+actor GoogleFixtureTransport: GoogleCalendarTransport {
+    struct Reply: Sendable { let body: String; var status = 200; var headers: [String: String] = [:] }
+    var replies: [Reply]
+    var requests: [URLRequest] = []
+    init(_ replies: [Reply]) { self.replies = replies }
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        requests.append(request)
+        guard !replies.isEmpty else { throw CalendarFailure.offline }
+        let reply = replies.removeFirst()
+        return (Data(reply.body.utf8), HTTPURLResponse(url: request.url!, statusCode: reply.status, httpVersion: nil, headerFields: reply.headers)!)
+    }
+}
+
+final class GoogleCalendarTests: XCTestCase {
+    func config() throws -> GoogleCalendarConfiguration {
+        try GoogleCalendarConfiguration(clientID: "fixture.apps.googleusercontent.com", redirectURI: URL(string: "com.googleusercontent.apps.fixture:/oauth2redirect")!)
+    }
+    func adapter(_ replies: [GoogleFixtureTransport.Reply]) throws -> (GoogleCalendarAdapter, GoogleFixtureTransport) {
+        let transport = GoogleFixtureTransport(replies)
+        let value = GoogleCalendarAdapter(configuration: try config(), transport: transport) { url, _ in
+            let items = URLComponents(url: url, resolvingAgainstBaseURL: false)!.queryItems!
+            let state = items.first { $0.name == "state" }!.value!
+            return URL(string: "com.googleusercontent.apps.fixture:/oauth2redirect?state=\(state)&code=fixture-code")!
+        }
+        return (value, transport)
+    }
+    func secret(subject: String = "A", expired: Bool = false) throws -> CalendarSecret {
+        let value = GoogleCalendarAdapter.Credential(subject: subject, clientID: "fixture.apps.googleusercontent.com", accessToken: "fixture-access",
+            refreshToken: "fixture-refresh", expiresAt: expired ? .distantPast : Date().addingTimeInterval(3600))
+        return CalendarSecret(data: try JSONEncoder().encode(value))
+    }
+    let account = CalendarAccountKey(provider: .google, subject: "A")
+    func window() throws -> CalendarWindow {
+        try CalendarWindow(start: CalendarDateNormalizer.instant("2026-09-01T00:00:00Z"), end: CalendarDateNormalizer.instant("2026-09-15T00:00:00Z"))
+    }
+    func token(subject: String) -> [GoogleFixtureTransport.Reply] {
+        let scopes = GoogleAuthorizationAttempt.readScopes.joined(separator: " ")
+        return [.init(body: "{\"access_token\":\"fixture-access\",\"refresh_token\":\"fixture-refresh\",\"expires_in\":3600,\"token_type\":\"Bearer\",\"scope\":\"\(scopes)\"}"),
+                .init(body: "{\"sub\":\"\(subject)\"}")]
+    }
+    func testNativeConfigurationAndPKCE() throws {
+        XCTAssertThrowsError(try GoogleCalendarConfiguration(clientID: "", redirectURI: URL(string: "http://localhost/callback")!))
+        let attempt = try GoogleAuthorizationAttempt(configuration: config())
+        let next = try GoogleAuthorizationAttempt(configuration: config())
+        XCTAssertNotEqual(attempt.state, next.state)
+        XCTAssertNotEqual(attempt.verifier, next.verifier)
+        XCTAssertEqual(attempt.verifier.count, 43)
+        let items = URLComponents(url: attempt.url, resolvingAgainstBaseURL: false)!.queryItems!
+        XCTAssertEqual(items.first { $0.name == "code_challenge_method" }?.value, "S256")
+        let hash = Data(SHA256.hash(data: Data(attempt.verifier.utf8))).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-").replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: "=", with: "")
+        XCTAssertEqual(items.first { $0.name == "code_challenge" }?.value, hash)
+        XCTAssertFalse(items.contains { $0.name == "client_secret" })
+    }
+    func testCallbackExactRedirectStateAndDuplicates() throws {
+        let attempt = try GoogleAuthorizationAttempt(configuration: config())
+        let callback = "com.googleusercontent.apps.fixture:/oauth2redirect?state=\(attempt.state)&code=good"
+        XCTAssertEqual(try attempt.code(from: URL(string: callback)!), "good")
+        for invalid in [callback + "&code=duplicate", callback + "#fragment", callback.replacingOccurrences(of: attempt.state, with: "wrong"), callback.replacingOccurrences(of: "/oauth2redirect", with: "/other")] {
+            XCTAssertThrowsError(try attempt.code(from: URL(string: invalid)!))
+        }
+        XCTAssertThrowsError(try attempt.code(from: URL(string: "com.googleusercontent.apps.fixture:/oauth2redirect?state=\(attempt.state)&error=access_denied")!))
+    }
+    func testTwoAuthorizedSubjectsAndMismatch() async throws {
+        let (value, transport) = try adapter(token(subject: "A") + token(subject: "B") + token(subject: "wrong"))
+        let a = try await value.authorize(existing: nil)
+        let b = try await value.authorize(existing: nil)
+        XCTAssertNotEqual(a.account, b.account)
+        XCTAssertEqual(a.account.subject, "A")
+        XCTAssertEqual(b.account.subject, "B")
+        do { _ = try await value.authorize(existing: account); XCTFail() } catch { XCTAssertEqual(error as? CalendarFailure, .invalidResponse) }
+        let requests = await transport.requests
+        XCTAssertTrue(requests.filter { $0.httpMethod == "POST" }.allSatisfy { !String(decoding: $0.httpBody!, as: UTF8.self).contains("client_secret") })
+        XCTAssertEqual(requests[1].url?.host, "openidconnect.googleapis.com")
+    }
+    func testVerifiedEmailDisplayAndCanonicalScopeAlias() async throws {
+        var replies = token(subject: "A")
+        replies[0] = .init(body: replies[0].body.replacingOccurrences(of: "openid email ", with: "openid https://www.googleapis.com/auth/userinfo.email "))
+        replies[1] = .init(body: "{\"sub\":\"A\",\"email\":\"first@example.invalid\",\"email_verified\":true}")
+        let (value, _) = try adapter(replies)
+        let result = try await value.authorize(existing: nil)
+        XCTAssertEqual(result.displayName, "first@example.invalid")
+        XCTAssertEqual(result.account.subject, "A")
+    }
+
+    func testUnverifiedEmailIsNeverUsedAsIdentityOrDisplay() async throws {
+        var replies = token(subject: "B")
+        replies[1] = .init(body: "{\"sub\":\"B\",\"email\":\"unverified@example.invalid\",\"email_verified\":false}")
+        let (value, _) = try adapter(replies)
+        let result = try await value.authorize(existing: nil)
+        XCTAssertEqual(result.displayName, "Google account B")
+        XCTAssertEqual(result.account.subject, "B")
+    }
+
+    func testRefreshRotationAndRevocation() async throws {
+        let (value, _) = try adapter([.init(body: "{\"access_token\":\"new-access\",\"refresh_token\":\"rotated\",\"token_type\":\"Bearer\",\"expires_in\":3600}"),
+                                      .init(body: "{\"error\":\"invalid_grant\"}", status: 400)])
+        let result = try await value.renewCredential(account: account, credential: secret(expired: true))
+        let decoded = try JSONDecoder().decode(GoogleCalendarAdapter.Credential.self, from: result.data)
+        XCTAssertEqual(decoded.refreshToken, "rotated")
+        do { _ = try await value.renewCredential(account: account, credential: secret(expired: true)); XCTFail() }
+        catch { XCTAssertEqual(error as? CalendarFailure, .reauthenticationRequired) }
+        do { _ = try await value.renewCredential(account: CalendarAccountKey(provider: .google, subject: "B"), credential: secret()); XCTFail() }
+        catch { XCTAssertEqual(error as? CalendarFailure, .reauthenticationRequired) }
+    }
+    func testAllCalendarPagesAndNoPartialSuccess() async throws {
+        let (value, transport) = try adapter([.init(body: "{\"items\":[{\"id\":\"one\",\"primary\":true}],\"nextPageToken\":\"page2\"}"),
+            .init(body: "{\"items\":[{\"id\":\"two\"},{\"id\":\"removed\",\"deleted\":true}]}"),
+            .init(body: "{\"items\":[{\"id\":\"one\"}],\"nextPageToken\":\"page2\"}"), .init(body: "{}", status: 503)])
+        let calendars = try await value.calendars(account: account, credential: secret())
+        XCTAssertEqual(calendars.map(\.id), ["one", "two"])
+        let requests = await transport.requests
+        XCTAssertTrue(requests[1].url!.absoluteString.contains("pageToken=page2"))
+        do { _ = try await value.calendars(account: account, credential: secret()); XCTFail() }
+        catch { XCTAssertEqual(error as? CalendarFailure, .transient) }
+    }
+    func testRecurringRescheduleAllDayCancellationAndContextBoundPages() async throws {
+        let first = """
+        {"timeZone":"America/Chicago","items":[
+        {"id":"instance","recurringEventId":"series","originalStartTime":{"dateTime":"2026-09-04T10:00:00-05:00"},"start":{"dateTime":"2026-09-05T10:00:00-05:00"},"end":{"dateTime":"2026-09-05T11:00:00-05:00"}},
+        {"id":"cancelled","status":"cancelled"}],"nextPageToken":"two"}
+        """
+        let second = """
+        {"timeZone":"America/Chicago","items":[{"id":"day","start":{"date":"2026-09-06"},"end":{"date":"2026-09-07"}}]}
+        """
+        let (value, _) = try adapter([.init(body: first), .init(body: second), .init(body: "{\"items\":[]}")])
+        let page = try await value.events(account: account, credential: secret(), calendarIDs: ["a/b", "z"], window: window(), cursor: nil)
+        XCTAssertEqual(page.events.count, 1)
+        XCTAssertEqual(page.events.first?.key.eventID, "series")
+        XCTAssertEqual(page.events.first?.key.occurrenceID, "instant:\(try CalendarDateNormalizer.instant("2026-09-04T10:00:00-05:00").timeIntervalSince1970)")
+        let next = try await value.events(account: account, credential: secret(), calendarIDs: ["a/b", "z"], window: window(), cursor: page.next)
+        XCTAssertEqual(next.events.first?.isAllDay, true)
+        XCTAssertEqual(next.events.first?.start, try CalendarDateNormalizer.instant("2026-09-06T05:00:00Z"))
+        XCTAssertNotNil(next.next)
+        do { _ = try await value.events(account: account, credential: secret(), calendarIDs: ["other"], window: window(), cursor: page.next); XCTFail() }
+        catch { XCTAssertEqual(error as? CalendarFailure, .invalidResponse) }
+        let final = try await value.events(account: account, credential: secret(), calendarIDs: ["a/b", "z"], window: window(), cursor: next.next)
+        XCTAssertNil(final.next)
+    }
+    func testRateLimitAndMalformedEventsAreExplicit() async throws {
+        let (value, _) = try adapter([.init(body: "{}", status: 429, headers: ["Retry-After":"120"]), .init(body: "{\"items\":[{\"id\":\"broken\"}]}")])
+        do { _ = try await value.calendars(account: account, credential: secret()); XCTFail() }
+        catch { guard case .rateLimited(let date) = error as? CalendarFailure else { return XCTFail() }; XCTAssertGreaterThan(date.timeIntervalSinceNow, 110) }
+        do { _ = try await value.events(account: account, credential: secret(), calendarIDs: ["one"], window: window(), cursor: nil); XCTFail() }
+        catch { XCTAssertEqual(error as? CalendarFailure, .invalidResponse) }
+    }
+    func test403ThrottlePermissionsAndMissingAllDayTimezone() async throws {
+        let (value, _) = try adapter([
+            .init(body: "{\"error\":{\"errors\":[{\"reason\":\"userRateLimitExceeded\"}]}}", status: 403),
+            .init(body: "{\"error\":{\"errors\":[{\"reason\":\"insufficientPermissions\"}]}}", status: 403),
+            .init(body: "{\"items\":[{\"id\":\"ambiguous\",\"start\":{\"date\":\"2026-09-06\"},\"end\":{\"date\":\"2026-09-07\"}}]}")])
+        do { _ = try await value.calendars(account: account, credential: secret()); XCTFail() }
+        catch { guard case .rateLimited = error as? CalendarFailure else { return XCTFail() } }
+        do { _ = try await value.calendars(account: account, credential: secret()); XCTFail() }
+        catch { XCTAssertEqual(error as? CalendarFailure, .reauthenticationRequired) }
+        do { _ = try await value.events(account: account, credential: secret(), calendarIDs: ["one"], window: window(), cursor: nil); XCTFail() }
+        catch { XCTAssertEqual(error as? CalendarFailure, .invalidResponse) }
+    }
+
+    func testCanceledAndReplayedAuthorizationCannotExchangeCode() async throws {
+        let transport = GoogleFixtureTransport([])
+        let value = GoogleCalendarAdapter(configuration: try config(), transport: transport) { _, _ in throw CancellationError() }
+        do { _ = try await value.authorize(existing: nil); XCTFail() } catch { XCTAssertEqual(error as? CalendarFailure, .cancelled) }
+        let requests = await transport.requests
+        XCTAssertTrue(requests.isEmpty)
+        let oldAttempt = try GoogleAuthorizationAttempt(configuration: config())
+        let replay = GoogleCalendarAdapter(configuration: try config(), transport: transport) { _, _ in
+            URL(string: "com.googleusercontent.apps.fixture:/oauth2redirect?state=\(oldAttempt.state)&code=old")!
+        }
+        do { _ = try await replay.authorize(existing: nil); XCTFail() } catch { XCTAssertEqual(error as? CalendarFailure, .invalidResponse) }
+        let afterReplay = await transport.requests
+        XCTAssertTrue(afterReplay.isEmpty)
+    }
+}

--- a/apps/mobile-native/docs/google-calendar.md
+++ b/apps/mobile-native/docs/google-calendar.md
@@ -1,0 +1,65 @@
+# Native Google Calendar adapter (ONY-255)
+
+Implements the provider behind ONY-254's account store: native browser authorization, code exchange and refresh, stable Google subject identity, complete selected-calendar reads and safe failure handling. There is no built-in client registration and no Google login enabled in the current Home screen. Actual authorized two-account QA remains required before issue completion or external beta.
+
+## Configuration and app integration
+
+Supply `GoogleCalendarConfiguration(clientID:redirectURI:)` with a product-owned **iOS OAuth client**, matching the app bundle ID. This implementation accepts that client's reversed-ID scheme with `/oauth2redirect`, for example `com.googleusercontent.apps.<client-prefix>:/oauth2redirect`; register and verify that exact URI. Do not use the desktop client or a loopback URI. Missing/invalid configuration fails closed. No client secret belongs in a native app.
+
+The integration owner must add the approved scheme to `CFBundleURLTypes` in the generated Info.plist source (`project.yml`), provide a valid visible window/presentation anchor, and retain `GoogleNativeAuthorization`. Construct the adapter with a browser closure calling `await authorization.open(url, callbackScheme: scheme)`. ASWebAuthenticationSession owns this callback; no guessed global callback routing or provider SDK dependency is needed. Root/app wiring is deliberately separate from the provider files to avoid collisions with Microsoft work.
+
+An app-owned settings coordinator can construct the provider as follows after configuration approval. The coordinator must retain `browser`, provide its active window, call `finishPendingDisconnects()` at startup, and keep tasks so Cancel can cancel the authorization task as well as `store.cancelConnect(.google)`:
+
+```swift
+// MainActor settings coordinator; values come from approved injected configuration.
+let browser = GoogleNativeAuthorization { activeWindow }
+let config = try GoogleCalendarConfiguration(clientID: approvedClientID, redirectURI: approvedRedirectURI)
+let provider = GoogleCalendarAdapter(configuration: config) { url, scheme in
+    try await browser.open(url, callbackScheme: scheme)
+}
+let store = try CalendarAccountStore(directory: dedicatedCalendarCacheDirectory)
+try await store.finishPendingDisconnects()
+let account = try await store.connect(using: provider)
+let range = try CalendarWindow(start: Date(), end: Date().addingTimeInterval(14 * 86400))
+try await store.refresh(account, using: provider, window: range)
+// Display snapshots; selected calendar IDs belong only to this account.
+try await store.select(selectedIDs, for: account)
+try await store.disconnect(account)
+```
+
+Authorization uses 256-bit random state and verifier, S256 PKCE, exact redirect/state validation, duplicate-parameter rejection, and an ephemeral system browser requesting account selection and consent. Cancellation closes its session; per-attempt identities reject stale callbacks and adapter results. Auth codes are exchanged once per attempt. Google userinfo supplies the stable subject; no unverified ID-token payload is trusted. Verified email is display-only and never the account key. Existing-account reauthorization rejects a changed subject.
+
+Requested scopes: `openid`, `email` (distinguishable account display), `calendar.calendarlist.readonly` and `calendar.events.readonly` under the Google API scope namespace. Scope validation accepts Google's canonical `userinfo.email` alias. These cover identity, calendar listing and event reading only. No event writes, invitations, Drive, or background service account access. Enable Calendar API and configure consent/test users in the product-owned project. Any production registration, scopes, verification or publishing changes require separate authorization.
+
+## Credentials and requests
+
+The opaque `CalendarSecret` contains subject, client ID, access/refresh tokens and expiry. The existing account store exclusively persists it in device-only Keychain. Renewal retains an omitted refresh token, accepts a rotated token, and binds credentials to both subject and client. The account store commits renewed credentials under a generation check before calendar calls. Google adapter does not maintain a second SDK token cache, so account disconnect uses the existing targeted Keychain/cache cleanup without hidden SDK sessions. It does not revoke tokens remotely or sign out other browser accounts.
+
+Fixed HTTPS endpoints use an ephemeral URLSession, no cookies/cache or credential-bearing redirects, a 30-second request timeout and an 8 MiB streamed response cap. Calendar paths are encoded as path components. HTTP401/invalid_grant and missing permissions require reauthentication; consent/policy failures remain explicit safe errors. HTTP429 and Google403 rate-limit reasons carry bounded Retry-After dates (seconds or HTTP date), and server failures are transient. No raw provider response/error, request or credential is logged.
+
+## Complete calendar/event reads
+
+Calendar listing reads all pages up to the shared 1,000-calendar bound; a failed later page fails the whole refresh. Event pages traverse every selected calendar and provider page through a cursor bound to subject, exact sorted calendar selection and date window. Cursors are opaque data, never URLs; changed contexts are rejected. Shared account-store limits and cycle detection prevent infinite pagination. No first-page-only success or silent truncation.
+
+Events use `singleEvents=true` to expand recurring meetings and `showDeleted=true` to explicitly exclude canceled occurrences. A series occurrence uses the recurring series ID and original start identity, so a reschedule changes its displayed time without changing its note link. Nonrecurring event identity uses its stable event ID. All-day dates retain the provider's originating timezone and exclusive end date. Missing all-day timezone, malformed dates, incomplete active events and invalid pages fail explicitly, preserving the old complete cache. Date-time values require explicit offsets. Specialist access beyond calendars returned with reader-or-better access is not promised.
+
+## Verification and Check this:
+
+```sh
+xcodegen generate --spec apps/mobile-native/project.yml
+xcodebuild test -project apps/mobile-native/DoodleNoteNative.xcodeproj -scheme DoodleNoteNative -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /tmp/ony255-derived -only-testing:DoodleNoteNativeTests/GoogleCalendarTests CODE_SIGNING_ALLOWED=NO
+```
+
+The HTTP/browser fixtures verify PKCE/state/redirect/replay/cancellation, two subjects, wrong-account reauth, rotation/revocation, complete calendar/event pages, recurrence/reschedule/cancel/all-day behavior, context-bound cursors, throttling and explicit failures. They do not prove provider registration, Google's real consent experience or production account behavior.
+
+After approved registration and app presentation wiring:
+
+1. Connect two authorized Google test accounts. Confirm distinguishable emails, independent calendar selections and local notes without DoodleNote sync.
+2. Select calendars containing recurring, rescheduled, canceled and all-day meetings across a timezone/DST boundary; verify all pages and unchanged event-note identity after rescheduling.
+3. Deny/cancel login and revoke one account's consent. Expect clear cancellation/reauthentication, old cache labeled stale and the other account unchanged.
+4. Go offline, then reconnect; verify cached events persist and successful refresh replaces the complete range. Disconnect one account; its credentials/cache disappear while created notes and the other account remain.
+5. Validate the native callback and Keychain on signed iPhone/iPad builds. Unavailable registrations/accounts mean these checks remain pending, not passed by mocked tests.
+
+No existing schema migration or cloud rollout. Rollback removes provider wiring while local notes remain intact; dispose only this provider's account/cache through the existing disconnect API. Production configuration has not been changed.
+
+Primary references checked 2026-09-06: [Google native OAuth](https://developers.google.com/identity/protocols/oauth2/native-app), [calendarList.list](https://developers.google.com/workspace/calendar/api/v3/reference/calendarList/list), [events.list](https://developers.google.com/workspace/calendar/api/v3/reference/events/list), [OpenID/userinfo](https://developers.google.com/identity/openid-connect/openid-connect).


### PR DESCRIPTION
## Linear Issue
[ONY-255](https://linear.app/onyxdevlabs/issue/ONY-255/connect-multiple-google-calendars-in-the-native-mobile-app)

## Outcome
Adds a native Google Calendar provider with independent account credentials, complete selected-calendar reads and safe failure handling. This draft is ready for technical review; approved native Google configuration, app presentation wiring and authorized account QA remain unavailable.

## What Changed
- Native ASWebAuthenticationSession with state, S256 PKCE, exact callback validation and stale/canceled-attempt protection.
- Protected credential envelope bound to stable Google subject/client, refresh rotation and verified-email display.
- Read-only calendar/event pagination, recurring original occurrence identity, rescheduling, cancellation and timezone-aware all-day normalization.
- Bounded ephemeral HTTP transport with no credential redirects; explicit offline/permission/revocation/throttle/partial-page failures.
- Eleven provider fixture tests and exact integration/QA documentation. Shared app/project/entitlement files remain untouched.

## Acceptance Criteria Evidence
- [x] Multiple account identities and independent provider adapter integration verified by fixtures and existing CalendarAccountStore tests.
- [x] Native PKCE/state/callback/replay/cancel implementation and protected per-account credential contract verified locally.
- [x] All selected calendar/event pages, recurring/rescheduled/canceled events and timezone/all-day values covered by fixtures; partial failures explicit.
- [x] Credential renewal/revocation, throttling and account mismatch covered; existing account-store tests preserve offline cache and note independence.
- [ ] Authorized two-account connect/select/refresh/offline/revoke/disconnect matrix requires an approved Google iOS client and test accounts. Fixtures are not live OAuth evidence.
- [ ] Production client/scopes/verification readiness and signed native callback behavior remain external gates; no production changes made.

## Verification
- XcodeGen generation passed. All eleven Google fixture tests passed on final iPad and final targeted iPhone runs.
- All remote CI green at `2af18f3b3cfaa0360678b19f1ebc5310b952b2a6`, including [Native mobile](https://github.com/Onyx-Dev-Labs/doodle-note/actions/runs/34070524487), general checks, Windows packaging, CodeQL and Vercel.
- Final iPad full suite: 74 cases, 72 passed and two expected skips (unsigned Keychain, optional model). Full iPhone suite before the two test-only additions: 72 cases, 70 passed and two expected skips; production code identical.
- iPhone result: `/tmp/ony255-derived/Logs/Test/Test-DoodleNoteNative-2026.09.06_19-37-40--0500.xcresult`; iPad: `/tmp/ony255-derived/Logs/Test/Test-DoodleNoteNative-2026.09.06_19-39-18--0500.xcresult`.
- Full suite command: `xcodebuild test -project apps/mobile-native/DoodleNoteNative.xcodeproj -scheme DoodleNoteNative -destination platform=iOS\ Simulator,id=SIMULATOR_UUID -derivedDataPath /tmp/ony255-derived CODE_SIGNING_ALLOWED=NO`. iPhone UUID `F6067793-A05A-4174-A892-AC5C0F7A2FCB`; iPad UUID `8EEF4C09-BF6B-4A1E-9416-BFD874E454FA`.
- `git diff --check` passed. Root review findings addressed in the same lane.
- Exact commands and test scope in `apps/mobile-native/docs/google-calendar.md`. Unsigned Keychain and opt-in speaker model are explicit expected skips, not provider/accuracy evidence.

## Local QA / Check this:
1. Generate/open `apps/mobile-native/DoodleNoteNative.xcodeproj`, run GoogleCalendarTests using the documented command; inspect callback/state and complete-page fixture behavior.
2. After approved configuration and presentation wiring, connect two authorized Google accounts. Expect distinguishable verified-email displays, stable subject identity and independent selected calendars without DoodleNote sync.
3. Exercise recurring/rescheduled/canceled and all-day meetings across timezones; expect complete pages, stable event-note identity and explicit errors for malformed/ambiguous data.
4. Deny/cancel/revoke one account and go offline; expect safe status, retained previous cache, unchanged other account and notes. Disconnect only one account.

## Risks and Release Notes
No live Google login, production OAuth/permissions, app registration, client secret, note/cloud schema change or merge. Root owns common callback/presentation/config integration; docs provide a concrete coordinator example. Provider remains unconfigured by default. Real account QA is required before issue completion.

## Follow-ups
Authorized native Google registration and manual matrix; ONY-257 upcoming-meeting integration. No automatic expansion into Home UI.
