### PR TITLE
[ONY-259] Add private cloud storage for editable ink and note previews

### DIFF
--- a/apps/web/app/api/cron/billing-lifecycle/route.ts
+++ b/apps/web/app/api/cron/billing-lifecycle/route.ts
@@ -1,3 +1,4 @@
+import { cleanupPrivateInk } from "@/lib/private-ink-cleanup";
 import { timingSafeEqual } from "node:crypto";
 
 import { NextResponse } from "next/server";
@@ -36,7 +37,24 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const started = Date.now();
   const deletions = await processDueDataDeletions();
   const notifications = await processPendingBillingNotifications();
-  return NextResponse.json({ ok: true, deletions, notifications });
+  let privateAssets;
+  try {
+    privateAssets = await cleanupPrivateInk(
+      undefined,
+      undefined,
+      undefined,
+      Math.min(20000, Math.max(0, 55000 - (Date.now() - started))),
+    );
+  } catch {
+    privateAssets = { error: "cleanup_pending" };
+  }
+  return NextResponse.json({
+    ok: true,
+    deletions,
+    notifications,
+    privateAssets,
+  });
 }

--- a/apps/web/app/api/sync/ink/route.ts
+++ b/apps/web/app/api/sync/ink/route.ts
@@ -1,0 +1,34 @@
+import { getDb } from "@repo/db";
+import { authenticateEntitledSyncRequest } from "@/lib/sync-auth";
+import { handlePrivateInk } from "@/lib/private-ink";
+import { privateInkEnabled, privateInkStore } from "@/lib/private-ink-store";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+async function handle(request: Request) {
+  const headers = {
+    "Cache-Control": "private, no-store, max-age=0",
+    Vary: "Authorization",
+  };
+  if (!privateInkEnabled())
+    return Response.json({ error: "not_found" }, { status: 404, headers });
+  try {
+    const auth = await authenticateEntitledSyncRequest(request);
+    if (auth.response) {
+      for (const [key, value] of Object.entries(headers))
+        auth.response.headers.set(key, value);
+      return auth.response;
+    }
+    return await handlePrivateInk(
+      request,
+      getDb(),
+      auth.device.organizationId,
+      privateInkStore(),
+    );
+  } catch {
+    return Response.json(
+      { error: "temporarily_unavailable" },
+      { status: 503, headers },
+    );
+  }
+}
+export { handle as GET, handle as POST, handle as PUT };

--- a/apps/web/docs/private-ink-storage.md
+++ b/apps/web/docs/private-ink-storage.md
@@ -1,0 +1,173 @@
+# Private editable ink and previews (ONY-259)
+
+This is a source implementation, disabled until an approved rollout. It does not
+prove a live private store or a physical Pencil roundtrip. Existing public desktop
+`/api/sync/media` attachments retain their existing behavior.
+
+## Provider and rollout boundary
+
+Use the existing Vercel Blob SDK (locked 2.8.0) through `PrivateInkStore` with
+`access: private`, a **dedicated** `DOODLENOTE_PRIVATE_INK_TOKEN`, immutable paths,
+and origin reads (`useCache: false`). Never use `BLOB_READ_WRITE_TOKEN` as fallback.
+A private store is required; a public store cannot be made private by hiding its
+URL. No store was created, credentials inspected, or configuration changed.
+
+Official references, checked 2026-09-07:
+- [Private storage](https://vercel.com/docs/vercel-blob/private-storage)
+- [SDK get/put and private access](https://vercel.com/docs/vercel-blob/using-blob-sdk)
+- [Blob security](https://vercel.com/docs/vercel-blob/security)
+
+The new API additionally requires `DOODLENOTE_PRIVATE_INK_ENABLED=true`, and an
+entitled authenticated sync device. Missing private configuration fails closed.
+Disabled API requests return 404 before database or storage access. Private-store
+URLs, storage paths, provider headers, credentials, and presigned URLs are never
+returned to clients. Existing sync entitlement/account isolation applies.
+
+Every download supplies library, note, immutable revision, version, and part.
+The server verifies that revision actually references that ready bundle, that it
+belongs to the authenticated workspace, and that the note is still recoverable.
+It fetches and verifies the bounded bytes, then rechecks revision/lifecycle before
+responding. Responses and errors use `Cache-Control: private, no-store, max-age=0`
+and `Vary: Authorization`. Download responses use `nosniff` and attachment content
+disposition. Provider caching is bypassed. No redirect or conditional 304 bypass
+exists. Client code must not send these endpoints through public image optimizers
+or save fetched bytes to a shared cache.
+
+## Native wire contract
+
+The adapter in ONY-262 first creates the note through sync v2, then reserves a
+bundle with POST `/api/sync/ink`. All UUID values are lowercase canonical strings.
+`attachmentId` identifies the drawing within its note; `versionId` is a new global
+UUID for each immutable bundle and is also the idempotency key. There is no mutable
+object overwrite or separate unbounded extension payload.
+
+```json
+{
+  "libraryId": "UUID", "noteId": "UUID", "attachmentId": "UUID",
+  "versionId": "UUID", "generation": "current lifecycle UUID",
+  "expectedRevision": "current content head UUID",
+  "ink": {"contentType":"application/x-apple-pencilkit","size":123,"sha256":"64 lowercase hex"},
+  "preview": {"contentType":"image/png","size":123,"sha256":"64 lowercase hex"}
+}
+```
+
+The example uses placeholders, not valid request values. The manifest body is
+limited to 4096 bytes. Each part is **1 to 3 MiB**, independently uploaded as the
+binary PUT body to `/api/sync/ink?versionId=UUID&part=ink` (or `preview`), with its
+exact content type. Oversized content fails explicitly; keep the local original
+and show a sync error. No truncation, lossy replacement, or original deletion.
+
+Ink is `PKDrawing.dataRepresentation()` from the fresh native app, retained byte
+for byte. The server treats that Apple serialization as opaque: MIME, size, and
+SHA-256 are validated; server-side PencilKit semantic decoding is not claimed.
+Native clients must validate with `PKDrawing(data:)` before replacing their local
+version. The preview must be noninterlaced 8-bit RGB or RGBA PNG, at most 4096 on
+either side and 4,194,304 total pixels. PNG signature, chunk boundaries/CRC, IHDR,
+IEND, and bounded decompressed scanlines are checked. The native adapter should
+render/encode this explicit preview format. A bundle associates the preview with
+the ink revision; it does not cryptographically prove that the image depicts the
+ink. Recording audio and voice profiles have no fields or supported content type.
+
+Reservation requires an existing active note and matching lifecycle generation
+and content head. A replay of the exact same reservation is safe even if another
+content edit subsequently advances the head. A changed manifest with a reused
+version is rejected. New revisions use new UUIDs. Upload success returns only
+`pending` or `ready`; both parts must be hash-verified before ready. A provider
+"exists" or lost-response retry succeeds only after the existing private bytes
+match the manifest hash and size.
+
+After `ready`, commit a normal sync v2 snapshot containing
+`inkAttachments: [{id: attachmentId, versionId}]`. A PostgreSQL trigger checks
+ready state, note/workspace/library ownership in the same transaction as revision
+creation. Invalid references roll back the entire operation, including initial
+note/adoption changes. A stale known content revision creates a conflict using
+ONY-258 semantics, preserving both bundles. Native conflict resolution must not
+replace the original local drawing before the chosen revision is acknowledged.
+
+Download with GET `/api/sync/ink?libraryId=UUID&noteId=UUID&revisionId=UUID&versionId=UUID&part=ink`
+or `part=preview`. Pending or unreferenced bundles are not downloadable. Other
+accounts, guessed IDs, and a version substituted into an unrelated revision get
+no bytes. An authenticated server response is required on every request.
+
+## Retention and durable cleanup
+
+All retained immutable revisions, including conflicts, keep their referenced
+bundles. Moving a note to Trash retains those assets through ONY-258's server
+30-day window. Explicit restore keeps the same asset versions. Expired Trash
+cannot download assets even before physical cleanup runs. Permanent purge and
+expiry delete asset metadata and enqueue both paths in the same database
+transaction as the lifecycle update. Cascading note/library/organization deletion
+also queues paths; the cleanup table deliberately has no cascading foreign key.
+
+Pending and ready-but-unreferenced uploads older than 24 hours are orphans. The
+collector filters actionable candidates before its limits and rechecks references
+under the same workspace mutex as sync commit. Upload finalization checks the
+current lifecycle. An upload finishing after purge remains unreachable and resets
+the durable cleanup entry. Minimal path tombstones are retained and re-deleted
+daily to reclaim provider writes that finish even after an aborted request. These
+tombstones hold no ink/preview bytes or credentials.
+
+The existing hourly billing worker runs ordinary billing work first and isolates
+private cleanup errors. Cleanup runs after schema installation even when the API
+flag is off, so rollback does not strand queued data. It prioritizes never-deleted
+paths over repeated tombstones, processes bounded candidates, reserves time for
+each 10-second provider request, and reports pending/failed counts. Multiple calls
+may be needed for large purges. Provider failures retry; no false physical-erasure
+claim is made from metadata deletion alone. The worker requires the existing
+CRON_SECRET authorization and no new schedule is installed by this PR.
+
+Personal billing purge deletes native and adopted assets only for selected
+personal workspaces. Shared workspace objects remain. Its durable billing job
+stays pending when private cleanup has failures or outstanding work. A workspace
+with no private assets never requires private storage credentials. After
+organization deletion, the existing hourly worker can still process its queued
+paths. Operational checks must distinguish logical access denial, a successful
+provider delete acknowledgement, and any provider backup/retention policy.
+
+## Migration, staged verification, and rollback
+
+1. Review this source PR. Merging main automatically deploys web code to Vercel
+   Production, including billing cleanup compatibility. The ink API stays disabled
+   absent its flag; catalog detection supports the old schema. Merge is a separate
+   approval from production schema/storage changes.
+2. In a separately authorized isolated workspace, apply migrations through 0014.
+   It adds metadata/cleanup tables and triggers/functions, without rewriting public
+   attachments. Existing sync snapshots with unresolved ink references require an
+   explicit inventory/backfill decision; do not invent asset bytes or URLs. Existing
+   desktop/public attachments are not migrated into private ink implicitly.
+3. Confirm a private store exists, account ownership, region/retention and actual
+   expected cost/caps. Obtain explicit approval before creating a paid store or
+   setting production credentials/configuration. Configure its dedicated private
+   credential and exercise known synthetic files. A wrong/public store must fail.
+4. Enable only for the approved test environment. Verify unauthenticated provider
+   URL requests reveal no bytes; API requests are authenticated and never cached
+   publicly. Exercise interrupted upload, retry, concurrent edits, Trash/restore,
+   expiry, permanent purge, billing purge, and organization deletion. Verify deletion
+   directly in that controlled store and the cleanup queue, not merely by HTTP 404.
+5. Required physical QA: draw with Pencil on iPad, upload the original and preview,
+   download and reopen in PencilKit, edit strokes again, and confirm byte/hash
+   identity before editing. Confirm iPhone/desktop preview readability and conflict
+   selection. This is not yet performed; no user iPad is available today.
+
+Before any assets exist, rollback can restore the prior deployed web artifact and
+roll back uncommitted migration SQL. After assets exist, disable only the API flag,
+retain the schema, private credential and cleanup-aware worker, and preserve
+original local drawings and immutable cloud records. Do not roll back to code
+without purge/cleanup support, drop tables, delete the store, or revert migration
+0014 on production data. Resume source fixes through a reviewed forward migration.
+
+## Reproducible local evidence
+
+- `pnpm --filter web exec tsx --test tests/private-ink.test.ts` uses actual migrated
+  isolated PGlite and synthetic object bytes in memory. No private fixture leaves
+  the machine. SDK adapter tests inject provider responses, checking private
+  access/cache/error semantics. They do **not** prove a live store configuration.
+- `python3 packages/db/scripts/verify-sync-postgres.py` starts/stops disposable
+  local PostgreSQL on a private Unix socket, verifies rollback/reapplication and
+  concurrent cross-workspace library/version reservations. It never reads a live
+  DATABASE_URL or connects to an existing database.
+- Full web/DB tests, types, build, lint and configured CI remain source checks.
+
+Human review: verify the staged private-store and physical steps above after their
+separate approvals. This issue remains incomplete until its required QA and merge
+boundary are satisfied; a source PR alone is not a release.

--- a/apps/web/docs/private-ink-storage.md
+++ b/apps/web/docs/private-ink-storage.md
@@ -52,7 +52,7 @@ object overwrite or separate unbounded extension payload.
 ```
 
 The example uses placeholders, not valid request values. The manifest body is
-limited to 4096 bytes. Each part is **1 to 3 MiB**, independently uploaded as the
+limited to 4096 bytes. Each part is **1 byte to 3 MiB**, independently uploaded as the
 binary PUT body to `/api/sync/ink?versionId=UUID&part=ink` (or `preview`), with its
 exact content type. Oversized content fails explicitly; keep the local original
 and show a sync error. No truncation, lossy replacement, or original deletion.

--- a/apps/web/lib/cloud-data-purge.ts
+++ b/apps/web/lib/cloud-data-purge.ts
@@ -1,3 +1,5 @@
+import { cleanupPrivateInk } from "./private-ink-cleanup";
+import type { PrivateInkStore } from "./private-ink-store";
 import { del, list } from "@vercel/blob";
 import {
   agentTokens,
@@ -23,6 +25,7 @@ export interface CloudDataPurgeResult {
 interface PurgePersonalCloudDataInput {
   userId: string;
   db?: Db;
+  privateInkProvider?: PrivateInkStore;
   deleteAttachmentPrefix?: (prefix: string) => Promise<void>;
 }
 
@@ -50,6 +53,7 @@ export async function purgePersonalCloudData({
   userId,
   db = getDb(),
   deleteAttachmentPrefix = deleteCloudAttachments,
+  privateInkProvider,
 }: PurgePersonalCloudDataInput): Promise<CloudDataPurgeResult> {
   const personalWorkspaces = await db
     .select({ id: organization.id })
@@ -85,6 +89,10 @@ export async function purgePersonalCloudData({
     } else {
       const deletedMeetings = await db.delete(meetings).where(eq(meetings.organizationId, workspace.id)).returning();
       meetingCount += deletedMeetings.length;
+    }
+    const privateCleanup = await cleanupPrivateInk(db, workspace.id, privateInkProvider);
+    if (privateCleanup.failed || privateCleanup.pending) {
+      throw new Error("Private asset cleanup pending");
     }
     await db.delete(folders).where(eq(folders.organizationId, workspace.id));
     await db

--- a/apps/web/lib/ink-preview.ts
+++ b/apps/web/lib/ink-preview.ts
@@ -1,0 +1,72 @@
+import { inflateSync } from "node:zlib";
+/** Deliberately narrow native preview contract: noninterlaced 8-bit RGB/RGBA PNG. */
+export function validateInkPreview(input: Uint8Array) {
+  const bytes = Buffer.from(input);
+  const fail = () => {
+    throw new Error("invalid_content");
+  };
+  if (
+    bytes.length < 33 ||
+    bytes.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a"
+  )
+    fail();
+  let offset = 8,
+    width = 0,
+    height = 0,
+    channels = 0,
+    ended = false;
+  const compressed: Buffer[] = [];
+  while (offset + 12 <= bytes.length) {
+    const size = bytes.readUInt32BE(offset);
+    if (size > bytes.length - offset - 12) fail();
+    const name = bytes.toString("ascii", offset + 4, offset + 8);
+    const data = bytes.subarray(offset + 8, offset + 8 + size);
+    let crc = 0xffffffff;
+    for (const byte of bytes.subarray(offset + 4, offset + 8 + size)) {
+      crc ^= byte;
+      for (let i = 0; i < 8; i++)
+        crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+    if ((crc ^ 0xffffffff) >>> 0 !== bytes.readUInt32BE(offset + 8 + size))
+      fail();
+    if (["acTL", "fcTL", "fdAT"].includes(name)) fail();
+    if (offset === 8) {
+      if (name !== "IHDR" || size !== 13) fail();
+      width = data.readUInt32BE(0);
+      height = data.readUInt32BE(4);
+      if (
+        !width ||
+        !height ||
+        width > 4096 ||
+        height > 4096 ||
+        width * height > 4_194_304 ||
+        data[8] !== 8 ||
+        ![2, 6].includes(data[9]!) ||
+        data[10] !== 0 ||
+        data[11] !== 0 ||
+        data[12] !== 0
+      )
+        fail();
+      channels = data[9] === 6 ? 4 : 3;
+    } else if (name === "IDAT") compressed.push(data);
+    else if (name === "IEND") {
+      if (size !== 0) fail();
+      ended = true;
+      offset += 12;
+      break;
+    } else if (name === "IHDR" || name[0] === name[0]?.toUpperCase()) fail(); // Unknown critical chunks, including animation, are not accepted.
+    offset += size + 12;
+  }
+  if (!ended || offset !== bytes.length || !compressed.length) fail();
+  const stride = width * channels + 1;
+  let decoded: Buffer;
+  try {
+    decoded = inflateSync(Buffer.concat(compressed), {
+      maxOutputLength: stride * height,
+    });
+  } catch {
+    return fail();
+  }
+  if (decoded.length !== stride * height) fail();
+  for (let row = 0; row < height; row++) if (decoded[row * stride]! > 4) fail();
+}

--- a/apps/web/lib/private-ink-cleanup.ts
+++ b/apps/web/lib/private-ink-cleanup.ts
@@ -1,0 +1,74 @@
+import { getDb, sql, inkRows, type Db } from "@repo/db";
+import { privateInkStore, type PrivateInkStore } from "./private-ink-store";
+/** Installed-schema detection also protects cleanup during flag-off rollback. */
+export async function cleanupPrivateInk(
+  db: Db = getDb(),
+  org?: string,
+  provider?: PrivateInkStore,
+  maxMilliseconds = 20000,
+) {
+  if (maxMilliseconds < 10000)
+    return { deleted: 0, failed: 0, pending: 0, deferred: true };
+  const deadline = Date.now() + maxMilliseconds;
+  const installed = inkRows(
+    await db.execute(
+      sql`select to_regprocedure('ink_collect(text)') is not null as available`,
+    ),
+  )[0]?.available;
+  if (!installed) return { deleted: 0, failed: 0, pending: 0 };
+  const workspaces = org
+    ? [org]
+    : inkRows(
+        await db.execute(sql`select organization_id from (
+    select v.organization_id from ink_versions v where v.created_at<now()-interval '24 hours'
+    and not exists(select 1 from sync_revisions r where r.note_id=v.note_id and r.snapshot->'inkAttachments' @> jsonb_build_array(jsonb_build_object('id',v.attachment_id,'versionId',v.id)))
+    union select organization_id from sync_notes where state='trashed' and expires_at<=now()
+  ) candidates order by organization_id limit 50`),
+      ).map((row) => String(row.organization_id));
+  for (const workspace of workspaces) {
+    if (Date.now() + 10000 > deadline) break;
+    await db.execute(sql`select ink_collect(${workspace})`);
+  }
+  const work = inkRows(
+    await db.execute(
+      sql`select path from ink_cleanup where (${org ?? null}::text is null or organization_id=${org ?? null}) and next_attempt_at<=now() order by (deleted_at is not null),next_attempt_at limit 100`,
+    ),
+  );
+  let deleted = 0,
+    failed = 0;
+  // No private credential dependency for accounts with no private objects.
+  if (work.length) {
+    let store: PrivateInkStore;
+    try {
+      store = provider ?? privateInkStore();
+    } catch {
+      return { deleted: 0, failed: work.length, pending: work.length };
+    }
+    for (const row of work) {
+      if (Date.now() + 10000 > deadline) break;
+      const path = String(row.path);
+      try {
+        await store.delete(path);
+        deleted++;
+        // Retain minimal tombstones and re-delete daily: covers a provider upload
+        // completing after its aborted request and the first cleanup attempt.
+        await db.execute(
+          sql`update ink_cleanup set deleted_at=now(),attempts=attempts+1,next_attempt_at=now()+interval '1 day' where path=${path}`,
+        );
+      } catch {
+        failed++;
+        await db.execute(
+          sql`update ink_cleanup set attempts=attempts+1,next_attempt_at=now()+interval '1 hour' where path=${path}`,
+        );
+      }
+    }
+  }
+  const pending = Number(
+    inkRows(
+      await db.execute(
+        sql`select count(*) as count from ink_cleanup where deleted_at is null and (${org ?? null}::text is null or organization_id=${org ?? null})`,
+      ),
+    )[0]?.count ?? 0,
+  );
+  return { deleted, failed, pending };
+}

--- a/apps/web/lib/private-ink-store.ts
+++ b/apps/web/lib/private-ink-store.ts
@@ -1,0 +1,96 @@
+import { get, put, del } from "@vercel/blob";
+import { INK_MAX_BYTES, type InkPart } from "@repo/db";
+export interface PrivateInkStore {
+  put(path: string, bytes: Uint8Array, contentType: string): Promise<void>;
+  get(path: string): Promise<Uint8Array | null>;
+  delete(path: string): Promise<void>;
+}
+export function privateInkEnabled() {
+  return process.env.DOODLENOTE_PRIVATE_INK_ENABLED === "true";
+}
+export function inkPath(version: string, part: InkPart) {
+  return `private-ink/${version}/${part}`;
+}
+export async function boundedBytes(
+  stream: ReadableStream<Uint8Array> | null,
+  max = INK_MAX_BYTES,
+): Promise<Uint8Array> {
+  if (!stream) throw new Error("empty_body");
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > max) throw new Error("too_large");
+      chunks.push(value);
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+  const result = new Uint8Array(size);
+  let at = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, at);
+    at += chunk.length;
+  }
+  return result;
+}
+/** Dedicated credential only. Never fall back to the legacy public attachment store. */
+export function privateInkStore(): PrivateInkStore {
+  const token = process.env.DOODLENOTE_PRIVATE_INK_TOKEN;
+  if (!token) throw new Error("private_store_unconfigured");
+  return createPrivateInkStore(token);
+}
+export function createPrivateInkStore(
+  token: string,
+  sdk: Pick<typeof import("@vercel/blob"), "put" | "get" | "del"> = {
+    put,
+    get,
+    del,
+  },
+): PrivateInkStore {
+  if (!token) throw new Error("private_store_unconfigured");
+  const options = () => ({ token, abortSignal: AbortSignal.timeout(10000) });
+  return {
+    async put(path, bytes, contentType) {
+      const blob = await sdk.put(path, Buffer.from(bytes), {
+        ...options(),
+        access: "private",
+        contentType,
+        addRandomSuffix: false,
+        allowOverwrite: false,
+      });
+      if (
+        new URL(blob.url).hostname.endsWith(
+          ".private.blob.vercel-storage.com",
+        ) !== true
+      )
+        throw new Error("private_store_required");
+    },
+    async get(path) {
+      const result = await sdk.get(path, {
+        ...options(),
+        access: "private",
+        useCache: false,
+      });
+      if (!result) return null;
+      if (
+        result.statusCode !== 200 ||
+        !new URL(result.blob.url).hostname.endsWith(
+          ".private.blob.vercel-storage.com",
+        )
+      ) {
+        await result.stream?.cancel();
+        throw new Error("private_store_required");
+      }
+      return boundedBytes(result.stream);
+    },
+    async delete(path) {
+      await sdk.del(path, options());
+    },
+  };
+}

--- a/apps/web/lib/private-ink.ts
+++ b/apps/web/lib/private-ink.ts
@@ -1,0 +1,148 @@
+import { validateInkPreview } from "./ink-preview";
+import { createHash } from "node:crypto";
+import {
+  type Db,
+  INK_TYPES,
+  inkId,
+  reserveInk,
+  uploadMetadata,
+  markInkUploaded,
+  downloadMetadata,
+  type InkPart,
+  type InkManifest,
+} from "@repo/db";
+import {
+  boundedBytes,
+  inkPath,
+  type PrivateInkStore,
+} from "./private-ink-store";
+const headers = {
+  "Cache-Control": "private, no-store, max-age=0",
+  Vary: "Authorization",
+  "X-Content-Type-Options": "nosniff",
+};
+function json(value: unknown, status = 200) {
+  return Response.json(value, { status, headers });
+}
+function valid(bytes: Uint8Array, manifest: InkManifest, part: InkPart) {
+  const d = manifest[part];
+  if (
+    bytes.byteLength !== d.size ||
+    createHash("sha256").update(bytes).digest("hex") !== d.sha256
+  )
+    throw new Error("invalid_content");
+  // PencilKit's versioned serialization is opaque server-side. Only PNG previews
+  // are rendered; ink bytes are downloaded as an attachment by native clients.
+  if (part === "preview") validateInkPreview(bytes);
+}
+export async function handlePrivateInk(
+  request: Request,
+  db: Db,
+  org: string,
+  store: PrivateInkStore,
+): Promise<Response> {
+  try {
+    if (request.method === "POST") {
+      const bytes = await boundedBytes(request.body, 4096);
+      let value: unknown;
+      try {
+        value = JSON.parse(Buffer.from(bytes).toString("utf8"));
+      } catch {
+        return json({ error: "invalid_manifest" }, 400);
+      }
+      const status = await reserveInk(db, org, value);
+      return json(
+        { status },
+        ["pending", "ready"].includes(status)
+          ? 200
+          : status === "not_found"
+            ? 404
+            : 409,
+      );
+    }
+    const q = new URL(request.url).searchParams;
+    const version = q.get("versionId");
+    inkId(version);
+    const part = q.get("part");
+    if (part !== "ink" && part !== "preview")
+      return json({ error: "invalid_part" }, 400);
+    if (request.method === "PUT") {
+      const metadata = await uploadMetadata(db, org, version);
+      if (!metadata) return json({ error: "not_found" }, 404);
+      if (request.headers.get("content-type") !== INK_TYPES[part])
+        return json({ error: "invalid_content_type" }, 400);
+      const bytes = await boundedBytes(request.body);
+      valid(bytes, metadata.manifest, part);
+      // Immutable deterministic object path. A lost reply or concurrent upload may
+      // report "exists"; only a hash-verified private read makes that a safe retry.
+      try {
+        await store.put(inkPath(version, part), bytes, INK_TYPES[part]);
+      } catch {
+        const existing = await store.get(inkPath(version, part));
+        if (!existing) throw new Error("storage_unavailable");
+        valid(existing, metadata.manifest, part);
+      }
+      const status = await markInkUploaded(db, org, version, part);
+      return json(
+        { status },
+        ["pending", "ready"].includes(status) ? 200 : 409,
+      );
+    }
+    if (request.method === "GET") {
+      const library = q.get("libraryId"),
+        note = q.get("noteId"),
+        revision = q.get("revisionId");
+      [library, note, revision].forEach(inkId);
+      const metadata = await downloadMetadata(
+        db,
+        org,
+        library!,
+        note!,
+        revision!,
+        version,
+      );
+      if (!metadata) return json({ error: "not_found" }, 404);
+      const bytes = await store.get(inkPath(version, part));
+      if (!bytes) return json({ error: "temporarily_unavailable" }, 503);
+      valid(bytes, metadata, part);
+      // Revalidate after I/O: purge/expiry must not serve a fetched blob.
+      if (
+        !(await downloadMetadata(db, org, library!, note!, revision!, version))
+      )
+        return json({ error: "not_found" }, 404);
+      return new Response(Buffer.from(bytes), {
+        headers: {
+          ...headers,
+          "Content-Type": INK_TYPES[part],
+          "Content-Length": String(bytes.length),
+          "Content-Disposition": `attachment; filename="note.${part === "ink" ? "drawing" : "png"}"`,
+        },
+      });
+    }
+    return json({ error: "method_not_allowed" }, 405);
+  } catch (error) {
+    const code = error instanceof Error ? error.message : "";
+    return json(
+      {
+        error: [
+          "invalid_id",
+          "invalid_manifest",
+          "invalid_content",
+          "too_large",
+          "empty_body",
+        ].includes(code)
+          ? code
+          : "temporarily_unavailable",
+      },
+      [
+        "invalid_id",
+        "invalid_manifest",
+        "invalid_content",
+        "too_large",
+        "empty_body",
+      ].includes(code)
+        ? 400
+        : 503,
+    );
+  }
+}

--- a/apps/web/tests/private-ink.test.ts
+++ b/apps/web/tests/private-ink.test.ts
@@ -1,0 +1,850 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import test from "node:test";
+import { createInMemoryDb } from "@repo/db/testing";
+import {
+  applySync,
+  sql,
+  inkRows,
+  reserveInk,
+  downloadMetadata,
+  type SyncOperation,
+  type InkManifest,
+} from "@repo/db";
+import { handlePrivateInk } from "../lib/private-ink";
+import { cleanupPrivateInk } from "../lib/private-ink-cleanup";
+import {
+  inkPath,
+  privateInkStore,
+  type PrivateInkStore,
+} from "../lib/private-ink-store";
+class Store implements PrivateInkStore {
+  objects = new Map<string, Uint8Array>();
+  gets = 0;
+  failDelete = false;
+  latePut: (() => Promise<void>) | undefined;
+  async put(path: string, bytes: Uint8Array) {
+    if (this.latePut) await this.latePut();
+    if (this.objects.has(path)) throw new Error("already_exists");
+    this.objects.set(path, bytes);
+  }
+  async get(path: string) {
+    this.gets++;
+    return this.objects.get(path) ?? null;
+  }
+  async delete(path: string) {
+    if (this.failDelete) throw new Error("provider secret must not escape");
+    this.objects.delete(path);
+  }
+}
+const ink = new Uint8Array([1, 2, 3, 4]); // Opaque synthetic bytes, NOT a physical PencilKit roundtrip.
+const png = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGD4DwABBAEAX+XDSwAAAABJRU5ErkJggg==",
+  "base64",
+);
+function descriptor(bytes: Uint8Array, contentType: string) {
+  return {
+    size: bytes.length,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    contentType,
+  };
+}
+async function fixture() {
+  const instance = await createInMemoryDb();
+  const { db } = instance;
+  await db.execute(
+    sql`insert into organization(id,name,slug,created_at) values ('a','A','a',now()),('b','B','b',now())`,
+  );
+  const sourceId = randomUUID();
+  const op: SyncOperation = {
+    protocolVersion: 2,
+    libraryId: randomUUID(),
+    noteId: randomUUID(),
+    operationId: randomUUID(),
+    kind: "upsert",
+    expectedRevision: null,
+    expectedLifecycleGeneration: null,
+    snapshot: {
+      title: "Ink fixture",
+      kind: "note",
+      createdAt: "2026-09-06T00:00:00Z",
+      language: "en-US",
+      text: "",
+      passages: [],
+      speakers: [],
+      summaries: [],
+      inkAttachments: [],
+      selectedSummaryId: null,
+      sourceRevisionId: sourceId,
+      sourceVersions: [
+        {
+          id: sourceId,
+          title: "Ink fixture",
+          text: "",
+          passages: [],
+          speakers: [],
+        },
+      ],
+    },
+  };
+  const receipt = (await applySync(db, "a", op)) as {
+    headRevision: string;
+    lifecycleGeneration: string;
+  };
+  const manifest: InkManifest = {
+    libraryId: op.libraryId,
+    noteId: op.noteId,
+    attachmentId: randomUUID(),
+    versionId: randomUUID(),
+    generation: receipt.lifecycleGeneration,
+    expectedRevision: receipt.headRevision,
+    ink: descriptor(ink, "application/x-apple-pencilkit"),
+    preview: descriptor(png, "image/png"),
+  };
+  const store = new Store();
+  const request = (
+    method: string,
+    part = "ink",
+    bytes?: Uint8Array,
+    revision = receipt.headRevision,
+  ) =>
+    new Request(
+      `http://localhost/api/sync/ink?versionId=${manifest.versionId}&part=${part}&libraryId=${op.libraryId}&noteId=${op.noteId}&revisionId=${revision}`,
+      {
+        method,
+        headers: {
+          "content-type":
+            part === "ink" ? "application/x-apple-pencilkit" : "image/png",
+        },
+        ...(bytes ? { body: Buffer.from(bytes) } : {}),
+      },
+    );
+  const upload = async () => {
+    assert.equal(await reserveInk(db, "a", manifest), "pending");
+    for (const [part, bytes] of [
+      ["ink", ink],
+      ["preview", png],
+    ] as const)
+      assert.equal(
+        (await handlePrivateInk(request("PUT", part, bytes), db, "a", store))
+          .status,
+        200,
+      );
+  };
+  const commit = async () =>
+    (await applySync(db, "a", {
+      ...op,
+      operationId: randomUUID(),
+      expectedRevision: receipt.headRevision,
+      expectedLifecycleGeneration: receipt.lifecycleGeneration,
+      snapshot: {
+        ...op.snapshot!,
+        inkAttachments: [
+          { id: manifest.attachmentId, versionId: manifest.versionId },
+        ],
+      },
+    })) as {
+      revision: string;
+      headRevision: string;
+      lifecycleGeneration: string;
+    };
+  return { ...instance, op, receipt, manifest, store, request, upload, commit };
+}
+test("private immutable bundle: reserve/replay, hashes, complete revision access and cross-tenant denial", async () => {
+  const f = await fixture();
+  try {
+    const { db, manifest, store, request } = f;
+    assert.equal(await reserveInk(db, "b", manifest), "not_found");
+    assert.equal(await reserveInk(db, "a", manifest), "pending");
+    assert.equal(
+      (
+        await handlePrivateInk(
+          request("PUT", "ink", new Uint8Array([9])),
+          db,
+          "a",
+          store,
+        )
+      ).status,
+      400,
+    );
+    assert.equal(store.objects.size, 0);
+    await f.upload();
+    assert.equal(await reserveInk(db, "a", manifest), "ready");
+    assert.equal(
+      (await handlePrivateInk(request("GET"), db, "a", store)).status,
+      404,
+    );
+    assert.equal(store.gets, 0);
+    const committed = await f.commit();
+    const response = await handlePrivateInk(
+      request("GET", "ink", undefined, committed.revision),
+      db,
+      "a",
+      store,
+    );
+    assert.equal(response.status, 200);
+    assert.deepEqual(new Uint8Array(await response.arrayBuffer()), ink);
+    assert.match(response.headers.get("cache-control")!, /no-store/);
+    assert.equal(response.headers.get("vary"), "Authorization");
+    assert.equal(response.headers.get("location"), null);
+    const gets = store.gets;
+    assert.equal(
+      (
+        await handlePrivateInk(
+          request("GET", "ink", undefined, committed.revision),
+          db,
+          "b",
+          store,
+        )
+      ).status,
+      404,
+    );
+    assert.equal(store.gets, gets);
+    assert.equal(
+      (
+        await handlePrivateInk(
+          request("GET", "preview", undefined, randomUUID()),
+          db,
+          "a",
+          store,
+        )
+      ).status,
+      404,
+    );
+    assert.equal(
+      (await handlePrivateInk(request("PUT", "ink", ink), db, "a", store))
+        .status,
+      200,
+    ); // provider exists -> verified replay
+    assert.equal(
+      await reserveInk(db, "a", {
+        ...manifest,
+        ink: { ...manifest.ink, sha256: "0".repeat(64) },
+      }),
+      "version_reused",
+    );
+    assert.equal(
+      (
+        await handlePrivateInk(
+          new Request("http://localhost", {
+            method: "POST",
+            body: JSON.stringify({ ...manifest, audio: "forbidden" }),
+          }),
+          db,
+          "a",
+          store,
+        )
+      ).status,
+      400,
+    );
+  } finally {
+    await f.close();
+  }
+});
+test("invalid and foreign asset references roll back sync revision and initial adoption", async () => {
+  const f = await fixture();
+  try {
+    const { db, op, manifest } = f;
+    await assert.rejects(
+      f.commit(),
+      (e: unknown) =>
+        (e as { cause?: Error }).cause?.message === "invalid_ink_reference",
+    );
+    assert.equal(
+      inkRows(
+        await db.execute(
+          sql`select count(*) as n from sync_revisions where note_id=${op.noteId}::uuid`,
+        ),
+      )[0]!.n,
+      1,
+    );
+    await f.upload();
+    const other = {
+      ...op,
+      noteId: randomUUID(),
+      operationId: randomUUID(),
+      snapshot: {
+        ...op.snapshot!,
+        inkAttachments: [
+          { id: manifest.attachmentId, versionId: manifest.versionId },
+        ],
+      },
+    };
+    await assert.rejects(
+      applySync(db, "a", other),
+      (e: unknown) =>
+        (e as { cause?: Error }).cause?.message === "invalid_ink_reference",
+    );
+    assert.equal(
+      inkRows(
+        await db.execute(
+          sql`select id from sync_notes where id=${other.noteId}::uuid`,
+        ),
+      ).length,
+      0,
+    );
+    await f.commit();
+  } finally {
+    await f.close();
+  }
+});
+test("Trash retains historical/conflict assets; purge denies reads and retries deletion", async () => {
+  const f = await fixture();
+  try {
+    await f.upload();
+    const commit = await f.commit();
+    const { db, op, store, manifest } = f;
+    const trash = (await applySync(db, "a", {
+      ...op,
+      operationId: randomUUID(),
+      kind: "trash",
+      snapshot: undefined,
+      expectedRevision: commit.headRevision,
+      expectedLifecycleGeneration: commit.lifecycleGeneration,
+    })) as {
+      headRevision: string;
+      lifecycleGeneration: string;
+      deletionId: string;
+    };
+    assert.ok(
+      await downloadMetadata(
+        db,
+        "a",
+        op.libraryId,
+        op.noteId,
+        commit.revision,
+        manifest.versionId,
+      ),
+    );
+    assert.equal(
+      (await handlePrivateInk(f.request("PUT", "ink", ink), db, "a", store))
+        .status,
+      404,
+    );
+    await applySync(db, "a", {
+      ...op,
+      operationId: randomUUID(),
+      kind: "purge",
+      snapshot: undefined,
+      expectedRevision: trash.headRevision,
+      expectedLifecycleGeneration: trash.lifecycleGeneration,
+      deletionId: trash.deletionId,
+    });
+    assert.equal(
+      await downloadMetadata(
+        db,
+        "a",
+        op.libraryId,
+        op.noteId,
+        commit.revision,
+        manifest.versionId,
+      ),
+      null,
+    );
+    store.failDelete = true;
+    assert.equal((await cleanupPrivateInk(db, "a", store)).failed, 2);
+    assert.equal(store.objects.size, 2);
+    store.failDelete = false;
+    await db.execute(sql`update ink_cleanup set next_attempt_at=now()`);
+    assert.equal((await cleanupPrivateInk(db, "a", store)).deleted, 2);
+    assert.equal(store.objects.size, 0);
+    assert.equal(await reserveInk(db, "a", manifest), "lifecycle_conflict");
+  } finally {
+    await f.close();
+  }
+});
+test("late upload after purge remains unreachable and resets durable cleanup", async () => {
+  const f = await fixture();
+  try {
+    const { db, op, receipt, store, manifest } = f;
+    await reserveInk(db, "a", manifest);
+    store.latePut = async () => {
+      store.latePut = undefined;
+      const trash = (await applySync(db, "a", {
+        ...op,
+        operationId: randomUUID(),
+        kind: "trash",
+        snapshot: undefined,
+        expectedRevision: receipt.headRevision,
+        expectedLifecycleGeneration: receipt.lifecycleGeneration,
+      })) as {
+        headRevision: string;
+        lifecycleGeneration: string;
+        deletionId: string;
+      };
+      await applySync(db, "a", {
+        ...op,
+        operationId: randomUUID(),
+        kind: "purge",
+        snapshot: undefined,
+        expectedRevision: trash.headRevision,
+        expectedLifecycleGeneration: trash.lifecycleGeneration,
+        deletionId: trash.deletionId,
+      });
+      await cleanupPrivateInk(db, "a", store);
+    };
+    assert.equal(
+      (await handlePrivateInk(f.request("PUT", "ink", ink), db, "a", store))
+        .status,
+      409,
+    );
+    assert.equal(store.objects.size, 1);
+    await cleanupPrivateInk(db, "a", store);
+    assert.equal(store.objects.size, 0);
+  } finally {
+    await f.close();
+  }
+});
+test("retained versions cannot starve orphan cleanup; org cascade keeps cleanup receipts", async () => {
+  const f = await fixture();
+  try {
+    const { db, manifest, op, store } = f;
+    await f.upload();
+    const commit = await f.commit();
+    // 101 retained versions precede a new orphan. Shared fixture only contains synthetic data.
+    for (let i = 0; i < 101; i++) {
+      const id = randomUUID();
+      await db.execute(sql`insert into ink_versions(id,attachment_id,note_id,organization_id,library_id,generation,manifest,uploaded,state,created_at)
+    select ${id}::uuid,attachment_id,note_id,organization_id,library_id,generation,manifest,uploaded,state,now()-interval '3 days' from ink_versions where id=${manifest.versionId}::uuid`);
+      await db.execute(
+        sql`update sync_revisions set snapshot=jsonb_set(snapshot,'{inkAttachments}',(snapshot->'inkAttachments')||jsonb_build_array(jsonb_build_object('id',${manifest.attachmentId}::text,'versionId',${id}::text))) where id=${commit.revision}::uuid`,
+      );
+    }
+    const orphan = {
+      ...manifest,
+      versionId: randomUUID(),
+      expectedRevision: commit.headRevision,
+    };
+    await reserveInk(db, "a", orphan);
+    store.objects.set(inkPath(orphan.versionId, "ink"), ink);
+    await db.execute(
+      sql`update ink_versions set created_at=now()-interval '2 days' where id=${orphan.versionId}::uuid`,
+    );
+    await cleanupPrivateInk(db, "a", store);
+    assert.equal(store.objects.has(inkPath(orphan.versionId, "ink")), false);
+    assert.equal(
+      inkRows(await db.execute(sql`select count(*) as n from ink_versions`))[0]!
+        .n,
+      102,
+    );
+    await db.execute(sql`delete from organization where id='a'`);
+    assert.equal(
+      inkRows(
+        await db.execute(
+          sql`select id from ink_versions where note_id=${op.noteId}::uuid`,
+        ),
+      ).length,
+      0,
+    );
+    await cleanupPrivateInk(db, undefined, store);
+    await cleanupPrivateInk(db, undefined, store);
+    await cleanupPrivateInk(db, undefined, store);
+    assert.equal(store.objects.size, 0);
+  } finally {
+    await f.close();
+  }
+});
+test("flag-off old schema and no private credentials are safe", async () => {
+  const { db, close } = await createInMemoryDb({ throughMigration: 13 });
+  try {
+    assert.deepEqual(await cleanupPrivateInk(db), {
+      deleted: 0,
+      failed: 0,
+      pending: 0,
+    });
+  } finally {
+    await close();
+  }
+  delete process.env.DOODLENOTE_PRIVATE_INK_TOKEN;
+  assert.throws(privateInkStore, /unconfigured/);
+  const { GET } = await import("../app/api/sync/ink/route");
+  delete process.env.DOODLENOTE_PRIVATE_INK_ENABLED;
+  const response = await GET(new Request("http://localhost/api/sync/ink"));
+  assert.equal(response.status, 404);
+  assert.match(response.headers.get("cache-control")!, /no-store/);
+  process.env.DOODLENOTE_PRIVATE_INK_ENABLED = "true";
+  assert.equal(
+    (await GET(new Request("http://localhost/api/sync/ink"))).status,
+    401,
+  );
+  delete process.env.DOODLENOTE_PRIVATE_INK_ENABLED;
+});
+
+test("PNG preview validation rejects truncated, corrupt, zero-sized and oversized decoded images", async () => {
+  const { validateInkPreview } = await import("../lib/ink-preview");
+  const { deflateSync } = await import("node:zlib");
+  function chunk(name: string, data: Buffer) {
+    const type = Buffer.from(name);
+    let crc = 0xffffffff;
+    for (const byte of Buffer.concat([type, data])) {
+      crc ^= byte;
+      for (let i = 0; i < 8; i++)
+        crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+    const length = Buffer.alloc(4),
+      sum = Buffer.alloc(4);
+    length.writeUInt32BE(data.length);
+    sum.writeUInt32BE((crc ^ 0xffffffff) >>> 0);
+    return Buffer.concat([length, type, data, sum]);
+  }
+  function sized(width: number, height: number) {
+    const header = Buffer.alloc(13);
+    header.writeUInt32BE(width);
+    header.writeUInt32BE(height, 4);
+    header[8] = 8;
+    header[9] = 6;
+    return Buffer.concat([
+      png.subarray(0, 8),
+      chunk("IHDR", header),
+      chunk("IDAT", deflateSync(Buffer.from([0, 0, 0, 0, 255]))),
+      chunk("IEND", Buffer.alloc(0)),
+    ]);
+  }
+  validateInkPreview(png);
+  assert.throws(
+    () =>
+      validateInkPreview(
+        Buffer.concat([
+          png.subarray(0, 33),
+          chunk("acTL", Buffer.alloc(8)),
+          png.subarray(33),
+        ]),
+      ),
+    /invalid_content/,
+  );
+  for (const invalid of [
+    png.subarray(0, 20),
+    png.subarray(0, -1),
+    sized(0, 1),
+    sized(4096, 4096),
+    sized(1, 2),
+    Buffer.from("not png"),
+  ])
+    assert.throws(() => validateInkPreview(invalid), /invalid_content/);
+});
+test("actual SDK adapter requests private access, bypasses cache and never accepts public/conditional responses", async () => {
+  const { createPrivateInkStore } = await import("../lib/private-ink-store");
+  const calls: unknown[] = [];
+  let mode = "private";
+  const sdk = {
+    async put(_path: string, _bytes: unknown, options: unknown) {
+      calls.push(options);
+      return { url: `https://fixture.${mode}.blob.vercel-storage.com/x` };
+    },
+    async get(_path: string, options: unknown) {
+      calls.push(options);
+      if (mode === "error")
+        throw new Error("private store access denied synthetic");
+      return {
+        statusCode: mode === "conditional" ? 304 : 200,
+        stream:
+          mode === "conditional"
+            ? null
+            : new ReadableStream({
+                start(c) {
+                  c.enqueue(ink);
+                  c.close();
+                },
+              }),
+        blob: { url: `https://fixture.${mode}.blob.vercel-storage.com/x` },
+      };
+    },
+    async del() {},
+  } as unknown as Parameters<typeof createPrivateInkStore>[1];
+  const adapter = createPrivateInkStore("synthetic-private-token", sdk);
+  await adapter.put(
+    "private-ink/example/ink",
+    ink,
+    "application/x-apple-pencilkit",
+  );
+  assert.deepEqual(await adapter.get("private-ink/example/ink"), ink);
+  assert.ok(calls.every((c) => (c as { access: string }).access === "private"));
+  assert.equal((calls[1] as { useCache: boolean }).useCache, false);
+  mode = "public";
+  await assert.rejects(
+    adapter.get("private-ink/example/ink"),
+    /private_store_required/,
+  );
+  mode = "conditional";
+  await assert.rejects(
+    adapter.get("private-ink/example/ink"),
+    /private_store_required/,
+  );
+  mode = "error";
+  await assert.rejects(adapter.get("private-ink/example/ink"), /denied/);
+});
+test("personal billing purge cleans private bundles but retains shared workspace objects", async () => {
+  const f = await fixture();
+  try {
+    const { db, store, op } = f;
+    await f.upload();
+    await f.commit();
+    await db.execute(
+      sql`insert into "user"(id,name,email,created_at,updated_at) values('owner','Owner','fixture@example.test',now(),now())`,
+    );
+    await db.execute(
+      sql`update organization set slug='personal-fixture' where id='a'`,
+    );
+    await db.execute(
+      sql`insert into member(id,organization_id,user_id,role,created_at) values('p','a','owner','owner',now()),('s','b','owner','member',now())`,
+    );
+    const shared = {
+      ...op,
+      libraryId: randomUUID(),
+      noteId: randomUUID(),
+      operationId: randomUUID(),
+    };
+    const r = (await applySync(db, "b", shared)) as {
+      headRevision: string;
+      lifecycleGeneration: string;
+    };
+    const m = {
+      ...f.manifest,
+      libraryId: shared.libraryId,
+      noteId: shared.noteId,
+      versionId: randomUUID(),
+      expectedRevision: r.headRevision,
+      generation: r.lifecycleGeneration,
+    };
+    await reserveInk(db, "b", m);
+    store.objects.set(inkPath(m.versionId, "ink"), ink);
+    const { purgePersonalCloudData } = await import("../lib/cloud-data-purge");
+    store.failDelete = true;
+    await assert.rejects(
+      purgePersonalCloudData({
+        db,
+        userId: "owner",
+        deleteAttachmentPrefix: async () => {},
+        privateInkProvider: store,
+      }),
+      /cleanup pending/,
+    );
+    store.failDelete = false;
+    await db.execute(sql`update ink_cleanup set next_attempt_at=now()`);
+    await purgePersonalCloudData({
+      db,
+      userId: "owner",
+      deleteAttachmentPrefix: async () => {},
+      privateInkProvider: store,
+    });
+    assert.deepEqual([...store.objects.keys()], [inkPath(m.versionId, "ink")]);
+  } finally {
+    await f.close();
+  }
+});
+
+test("global cleanup skips 51 retained-only workspaces and reaches an orphan workspace", async () => {
+  const f = await fixture();
+  try {
+    const { db, manifest, store } = f;
+    await db.execute(
+      sql`insert into organization(id,name,slug,created_at) select 'retained-'||i,'Synthetic','retained-'||i,now() from generate_series(1,51) i`,
+    );
+    await db.execute(
+      sql`insert into sync_libraries(id,organization_id) select gen_random_uuid(),id from organization where id like 'retained-%'`,
+    );
+    await db.execute(
+      sql`insert into sync_notes(id,library_id,organization_id) select gen_random_uuid(),id,organization_id from sync_libraries where organization_id like 'retained-%'`,
+    );
+    await db.execute(
+      sql`insert into ink_versions(id,attachment_id,note_id,organization_id,library_id,generation,manifest,state,created_at) select gen_random_uuid(),gen_random_uuid(),id,organization_id,library_id,lifecycle_generation,'{}'::jsonb,'ready',now()-interval '3 days' from sync_notes where organization_id like 'retained-%'`,
+    );
+    await db.execute(
+      sql`insert into sync_revisions(id,note_id,organization_id,sequence,kind,snapshot) select gen_random_uuid(),note_id,organization_id,1,'upsert',jsonb_build_object('inkAttachments',jsonb_build_array(jsonb_build_object('id',attachment_id,'versionId',id))) from ink_versions where organization_id like 'retained-%'`,
+    );
+    // Alphabetically later than retained-only organizations.
+    await db.execute(sql`update organization set id='z-orphan' where id='b'`);
+    const op = {
+      ...f.op,
+      libraryId: randomUUID(),
+      noteId: randomUUID(),
+      operationId: randomUUID(),
+    };
+    const receipt = (await applySync(db, "z-orphan", op)) as {
+      headRevision: string;
+      lifecycleGeneration: string;
+    };
+    const orphan = {
+      ...manifest,
+      versionId: randomUUID(),
+      libraryId: op.libraryId,
+      noteId: op.noteId,
+      expectedRevision: receipt.headRevision,
+      generation: receipt.lifecycleGeneration,
+    };
+    await reserveInk(db, "z-orphan", orphan);
+    store.objects.set(inkPath(orphan.versionId, "ink"), ink);
+    await db.execute(
+      sql`update ink_versions set created_at=now()-interval '2 days' where id=${orphan.versionId}::uuid`,
+    );
+    await cleanupPrivateInk(db, undefined, store);
+    assert.equal(store.objects.size, 0);
+    assert.equal(
+      inkRows(
+        await db.execute(
+          sql`select count(*) as n from ink_versions where organization_id like 'retained-%'`,
+        ),
+      )[0]!.n,
+      51,
+    );
+  } finally {
+    await f.close();
+  }
+});
+test("cleanup prioritizes fresh deletion and stops within its work budget", async (t) => {
+  const f = await fixture();
+  try {
+    const { db, store } = f;
+    await db.execute(
+      sql`insert into ink_cleanup(path,organization_id,deleted_at,next_attempt_at) select 'old/'||i,'a',now()-interval '1 day',now()-interval '1 day' from generate_series(1,100) i`,
+    );
+    await db.execute(
+      sql`insert into ink_cleanup(path,organization_id) values('fresh','a')`,
+    );
+    store.objects.set("fresh", ink);
+    let clock = Date.now();
+    const visited: string[] = [];
+    const timed: PrivateInkStore = {
+      ...store,
+      put: async () => {},
+      get: async () => null,
+      delete: async (path) => {
+        visited.push(path);
+        await store.delete(path);
+        clock += 10001;
+      },
+    };
+    t.mock.method(Date, "now", () => clock);
+    const result = await cleanupPrivateInk(db, "a", timed, 20000);
+    assert.deepEqual(visited, ["fresh"]);
+    assert.equal(result.deleted, 1);
+    assert.equal(store.objects.size, 0);
+  } finally {
+    t.mock.restoreAll();
+    await f.close();
+  }
+});
+test("conflict revisions keep ink through restore; authoritative expiry removes it", async () => {
+  const f = await fixture();
+  try {
+    await f.upload();
+    const current = await f.commit();
+    const conflict = await f.commit();
+    const { db, op, manifest, store } = f;
+    assert.notEqual(current.revision, conflict.revision);
+    const lifecycle = async (
+      kind: "trash" | "restore",
+      r: {
+        headRevision: string;
+        lifecycleGeneration: string;
+        deletionId?: string;
+      },
+    ) =>
+      (await applySync(db, "a", {
+        ...op,
+        kind,
+        snapshot: undefined,
+        operationId: randomUUID(),
+        expectedRevision: r.headRevision,
+        expectedLifecycleGeneration: r.lifecycleGeneration,
+        ...(r.deletionId ? { deletionId: r.deletionId } : {}),
+      })) as {
+        headRevision: string;
+        lifecycleGeneration: string;
+        deletionId: string;
+      };
+    const trashed = await lifecycle("trash", current);
+    const restored = await lifecycle("restore", trashed);
+    assert.ok(
+      await downloadMetadata(
+        db,
+        "a",
+        op.libraryId,
+        op.noteId,
+        conflict.revision,
+        manifest.versionId,
+      ),
+    );
+    await lifecycle("trash", restored);
+    await db.execute(
+      sql`update sync_notes set expires_at=now()-interval '1 second' where id=${op.noteId}::uuid`,
+    );
+    assert.equal(
+      await downloadMetadata(
+        db,
+        "a",
+        op.libraryId,
+        op.noteId,
+        current.revision,
+        manifest.versionId,
+      ),
+      null,
+    );
+    await cleanupPrivateInk(db, "a", store);
+    assert.equal(store.objects.size, 0);
+  } finally {
+    await f.close();
+  }
+});
+
+test("interrupted half bundle never replaces last revision, oversized bodies and provider errors are safe", async () => {
+  const f = await fixture();
+  try {
+    const { db, manifest, store } = f;
+    await reserveInk(db, "a", manifest);
+    assert.equal(
+      (await handlePrivateInk(f.request("PUT", "ink", ink), db, "a", store))
+        .status,
+      200,
+    );
+    await assert.rejects(
+      f.commit(),
+      (e: unknown) =>
+        (e as { cause?: Error }).cause?.message === "invalid_ink_reference",
+    );
+    assert.equal(
+      inkRows(
+        await db.execute(
+          sql`select head_revision from sync_notes where id=${f.op.noteId}::uuid`,
+        ),
+      )[0]!.head_revision,
+      f.receipt.headRevision,
+    );
+    assert.equal(
+      (
+        await handlePrivateInk(
+          f.request("PUT", "preview", new Uint8Array(3 * 1024 * 1024 + 1)),
+          db,
+          "a",
+          store,
+        )
+      ).status,
+      400,
+    );
+    const denied: PrivateInkStore = {
+      put: async () => {
+        throw new Error("provider secret");
+      },
+      get: async () => {
+        throw new Error("provider secret");
+      },
+      delete: async () => {},
+    };
+    const response = await handlePrivateInk(
+      f.request("PUT", "preview", png),
+      db,
+      "a",
+      denied,
+    );
+    assert.equal(response.status, 503);
+    assert.doesNotMatch(await response.text(), /secret/);
+    assert.equal(
+      (await handlePrivateInk(f.request("PUT", "preview", png), db, "a", store))
+        .status,
+      200,
+    );
+    await f.commit();
+  } finally {
+    await f.close();
+  }
+});

--- a/packages/db/drizzle/0014_mean_wild_child.sql
+++ b/packages/db/drizzle/0014_mean_wild_child.sql
@@ -1,0 +1,128 @@
+CREATE TABLE "ink_cleanup" (
+	"path" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"next_attempt_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "ink_versions" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"attachment_id" uuid NOT NULL,
+	"note_id" uuid NOT NULL,
+	"organization_id" text NOT NULL,
+	"library_id" uuid NOT NULL,
+	"generation" uuid NOT NULL,
+	"manifest" jsonb NOT NULL,
+	"uploaded" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"state" text DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "ink_versions" ADD CONSTRAINT "ink_versions_note_id_sync_notes_id_fk" FOREIGN KEY ("note_id") REFERENCES "public"."sync_notes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE FUNCTION ink_path(v uuid, part text) RETURNS text LANGUAGE sql IMMUTABLE AS $$
+ SELECT 'private-ink/' || v::text || '/' || part;
+$$;
+--> statement-breakpoint
+CREATE FUNCTION ink_enqueue(v uuid, org text) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+ INSERT INTO ink_cleanup(path,organization_id) VALUES (ink_path(v,'ink'),org),(ink_path(v,'preview'),org)
+ ON CONFLICT(path) DO UPDATE SET next_attempt_at=now(),deleted_at=null;
+END $$;
+--> statement-breakpoint
+CREATE FUNCTION ink_remove_trigger() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+ PERFORM ink_enqueue(OLD.id,OLD.organization_id); RETURN OLD;
+END $$;
+--> statement-breakpoint
+CREATE TRIGGER ink_remove BEFORE DELETE ON ink_versions FOR EACH ROW EXECUTE FUNCTION ink_remove_trigger();
+--> statement-breakpoint
+CREATE FUNCTION ink_note_purge_trigger() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+ IF NEW.state='purged' AND OLD.state<>'purged' THEN DELETE FROM ink_versions WHERE note_id=NEW.id; END IF;
+ RETURN NEW;
+END $$;
+--> statement-breakpoint
+CREATE TRIGGER ink_note_purge AFTER UPDATE OF state ON sync_notes FOR EACH ROW EXECUTE FUNCTION ink_note_purge_trigger();
+--> statement-breakpoint
+CREATE FUNCTION ink_revision_trigger() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE ref jsonb;
+BEGIN
+ FOR ref IN SELECT value FROM jsonb_array_elements(coalesce(NEW.snapshot->'inkAttachments','[]'::jsonb)) LOOP
+  IF NOT EXISTS(SELECT 1 FROM ink_versions v JOIN sync_notes n ON n.id=v.note_id
+   WHERE v.id=(ref->>'versionId')::uuid AND v.attachment_id=(ref->>'id')::uuid
+    AND v.note_id=NEW.note_id AND v.organization_id=NEW.organization_id AND v.library_id=n.library_id
+    AND n.state='active' AND v.state='ready') THEN
+   RAISE EXCEPTION 'invalid_ink_reference' USING ERRCODE='23514';
+  END IF;
+ END LOOP;
+ RETURN NEW;
+END $$;
+--> statement-breakpoint
+CREATE TRIGGER ink_revision BEFORE INSERT OR UPDATE OF snapshot ON sync_revisions FOR EACH ROW EXECUTE FUNCTION ink_revision_trigger();
+--> statement-breakpoint
+CREATE FUNCTION ink_reserve(org text, m jsonb) RETURNS text LANGUAGE plpgsql AS $$
+DECLARE n sync_notes; v ink_versions;
+BEGIN
+ PERFORM sync_next_sequence(org);
+ SELECT * INTO n FROM sync_notes WHERE id=(m->>'noteId')::uuid AND organization_id=org AND library_id=(m->>'libraryId')::uuid FOR UPDATE;
+ IF NOT FOUND THEN RETURN 'not_found'; END IF;
+ IF n.state<>'active' OR n.lifecycle_generation<>(m->>'generation')::uuid THEN RETURN 'lifecycle_conflict'; END IF;
+ SELECT * INTO v FROM ink_versions WHERE id=(m->>'versionId')::uuid;
+ IF FOUND THEN
+  IF v.organization_id=org AND v.note_id=n.id AND v.manifest=m THEN RETURN v.state; END IF;
+  RETURN 'version_reused';
+ END IF;
+ IF EXISTS(SELECT 1 FROM ink_cleanup WHERE path=ink_path((m->>'versionId')::uuid,'ink')) THEN RETURN 'retired'; END IF;
+ IF n.head_revision IS DISTINCT FROM (m->>'expectedRevision')::uuid THEN RETURN 'revision_conflict'; END IF;
+ INSERT INTO ink_versions(id,attachment_id,note_id,organization_id,library_id,generation,manifest)
+ VALUES ((m->>'versionId')::uuid,(m->>'attachmentId')::uuid,n.id,org,n.library_id,n.lifecycle_generation,m) ON CONFLICT(id) DO NOTHING;
+ SELECT * INTO v FROM ink_versions WHERE id=(m->>'versionId')::uuid;
+ IF v.organization_id<>org OR v.note_id<>n.id OR v.manifest<>m THEN RETURN 'version_reused'; END IF;
+ -- A conflicting owner's deletion may have committed while INSERT waited.
+ IF EXISTS(SELECT 1 FROM ink_cleanup WHERE path=ink_path(v.id,'ink')) THEN
+  DELETE FROM ink_versions WHERE id=v.id; RETURN 'retired';
+ END IF;
+ RETURN 'pending';
+END $$;
+--> statement-breakpoint
+CREATE FUNCTION ink_uploaded(org text, version uuid, part text) RETURNS text LANGUAGE plpgsql AS $$
+DECLARE v ink_versions; n sync_notes;
+BEGIN
+ PERFORM sync_next_sequence(org);
+ SELECT * INTO v FROM ink_versions WHERE id=version AND organization_id=org;
+ IF NOT FOUND THEN
+  UPDATE ink_cleanup SET next_attempt_at=now(),deleted_at=null WHERE path=ink_path(version,part) AND organization_id=org;
+  RETURN 'retired';
+ END IF;
+ SELECT * INTO n FROM sync_notes WHERE id=v.note_id FOR UPDATE;
+ IF n.state<>'active' OR n.lifecycle_generation<>v.generation OR v.created_at<now()-interval '24 hours' AND v.state='pending' THEN
+  DELETE FROM ink_versions WHERE id=version AND state='pending'; RETURN 'lifecycle_conflict';
+ END IF;
+ IF part NOT IN ('ink','preview') THEN RETURN 'invalid_part'; END IF;
+ UPDATE ink_versions SET uploaded=uploaded||jsonb_build_object(part,true) WHERE id=version;
+ UPDATE ink_versions SET state='ready' WHERE id=version AND uploaded @> '{"ink":true,"preview":true}'::jsonb;
+ SELECT state INTO v.state FROM ink_versions WHERE id=version; RETURN v.state;
+END $$;
+--> statement-breakpoint
+CREATE FUNCTION ink_collect(org text DEFAULT NULL) RETURNS integer LANGUAGE plpgsql AS $$
+DECLARE n sync_notes; v ink_versions; count integer:=0;
+BEGIN
+ IF org IS NULL THEN RETURN 0; END IF;
+ IF NOT EXISTS(SELECT 1 FROM organization WHERE id=org) THEN RETURN 0; END IF;
+ PERFORM sync_next_sequence(org);
+ -- Same workspace mutex/order as sync_apply. Bounded per call, revisited hourly.
+ FOR n IN SELECT * FROM sync_notes WHERE state='trashed' AND expires_at<=now() AND (org IS NULL OR organization_id=org) ORDER BY organization_id,id LIMIT 50 LOOP
+  PERFORM sync_expire(n.organization_id,n.library_id);
+ END LOOP;
+ FOR v IN SELECT candidate.* FROM ink_versions candidate WHERE (org IS NULL OR candidate.organization_id=org) AND created_at<now()-interval '24 hours'
+  AND NOT EXISTS(SELECT 1 FROM sync_revisions r WHERE r.note_id=candidate.note_id AND r.snapshot->'inkAttachments' @> jsonb_build_array(jsonb_build_object('id',candidate.attachment_id,'versionId',candidate.id)))
+  ORDER BY candidate.organization_id,candidate.id LIMIT 100 LOOP
+  PERFORM sync_next_sequence(v.organization_id);
+  -- Recheck after taking the mutex: a revision may have committed while waiting.
+  IF NOT EXISTS(SELECT 1 FROM sync_revisions r WHERE r.note_id=v.note_id AND r.snapshot->'inkAttachments' @> jsonb_build_array(jsonb_build_object('id',v.attachment_id,'versionId',v.id))) THEN
+   DELETE FROM ink_versions WHERE id=v.id; count:=count+1;
+  END IF;
+ END LOOP;
+ RETURN count;
+END $$;

--- a/packages/db/drizzle/meta/0014_snapshot.json
+++ b/packages/db/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,2516 @@
+{
+  "id": "ac4ce016-9341-4d32-b13d-35d1145cf1bb",
+  "prevId": "04ec360c-d905-4a91-b5ba-6a83b8314667",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_tokens": {
+      "name": "agent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Agent'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tokens_user_id_idx": {
+          "name": "agent_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tokens_user_id_user_id_fk": {
+          "name": "agent_tokens_user_id_user_id_fk",
+          "tableFrom": "agent_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_tokens_organization_id_organization_id_fk": {
+          "name": "agent_tokens_organization_id_organization_id_fk",
+          "tableFrom": "agent_tokens",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tokens_token_hash_unique": {
+          "name": "agent_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_data_deletions": {
+      "name": "billing_data_deletions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_data_deletions_due_idx": {
+          "name": "billing_data_deletions_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_data_deletions_user_id_user_id_fk": {
+          "name": "billing_data_deletions_user_id_user_id_fk",
+          "tableFrom": "billing_data_deletions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_notifications": {
+      "name": "billing_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_notifications_dedupe_key_uidx": {
+          "name": "billing_notifications_dedupe_key_uidx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_notifications_pending_idx": {
+          "name": "billing_notifications_pending_idx",
+          "columns": [
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_notifications_user_id_user_id_fk": {
+          "name": "billing_notifications_user_id_user_id_fk",
+          "tableFrom": "billing_notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.folders": {
+      "name": "folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "folders_organization_id_idx": {
+          "name": "folders_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "folders_organization_id_organization_id_fk": {
+          "name": "folders_organization_id_organization_id_fk",
+          "tableFrom": "folders",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ink_cleanup": {
+      "name": "ink_cleanup",
+      "schema": "",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ink_versions": {
+      "name": "ink_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded": {
+          "name": "uploaded",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ink_versions_note_id_sync_notes_id_fk": {
+          "name": "ink_versions_note_id_sync_notes_id_fk",
+          "tableFrom": "ink_versions",
+          "tableTo": "sync_notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_stars": {
+      "name": "meeting_stars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meeting_stars_meeting_user_uidx": {
+          "name": "meeting_stars_meeting_user_uidx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meeting_stars_user_id_idx": {
+          "name": "meeting_stars_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meeting_stars_meeting_id_meetings_id_fk": {
+          "name": "meeting_stars_meeting_id_meetings_id_fk",
+          "tableFrom": "meeting_stars",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meeting_stars_user_id_user_id_fk": {
+          "name": "meeting_stars_user_id_user_id_fk",
+          "tableFrom": "meeting_stars",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_tag_links": {
+      "name": "meeting_tag_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meeting_tag_links_meeting_tag_uidx": {
+          "name": "meeting_tag_links_meeting_tag_uidx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meeting_tag_links_meeting_id_idx": {
+          "name": "meeting_tag_links_meeting_id_idx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meeting_tag_links_meeting_id_meetings_id_fk": {
+          "name": "meeting_tag_links_meeting_id_meetings_id_fk",
+          "tableFrom": "meeting_tag_links",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meeting_tag_links_tag_id_meeting_tags_id_fk": {
+          "name": "meeting_tag_links_tag_id_meeting_tags_id_fk",
+          "tableFrom": "meeting_tag_links",
+          "tableTo": "meeting_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_tags": {
+      "name": "meeting_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meeting_tags_organization_name_uidx": {
+          "name": "meeting_tags_organization_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meeting_tags_organization_id_idx": {
+          "name": "meeting_tags_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meeting_tags_organization_id_organization_id_fk": {
+          "name": "meeting_tags_organization_id_organization_id_fk",
+          "tableFrom": "meeting_tags",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetings": {
+      "name": "meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled meeting'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'meeting'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_expires_at": {
+          "name": "share_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_include_transcript": {
+          "name": "share_include_transcript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetings_organization_id_idx": {
+          "name": "meetings_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetings_organization_id_organization_id_fk": {
+          "name": "meetings_organization_id_organization_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetings_folder_id_folders_id_fk": {
+          "name": "meetings_folder_id_folders_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meetings_share_token_unique": {
+          "name": "meetings_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notes": {
+      "name": "notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_content": {
+          "name": "raw_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enhanced_content": {
+          "name": "enhanced_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notes_meeting_id_meetings_id_fk": {
+          "name": "notes_meeting_id_meetings_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notes_meeting_id_unique": {
+          "name": "notes_meeting_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meeting_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grandfathered": {
+          "name": "grandfathered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_user_id_user_id_fk": {
+          "name": "subscriptions_user_id_user_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_customer_id_unique": {
+          "name": "subscriptions_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_clocks": {
+      "name": "sync_clocks",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_clocks_organization_id_organization_id_fk": {
+          "name": "sync_clocks_organization_id_organization_id_fk",
+          "tableFrom": "sync_clocks",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_devices": {
+      "name": "sync_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Desktop'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_devices_user_id_idx": {
+          "name": "sync_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_devices_user_id_user_id_fk": {
+          "name": "sync_devices_user_id_user_id_fk",
+          "tableFrom": "sync_devices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_devices_organization_id_organization_id_fk": {
+          "name": "sync_devices_organization_id_organization_id_fk",
+          "tableFrom": "sync_devices",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sync_devices_token_hash_unique": {
+          "name": "sync_devices_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_libraries": {
+      "name": "sync_libraries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_libraries_organization_id_organization_id_fk": {
+          "name": "sync_libraries_organization_id_organization_id_fk",
+          "tableFrom": "sync_libraries",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_notes": {
+      "name": "sync_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_revision": {
+          "name": "head_revision",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_generation": {
+          "name": "lifecycle_generation",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "deletion_id": {
+          "name": "deletion_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_notes_library_id_sync_libraries_id_fk": {
+          "name": "sync_notes_library_id_sync_libraries_id_fk",
+          "tableFrom": "sync_notes",
+          "tableTo": "sync_libraries",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_notes_organization_id_organization_id_fk": {
+          "name": "sync_notes_organization_id_organization_id_fk",
+          "tableFrom": "sync_notes",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_operations": {
+      "name": "sync_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt": {
+          "name": "receipt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_operations_organization_id_organization_id_fk": {
+          "name": "sync_operations_organization_id_organization_id_fk",
+          "tableFrom": "sync_operations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_operations_note_id_sync_notes_id_fk": {
+          "name": "sync_operations_note_id_sync_notes_id_fk",
+          "tableFrom": "sync_operations",
+          "tableTo": "sync_notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_revisions": {
+      "name": "sync_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_revisions_org_sequence": {
+          "name": "sync_revisions_org_sequence",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_revisions_note_id_sync_notes_id_fk": {
+          "name": "sync_revisions_note_id_sync_notes_id_fk",
+          "tableFrom": "sync_revisions",
+          "tableTo": "sync_notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sync_revisions_organization_id_organization_id_fk": {
+          "name": "sync_revisions_organization_id_organization_id_fk",
+          "tableFrom": "sync_revisions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcript_segments": {
+      "name": "transcript_segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker": {
+          "name": "speaker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "absolute_start_ms": {
+          "name": "absolute_start_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcript_segments_meeting_id_idx": {
+          "name": "transcript_segments_meeting_id_idx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transcript_segments_meeting_id_meetings_id_fk": {
+          "name": "transcript_segments_meeting_id_meetings_id_fk",
+          "tableFrom": "transcript_segments",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verified_caller_ids": {
+      "name": "verified_caller_ids",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "outgoing_caller_id_sid": {
+          "name": "outgoing_caller_id_sid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "verified_caller_ids_user_id_user_id_fk": {
+          "name": "verified_caller_ids_user_id_user_id_fk",
+          "tableFrom": "verified_caller_ids",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_issuer_accountId_uidx": {
+          "name": "account_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1788733073040,
       "tag": "0013_same_abomination",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1788741254610,
+      "tag": "0014_mean_wild_child",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/scripts/verify-sync-postgres.py
+++ b/packages/db/scripts/verify-sync-postgres.py
@@ -46,9 +46,10 @@ def main():
             journal=json.loads((ROOT/'drizzle/meta/_journal.json').read_text())['entries']
             for entry in journal:
                 migration=(ROOT/'drizzle'/f"{entry['tag']}.sql").read_text()
-                if entry['idx']==13:
+                if entry['idx'] in (13,14):
                     sql('BEGIN;'+migration+'ROLLBACK;')
-                    assert sql("SELECT to_regclass('sync_notes') IS NULL;")=='t'
+                    table="sync_notes" if entry["idx"]==13 else "ink_versions"
+                    assert sql(f"SELECT to_regclass('{table}') IS NULL;")=='t'
                     sql('BEGIN;'+migration+'COMMIT;')
                 else:
                     sql(migration)
@@ -67,7 +68,22 @@ def main():
                 outcomes=list(pool.map(lambda op:apply('a',op),edits))
             assert sorted(r['status'] for r in outcomes)==['conflict','ok'], outcomes
             assert sql(f"SELECT count(*) FROM sync_revisions WHERE note_id='{note}';")=='3'
-            print('PASS: migration rollback/reapply, cross-workspace library race, concurrent same-base edits preserve conflict')
+            version=uid()
+            manifests=[]
+            for org in ('a','b'):
+                op=operation(uid(),uid()); receipt=apply(org,op)
+                manifests.append((org,dict(libraryId=op['libraryId'],noteId=op['noteId'],attachmentId=uid(),versionId=version,
+                    generation=receipt['lifecycleGeneration'],expectedRevision=receipt['headRevision'],
+                    ink=dict(size=1,sha256='0'*64,contentType='application/x-apple-pencilkit'),
+                    preview=dict(size=1,sha256='0'*64,contentType='image/png'))))
+            def reserve(args):
+                org,manifest=args
+                return sql(f"SELECT ink_reserve('{org}','{json.dumps(manifest)}'::jsonb);")
+            with concurrent.futures.ThreadPoolExecutor(2) as pool:
+                outcomes=list(pool.map(reserve,manifests))
+            assert sorted(outcomes)==['pending','version_reused'], outcomes
+            assert sql(f"SELECT count(*) FROM ink_versions WHERE id='{version}';")=='1'
+            print('PASS: migration rollback/reapply, cross-workspace library/version races, concurrent same-base edits preserve conflict')
         finally:
             subprocess.run([str(BIN/'pg_ctl'), '-D', data, '-m', 'fast', '-w', 'stop'], check=True, capture_output=True)
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -19,3 +19,5 @@ export {
 } from "drizzle-orm";
 export * from './sync-contract';
 export * from './sync-service';
+
+export * from './ink-assets';

--- a/packages/db/src/ink-assets.ts
+++ b/packages/db/src/ink-assets.ts
@@ -1,0 +1,122 @@
+import { sql } from "drizzle-orm";
+import type { Db } from "./client";
+export const INK_MAX_BYTES = 3 * 1024 * 1024;
+export const INK_TYPES = {
+  ink: "application/x-apple-pencilkit",
+  preview: "image/png",
+} as const;
+export type InkPart = keyof typeof INK_TYPES;
+export interface InkManifest {
+  libraryId: string;
+  noteId: string;
+  attachmentId: string;
+  versionId: string;
+  generation: string;
+  expectedRevision: string;
+  ink: { size: number; sha256: string; contentType: string };
+  preview: { size: number; sha256: string; contentType: string };
+}
+export function inkId(value: unknown): asserts value is string {
+  if (
+    typeof value !== "string" ||
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(
+      value,
+    )
+  )
+    throw new Error("invalid_id");
+}
+export function validateInkManifest(value: unknown): InkManifest {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new Error("invalid_manifest");
+  const m = value as Record<string, unknown>;
+  const ids = [
+    "libraryId",
+    "noteId",
+    "attachmentId",
+    "versionId",
+    "generation",
+    "expectedRevision",
+  ];
+  if (Object.keys(m).some((k) => ![...ids, "ink", "preview"].includes(k)))
+    throw new Error("invalid_manifest");
+  ids.forEach((k) => inkId(m[k]));
+  for (const part of ["ink", "preview"] as const) {
+    const d = m[part] as InkManifest["ink"];
+    if (
+      !d ||
+      typeof d !== "object" ||
+      Object.keys(d).some(
+        (k) => !["size", "sha256", "contentType"].includes(k),
+      ) ||
+      !Number.isInteger(d.size) ||
+      d.size < 1 ||
+      d.size > INK_MAX_BYTES ||
+      d.contentType !== INK_TYPES[part] ||
+      typeof d.sha256 !== "string" ||
+      !/^[0-9a-f]{64}$/.test(d.sha256)
+    )
+      throw new Error("invalid_manifest");
+  }
+  return m as unknown as InkManifest;
+}
+export function inkRows(r: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(r)
+    ? r
+    : (r as { rows: Array<Record<string, unknown>> }).rows;
+}
+export async function reserveInk(
+  db: Db,
+  org: string,
+  value: unknown,
+): Promise<string> {
+  const m = validateInkManifest(value);
+  return String(
+    inkRows(
+      await db.execute(
+        sql`select ink_reserve(${org},${JSON.stringify(m)}::jsonb) as status`,
+      ),
+    )[0]!.status,
+  );
+}
+export async function uploadMetadata(db: Db, org: string, version: string) {
+  inkId(version);
+  const row = inkRows(
+    await db.execute(sql`select v.manifest,v.state from ink_versions v join sync_notes n on n.id=v.note_id
+ where v.id=${version}::uuid and v.organization_id=${org} and n.organization_id=${org} and n.state='active' and n.lifecycle_generation=v.generation
+ and (v.state='ready' or v.created_at>now()-interval '24 hours')`),
+  )[0];
+  return row
+    ? { manifest: row.manifest as InkManifest, state: String(row.state) }
+    : null;
+}
+export async function markInkUploaded(
+  db: Db,
+  org: string,
+  version: string,
+  part: InkPart,
+) {
+  return String(
+    inkRows(
+      await db.execute(
+        sql`select ink_uploaded(${org},${version}::uuid,${part}) as status`,
+      ),
+    )[0]!.status,
+  );
+}
+export async function downloadMetadata(
+  db: Db,
+  org: string,
+  library: string,
+  note: string,
+  revision: string,
+  version: string,
+) {
+  [library, note, revision, version].forEach(inkId);
+  const row = inkRows(
+    await db.execute(sql`select v.manifest from ink_versions v join sync_notes n on n.id=v.note_id join sync_revisions r on r.note_id=n.id
+ where v.id=${version}::uuid and v.organization_id=${org} and n.organization_id=${org} and n.library_id=${library}::uuid and n.id=${note}::uuid
+ and r.id=${revision}::uuid and r.organization_id=${org} and v.state='ready' and n.state<>'purged' and (n.state<>'trashed' or n.expires_at>now())
+ and r.snapshot->'inkAttachments' @> jsonb_build_array(jsonb_build_object('id',v.attachment_id,'versionId',v.id))`),
+  )[0];
+  return row ? (row.manifest as InkManifest) : null;
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -342,3 +342,25 @@ export const syncOperations = pgTable('sync_operations', {
   payloadHash: text('payload_hash').notNull(),
   receipt: jsonb('receipt').notNull(),
 });
+
+/** Immutable private ink bundles; paths are server-only and never sync payloads. */
+export const inkVersions = pgTable('ink_versions', {
+  id: uuid('id').primaryKey(),
+  attachmentId: uuid('attachment_id').notNull(),
+  noteId: uuid('note_id').notNull().references(() => syncNotes.id,{onDelete:'cascade'}),
+  organizationId: text('organization_id').notNull(),
+  libraryId: uuid('library_id').notNull(),
+  generation: uuid('generation').notNull(),
+  manifest: jsonb('manifest').notNull(),
+  uploaded: jsonb('uploaded').notNull().default({}),
+  state: text('state').notNull().default('pending'),
+  createdAt: timestamp('created_at',{withTimezone:true}).notNull().defaultNow(),
+});
+/** No cascading FK: deletion work must survive account/note removal. */
+export const inkCleanup = pgTable('ink_cleanup', {
+  path: text('path').primaryKey(),
+  organizationId: text('organization_id').notNull(),
+  nextAttemptAt: timestamp('next_attempt_at',{withTimezone:true}).notNull().defaultNow(),
+  attempts: integer('attempts').notNull().default(0),
+  deletedAt: timestamp('deleted_at',{withTimezone:true}),
+});


### PR DESCRIPTION
## Linear Issue
- [ONY-259](https://linear.app/onyxdevlabs/issue/ONY-259/add-private-cloud-storage-for-editable-ink-and-note-previews)

## Outcome
Adds a separate authenticated private path for immutable PencilKit/PNG bundles. A note revision can reference only a complete, owned bundle; interrupted uploads preserve the last valid revision. This draft is ready for technical review. Live private-store verification and physical Pencil QA remain incomplete.

## What Changed
- Dedicated Vercel private adapter and disabled `/api/sync/ink` API, strict size/type/SHA-256 and PNG validation, no returned storage URLs, authenticated revision-bound downloads with no-store responses.
- Additive migration0014 with atomic reservation/revision checks, durable orphan/purge cleanup, workspace ownership and cross-workspace reservation race protection.
- Trash/conflict retention and expiry, private cleanup during personal billing purge, queue preservation after organization cascade, bounded cleanup through the existing hourly worker. Existing public desktop attachment behavior remains compatible.
- Native wire/limits, local evidence and staged storage/rollback runbook in `apps/web/docs/private-ink-storage.md`.

## Acceptance Criteria Evidence
- [x] Versioned owned ink/preview bundles: migrated SQL and API fixtures prove complete-bundle gating and immutable revision references.
- [x] Cross-account/guessed revision denial, unauthenticated HTTP denial, private SDK access/cache semantics, no public or conditional provider response accepted.
- [x] Hash/type/size/PNG checks, interrupted upload, exact replay, duplicate provider response, orphan cleanup and last revision preservation.
- [x] Historical/conflict and Trash/restore retention, server expiry, permanent purge, late upload after deletion, personal/shared isolation and org cascade cleanup.
- [x] Controlled synthetic deletion evidence, migration rollback/reapply and real local PostgreSQL concurrent library/version reservation fixtures. No private customer data or cloud uploads used.
- [ ] Verify configured private provider in an approved isolated cloud workspace, including direct unauthorized URL denial and deletion evidence.
- [ ] Physical iPad editable Pencil roundtrip and iPhone/desktop preview QA. Native adapter/rendering is delivered by dependent issues; not claimed by server tests.

## Verification
- `pnpm --filter web exec tsx --test tests/private-ink.test.ts`: 13 passed, 0 failed/skipped.
- `pnpm --filter @repo/db test`: 18 passed, 0 failed/skipped.
- `python3 packages/db/scripts/verify-sync-postgres.py`: disposable local PostgreSQL migration13/14 rollback/reapply and concurrency checks passed.
- `pnpm --filter web typecheck`, `pnpm --filter web lint`, `pnpm --filter web build`, `pnpm --filter @repo/db typecheck`: passed.
- `pnpm --filter web test`: 112 passed, 0 failed/skipped. [CI34071013904](https://github.com/Onyx-Dev-Labs/doodle-note/actions/runs/34071013904) passed, including Windows packaging; [CodeQL34071013892](https://github.com/Onyx-Dev-Labs/doodle-note/actions/runs/34071013892) and Vercel preview passed at `0ae9111e2905802215ebf58cf7321093ac13b76e`.
- `git diff --check`: passed. No native code, simulator, device or live storage mutation.

## Local QA / Check this:
1. Run `pnpm --filter web exec tsx --test tests/private-ink.test.ts` from this branch. Inspect the controlled store fixtures: a partial bundle stays unreferenced, replay succeeds, and a cross-account or unrelated revision yields no bytes.
2. Review the wire runbook before implementing native upload. Normalize previews to noninterlaced RGB/RGBA 8-bit PNG within the documented pixel cap; oversized drawings stay local with an explicit sync error.
3. In a separately approved isolated private store, test upload/download, revoked access, Trash/restore and permanent deletion. Verify provider object removal and pending cleanup state, not just API404.
4. When the native adapter and iPad are available, draw, sync, download and reopen the editable drawing; compare pre-edit hashes, edit a stroke, and verify iPhone/desktop previews and conflict choice.

## Risks and Release Notes
**Merging main automatically deploys web code to Vercel Production**, including billing-worker cleanup compatibility. Merge is not authorized by this draft. The new API remains404 without `DOODLENOTE_PRIVATE_INK_ENABLED=true`; migration0014, a dedicated private store credential and separate rollout approval are still required. No production migration, store creation/permission change, flag activation or paid resource was performed.

A public Blob store cannot substitute for a private store. Actual dedicated private-store availability/cost/configuration remains unverified. Synthetic provider tests do not prove live privacy. Opaque PencilKit bytes are bounded and hash-validated server-side; semantic native decoding requires physical/native QA.

Before assets exist, revert the web artifact and roll back uncommitted migration SQL. After assets exist, disable the ink API but retain schema, credentials and cleanup-aware worker. Do not drop metadata/tombstones or roll back to code that omits private purge handling. Durable deletion jobs retry provider failures; metadata denial alone is not physical erasure. The existing cron schedule is reused without change.

## Follow-ups
ONY-261/262 consume this contract for native editable roundtrip, client preview and conflict workflows. Keep ONY-259 In Review until its merge and required QA boundary is met.
