### PR TITLE
[ONY-247] Complete iPad Pencil, keyboard, and adaptive note editing

### DIFF
--- a/apps/mobile-native/Sources/Editing/InkEditor.swift
+++ b/apps/mobile-native/Sources/Editing/InkEditor.swift
@@ -1,0 +1,222 @@
+import SwiftUI
+import PencilKit
+
+/// The view owns this session across pane and size changes. Source bytes never become an empty fallback.
+@MainActor @Observable final class InkEditingSession: NSObject, PKCanvasViewDelegate {
+    let canvas = DrawingCanvasView()
+    private(set) var problem: String?
+    private(set) var undoSteps: [Data] = []
+    private(set) var redoSteps: [Data] = []
+    private(set) var bytes = Data()
+    private var documentID: UUID?
+    private var beforeTool: Data?
+    private var applying = false
+    var editable = true
+    var changed: (Data) -> Void = { _ in }
+    var zoom: CGFloat = 1
+
+    override init() {
+        super.init()
+        canvas.delegate = self
+        canvas.backgroundColor = .systemBackground
+        canvas.drawingPolicy = .anyInput
+        canvas.minimumZoomScale = 0.2
+        canvas.maximumZoomScale = 4
+        canvas.alwaysBounceVertical = true
+        canvas.alwaysBounceHorizontal = true
+        canvas.contentSize = CGSize(width: 1200, height: 1800)
+        canvas.tool = PKInkingTool(.pen, color: .label, width: 3)
+        canvas.accessibilityLabel = "Editable drawing canvas"
+        canvas.accessibilityIdentifier = "inkCanvas"
+        canvas.undoAction = { [weak self] in self?.undo() }
+        canvas.redoAction = { [weak self] in self?.redo() }
+    }
+
+    func load(_ data: Data, id: UUID, editable: Bool) {
+        self.editable = editable
+        canvas.drawingGestureRecognizer.isEnabled = editable && problem == nil
+        guard id != documentID || data != bytes else { return }
+        applying = true
+        canvas.drawingGestureRecognizer.isEnabled = false
+        defer { applying = false }
+        documentID = id
+        undoSteps = []; redoSteps = []; beforeTool = nil
+        do {
+            let drawing = data.isEmpty ? PKDrawing() : try PKDrawing(data: data)
+            problem = nil
+            canvas.drawingGestureRecognizer.isEnabled = editable
+            apply(drawing, data: data)
+        } catch {
+            problem = "The original drawing is preserved. It cannot be edited until it can be opened."
+            bytes = data
+            canvas.drawingGestureRecognizer.isEnabled = false
+        }
+    }
+
+    private func apply(_ drawing: PKDrawing, data: Data) {
+        applying = true
+        bytes = data
+        canvas.drawing = drawing
+        canvas.accessibilityValue = "\(drawing.strokes.count) strokes"
+        let bounds = drawing.bounds
+        canvas.contentSize = CGSize(width: max(1200, bounds.maxX + 80), height: max(1800, bounds.maxY + 80))
+        applying = false
+    }
+    func replace(with drawing: PKDrawing) {
+        guard editable, problem == nil else { return }
+        let data = drawing.dataRepresentation()
+        guard data != bytes else { return }
+        remember(bytes)
+        apply(drawing, data: data)
+        changed(data)
+    }
+    private func remember(_ previous: Data) {
+        undoSteps.append(previous)
+        redoSteps = []
+        // Bound retained history, while retaining one full previous drawing for large single changes.
+        while undoSteps.count > 1 && (undoSteps.count > 20 || undoSteps.reduce(0, { $0 + $1.count }) > 32 * 1024 * 1024) {
+            undoSteps.removeFirst()
+        }
+    }
+    func undo() {
+        finishGesture()
+        guard editable, problem == nil, let previous = undoSteps.popLast(),
+              let drawing = previous.isEmpty ? PKDrawing() : try? PKDrawing(data: previous) else { return }
+        redoSteps.append(bytes)
+        apply(drawing, data: previous)
+        changed(previous)
+    }
+    func redo() {
+        finishGesture()
+        guard editable, problem == nil, let next = redoSteps.popLast(),
+              let drawing = next.isEmpty ? PKDrawing() : try? PKDrawing(data: next) else { return }
+        undoSteps.append(bytes)
+        apply(drawing, data: next)
+        changed(next)
+    }
+    func canvasViewDidBeginUsingTool(_ canvasView: PKCanvasView) { beforeTool = bytes }
+    func canvasViewDidEndUsingTool(_ canvasView: PKCanvasView) { finishGesture() }
+    func finishGesture() {
+        if let previous = beforeTool, previous != bytes { remember(previous) }
+        beforeTool = nil
+    }
+    func canvasViewDrawingDidChange(_ canvasView: PKCanvasView) {
+        guard !applying, editable, problem == nil else { return }
+        let data = canvasView.drawing.dataRepresentation()
+        guard data != bytes else { return }
+        if beforeTool == nil { remember(bytes) }
+        bytes = data
+        canvas.accessibilityValue = "\(canvas.drawing.strokes.count) strokes"
+        changed(data)
+    }
+    func setZoom(_ scale: CGFloat) {
+        canvas.setZoomScale(min(4, max(0.2, scale)), animated: false)
+        zoom = canvas.zoomScale
+    }
+    func fit() { setZoom(canvas.bounds.width / max(1200, canvas.drawing.bounds.maxX + 80)) }
+    func scrollViewDidZoom(_ scrollView: UIScrollView) { zoom = scrollView.zoomScale }
+}
+
+final class DrawingCanvasView: PKCanvasView {
+    // Session history groups complete drawing gestures; UIKit's independent history must not diverge.
+    override var undoManager: UndoManager? { nil }
+    var undoAction: (() -> Void)?
+    var redoAction: (() -> Void)?
+    override var keyCommands: [UIKeyCommand]? {
+        [UIKeyCommand(input: "z", modifierFlags: .command, action: #selector(undoInk)),
+         UIKeyCommand(input: "z", modifierFlags: [.command, .shift], action: #selector(redoInk))]
+    }
+    @objc private func undoInk() { undoAction?() }
+    @objc private func redoInk() { redoAction?() }
+}
+
+private struct RetainedInkCanvas: UIViewRepresentable {
+    let session: InkEditingSession
+    let data: Data
+    let id: UUID
+    let editable: Bool
+    let changed: (Data) -> Void
+    func makeUIView(context: Context) -> DrawingCanvasView { session.canvas }
+    func updateUIView(_ view: DrawingCanvasView, context: Context) {
+        session.changed = changed
+        session.load(data, id: id, editable: editable)
+    }
+    static func dismantleUIView(_ view: DrawingCanvasView, coordinator: ()) { view.resignFirstResponder() }
+}
+
+struct InkEditor: View {
+    @Bindable var session: InkEditingSession
+    let id: UUID
+    @Binding var data: Data
+    var editable = true
+    @State private var tool = "Pen"
+    @State private var color = "Black"
+    @State private var width: CGFloat = 3
+    @State private var finger = true
+    private let colors: [(String, UIColor)] = [("Black", .label), ("Blue", .systemBlue), ("Red", .systemRed), ("Green", .systemGreen)]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView(.horizontal) {
+                HStack(spacing: 14) {
+                    Menu {
+                        Menu("Tool") {
+                            Picker("Drawing tool", selection: $tool) {
+                                ForEach(["Pen", "Pencil", "Marker", "Eraser", "Lasso"], id: \.self) { Text($0) }
+                            }
+                        }
+                        Menu("Color") { Picker("Ink color", selection: $color) { ForEach(colors, id: \.0) { Text($0.0) } } }
+                        Menu("Width") {
+                            Picker("Stroke width", selection: $width) {
+                                Text("Fine").tag(CGFloat(3)); Text("Medium").tag(CGFloat(5)); Text("Broad").tag(CGFloat(10))
+                            }
+                        }
+                        Toggle("Draw with finger", isOn: $finger)
+                    #if DEBUG
+                    if ProcessInfo.processInfo.arguments.contains("--ink-fixture") {
+                        Button("Add sample ink") { session.replace(with: InkFixture.drawing()) }
+                            .accessibilityIdentifier("addSampleInk")
+                    }
+                    #endif
+
+                    } label: { Label(tool, systemImage: "pencil.tip") }
+                    .accessibilityLabel("Drawing tools").accessibilityIdentifier("drawingTools")
+                    .disabled(!editable || session.problem != nil)
+                    Button("Undo", systemImage: "arrow.uturn.backward") { session.undo() }
+                        .disabled(!editable || session.undoSteps.isEmpty).accessibilityIdentifier("undoInk").keyboardShortcut("z", modifiers: .command)
+                    Button("Redo", systemImage: "arrow.uturn.forward") { session.redo() }
+                        .disabled(!editable || session.redoSteps.isEmpty).accessibilityIdentifier("redoInk").keyboardShortcut("z", modifiers: [.command, .shift])
+                    Menu {
+                        Button("Fit page") { session.fit() }
+                        Button("100 percent") { session.setZoom(1) }
+                        Button("200 percent") { session.setZoom(2) }
+                    } label: { Text("Zoom \(Int(session.zoom * 100))%") }
+                    .accessibilityLabel("Drawing zoom").accessibilityIdentifier("inkZoom")
+                }.buttonStyle(.bordered).padding(8)
+            }.fixedSize(horizontal: false, vertical: true)
+            if let problem = session.problem {
+                ContentUnavailableView("Drawing could not be opened", systemImage: "pencil.tip.crop.circle.badge.exclamationmark", description: Text(problem))
+            } else {
+                RetainedInkCanvas(session: session, data: data, id: id, editable: editable, changed: { data = $0 })
+            }
+        }
+        .onAppear { session.load(data, id: id, editable: editable); configureTool() }
+        .onDisappear { session.finishGesture() }
+        .onChange(of: data) { _, value in session.load(value, id: id, editable: editable) }
+        .onChange(of: tool) { _, _ in configureTool() }
+        .onChange(of: color) { _, _ in configureTool() }
+        .onChange(of: width) { _, _ in configureTool() }
+        .onChange(of: finger) { _, _ in configureTool() }
+    }
+    private func configureTool() {
+        let uiColor = colors.first { $0.0 == color }?.1 ?? .label
+        switch tool {
+        case "Eraser": session.canvas.tool = PKEraserTool(.vector)
+        case "Lasso": session.canvas.tool = PKLassoTool()
+        default:
+            let type: PKInk.InkType = tool == "Pencil" ? .pencil : (tool == "Marker" ? .marker : .pen)
+            session.canvas.tool = PKInkingTool(type, color: uiColor, width: width)
+        }
+        session.canvas.drawingPolicy = finger ? .anyInput : .pencilOnly
+    }
+}

--- a/apps/mobile-native/Sources/Editing/InkFixture.swift
+++ b/apps/mobile-native/Sources/Editing/InkFixture.swift
@@ -1,0 +1,20 @@
+#if DEBUG
+import PencilKit
+
+/// Synthetic, nonempty drawing for deterministic editor tests; never reads a user's drawing.
+enum InkFixture {
+    static func drawing() -> PKDrawing {
+        let paths: [[CGPoint]] = [
+            [CGPoint(x: 60, y: 80), CGPoint(x: 330, y: 80), CGPoint(x: 330, y: 230), CGPoint(x: 60, y: 230), CGPoint(x: 60, y: 80)],
+            [CGPoint(x: 100, y: 160), CGPoint(x: 150, y: 200), CGPoint(x: 270, y: 115)],
+            [CGPoint(x: 75, y: 290), CGPoint(x: 120, y: 275), CGPoint(x: 170, y: 300), CGPoint(x: 220, y: 280), CGPoint(x: 305, y: 292)]
+        ]
+        return PKDrawing(strokes: paths.enumerated().map { index, points in
+            let controls = points.enumerated().map { offset, point in
+                PKStrokePoint(location: CGPoint(x: point.x * 2.5, y: point.y * 2), timeOffset: Double(offset) * 0.1, size: CGSize(width: 5, height: 5), opacity: 1, force: 1, azimuth: 0, altitude: .pi / 2)
+            }
+            return PKStroke(ink: PKInk(.pen, color: index == 1 ? .systemGreen : .systemBlue), path: PKStrokePath(controlPoints: controls, creationDate: Date(timeIntervalSince1970: 0)))
+        })
+    }
+}
+#endif

--- a/apps/mobile-native/Sources/NoteEditor.swift
+++ b/apps/mobile-native/Sources/NoteEditor.swift
@@ -12,6 +12,10 @@ struct NoteEditor: View {
     @State private var summaryText = ""
     @State private var editingSummary: SummaryVersion?
     @State private var confirmAudioRemoval = false
+    @State private var inkSession = InkEditingSession()
+    @State private var showDetails = false
+    @FocusState private var editingText: Bool
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     private var note: NoteRecord { library.note(id) ?? NoteRecord(id: id) }
     private var isActive: Bool { recording.noteID == id }
@@ -29,51 +33,53 @@ struct NoteEditor: View {
     }
 
     var body: some View {
+        GeometryReader { geometry in
         VStack(spacing: 0) {
             TextField("Untitled note", text: binding(\.title), axis: .vertical)
-                .font(.largeTitle.bold()).padding().accessibilityIdentifier("noteTitle").disabled(note.schemaVersion != 2)
+                .font(.title2.bold()).lineLimit(2).padding(.horizontal).padding(.top, 8).accessibilityIdentifier("noteTitle").disabled(note.schemaVersion != 2)
+            DisclosureGroup("Note details", isExpanded: $showDetails) {
             Picker("Move to folder", selection: Binding(get: { note.metadata?.folderID }, set: { folder in
                 library.update(id) { $0.metadata?.folderID = folder }
             })) {
                 Text("No folder").tag(UUID?.none)
                 ForEach(library.folders) { Text($0.name).tag(Optional($0.id)) }
             }.padding(.horizontal).disabled(note.schemaVersion != 2).accessibilityIdentifier("noteFolder")
-            if note.captureState == .interrupted {
-                Label("Recording interrupted. Saved audio and notes are retained. Start again when ready.", systemImage: "pause.circle")
-                    .font(.callout).foregroundStyle(.orange).padding(.horizontal)
-            }
             HStack {
                 Picker("Spoken language", selection: binding(\.language)) {
                     ForEach(SpokenLanguage.allCases) { Text($0.name).tag($0) }
                 }
                 .disabled(note.schemaVersion != 2 || recording.noteID != nil || recording.busy || recording.speech.readiness == .downloading)
                 Spacer()
-                if let started = recording.startedAt, isActive {
-                    Label { Text(started, style: .timer).monospacedDigit() } icon: { Image(systemName: "record.circle.fill") }
-                        .foregroundStyle(.red)
-                }
             }.padding(.horizontal)
-            // Keep recording controls clear of PencilKit's floating tool palette.
+            }.padding(.horizontal)
+            if note.captureState == .interrupted {
+                Label("Recording interrupted. Saved audio and notes are retained. Start again when ready.", systemImage: "pause.circle")
+                    .font(.callout).foregroundStyle(.orange).padding(.horizontal)
+            }
+            // Recording controls stay outside the docked drawing tools.
             captureControls
             if showSpeakers { speakerSettings }
-            if sizeClass == .regular {
+            if sizeClass == .regular && geometry.size.width >= 740 && !dynamicTypeSize.isAccessibilitySize {
                 HStack(spacing: 0) {
-                    VStack(spacing: 0) { notePicker; notePane }.frame(maxWidth: .infinity)
+                    VStack(spacing: 0) { notePicker; if pane == 2 { notePaneForNotes } else { notePane } }.frame(maxWidth: .infinity)
                     Divider()
                     transcript.frame(maxWidth: .infinity)
                 }
             } else {
-                Picker("Content", selection: $pane) {
-                    Text("Notes").tag(0)
-                    Text("Ink").tag(1)
-                    Text("Transcript").tag(2)
-                    Text("Summary").tag(3)
-                }.pickerStyle(.segmented).padding()
+                notePicker
                 if pane == 2 { transcript } else { notePane }
             }
         }
+        }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            Menu("Editor navigation", systemImage: "rectangle.split.2x1") {
+                Button("Personal notes") { pane = 0; editingText = true }
+                Button("Drawing") { pane = 1; editingText = false }
+                Button("Transcript") { pane = 2; editingText = false }
+                Button("Summary") { pane = 3; editingText = false }
+            }
+            if editingText { Button("Done typing") { editingText = false }.accessibilityIdentifier("doneTyping") }
             Menu("Note storage", systemImage: "ellipsis.circle") {
                 Button("Move to Trash", role: .destructive) {
                     player.stop()
@@ -100,14 +106,38 @@ struct NoteEditor: View {
                 await recording.speakers.check()
             }
         }
-        .onDisappear { player.stop() }
+        .task {
+            #if DEBUG
+            if ProcessInfo.processInfo.arguments.contains("--ink-fixture"), note.passages.isEmpty {
+                library.update(id) { $0.passages = [
+                    TranscriptPassage(start: 0, end: 8, text: "Let’s keep the sketch beside the meeting notes while we explore this idea.", isFinal: true, speakerName: "Fixture speaker 1"),
+                    TranscriptPassage(start: 8, end: 16, text: "We can review the next steps together, then keep this drawing editable.", isFinal: true, speakerName: "Fixture speaker 2")
+                ] }
+            }
+            #endif
+        }
+        .onChange(of: pane) { _, value in if value != 0 { editingText = false } }
+        .onDisappear { player.stop(); Task { await library.flush() } }
         .onChange(of: recording.noteID) { _, value in if value != nil { player.stop() } }
         .onChange(of: recording.busy) { _, value in if value { player.stop() } }
     }
 
     private var notePicker: some View {
-        Picker("Content", selection: $pane) { Text("Notes").tag(0); Text("Ink").tag(1); Text("Summary").tag(3) }
-            .pickerStyle(.segmented).padding()
+        ScrollView(.horizontal) {
+            HStack(spacing: 8) {
+                contentButton("Notes", pane: 0, key: "1")
+                contentButton("Ink", pane: 1, key: "2")
+                contentButton("Transcript", pane: 2, key: "3")
+                contentButton("Summary", pane: 3, key: "4")
+            }.padding(8)
+        }.fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func contentButton(_ title: String, pane value: Int, key: KeyEquivalent) -> some View {
+        Button(title) { pane = value; editingText = value == 0 }
+            .keyboardShortcut(key, modifiers: .command)
+            .buttonStyle(.bordered).tint(pane == value ? .accentColor : .secondary)
+            .accessibilityAddTraits(pane == value ? .isSelected : [])
     }
 
     @ViewBuilder private var notePane: some View {
@@ -139,23 +169,24 @@ struct NoteEditor: View {
                 }
             }
         } else if pane == 1 {
-            if note.ink.isEmpty || (try? PKDrawing(data: note.ink)) != nil {
-                InkCanvas(data: binding(\.ink), editable: note.schemaVersion == 2).accessibilityLabel("Drawing canvas")
-            } else {
-                ContentUnavailableView("Drawing could not be opened", systemImage: "pencil.tip.crop.circle.badge.exclamationmark",
-                    description: Text("The original drawing is preserved."))
-            }
+            InkEditor(session: inkSession, id: id, data: binding(\.ink), editable: note.schemaVersion == 2)
         } else {
+            notePaneForNotes
+        }
+    }
+
+    private var notePaneForNotes: some View {
             VStack(alignment: .leading, spacing: 0) {
-                Text("Your personal notes").font(.caption).foregroundStyle(.secondary).padding(.horizontal)
+                Text(UIDevice.current.userInterfaceIdiom == .pad ? "Personal notes · Type or use system Scribble" : "Personal notes").font(.caption).foregroundStyle(.secondary).padding(.horizontal)
                 if note.schemaVersion == 2 {
                     TextEditor(text: binding(\.text)).padding(.horizontal, 8)
                         .accessibilityLabel("Personal notes").accessibilityIdentifier("personalNotes")
+                        .focused($editingText)
+                        .accessibilityHint("Type with the keyboard or write with Apple Pencil using system Scribble. Saved drawings are not converted automatically.")
                 } else {
                     ScrollView { Text(note.text).textSelection(.enabled).frame(maxWidth: .infinity, alignment: .leading).padding() }
                 }
             }
-        }
     }
 
     private var transcript: some View {
@@ -197,12 +228,29 @@ struct NoteEditor: View {
         }
     }
 
+    private var recordControl: some View {
+                Button(isActive ? "Stop recording" : "Record", systemImage: isActive ? "stop.fill" : "mic.fill") {
+                    player.stop()
+                    Task {
+                        if isActive { await recording.stop(library: library) }
+                        else { await recording.start(id, library: library) }
+                    }
+                }.buttonStyle(.borderedProminent).tint(isActive ? .red : .accentColor)
+                    .disabled(library.storageBusy || note.schemaVersion != 2 || recording.busy || (recording.noteID != nil && !isActive) || recording.speech.readiness == .downloading || recording.speakers.preparing)
+                    .accessibilityIdentifier("recordButton")
+    }
+
     private var captureControls: some View {
         VStack(spacing: 8) {
+                if let started = recording.startedAt, isActive {
+                    Label { Text(started, style: .timer).monospacedDigit() } icon: { Image(systemName: "record.circle.fill") }
+                        .foregroundStyle(.red)
+                }
             if let problem = player.problem { Text(problem).font(.caption).foregroundStyle(.red) }
             if recording.speakers.state == .failed {
                 Text(recording.speakers.detail).font(.caption).foregroundStyle(.orange)
             }
+            ViewThatFits(in: .horizontal) {
             HStack {
                 Button("Speakers", systemImage: "person.2") { showSpeakers.toggle() }
                     .accessibilityIdentifier("speakerSettings")
@@ -213,15 +261,16 @@ struct NoteEditor: View {
                     }.buttonStyle(.bordered).disabled(!recording.permitsPlayback)
                 }
                 Spacer()
-                Button(isActive ? "Stop recording" : "Record", systemImage: isActive ? "stop.fill" : "mic.fill") {
-                    player.stop()
-                    Task {
-                        if isActive { await recording.stop(library: library) }
-                        else { await recording.start(id, library: library) }
-                    }
-                }.buttonStyle(.borderedProminent).tint(isActive ? .red : .accentColor)
-                    .disabled(library.storageBusy || note.schemaVersion != 2 || recording.busy || (recording.noteID != nil && !isActive) || recording.speech.readiness == .downloading || recording.speakers.preparing)
-                    .accessibilityIdentifier("recordButton")
+                recordControl
+            }
+            VStack(alignment: .leading, spacing: 8) {
+                Button("Speakers", systemImage: "person.2") { showSpeakers.toggle() }.accessibilityIdentifier("speakerSettings")
+                recordControl
+                if !audio.isEmpty && recording.noteID == nil {
+                    Button(player.isPlaying ? "Stop playback" : "Play recording") { if player.isPlaying { player.stop() } else { play() } }
+                        .disabled(!recording.permitsPlayback)
+                }
+            }
             }
             if recording.busy { ProgressView("Preparing or finalizing recording…").font(.caption) }
         }.padding().background(.bar)
@@ -256,56 +305,5 @@ struct NoteEditor: View {
                 }.font(.caption)
             }.padding()
         }.frame(maxHeight: 240).background(.quaternary.opacity(0.3))
-    }
-}
-
-struct InkCanvas: UIViewRepresentable {
-    @Binding var data: Data
-    var editable = true
-
-    func makeCoordinator() -> Coordinator { Coordinator(self) }
-    func makeUIView(context: Context) -> PKCanvasView {
-        let canvas = DrawingCanvasView()
-        canvas.picker = context.coordinator.picker
-        canvas.drawingPolicy = .anyInput
-        canvas.alwaysBounceVertical = true
-        canvas.contentSize = CGSize(width: 1200, height: 1800)
-        canvas.minimumZoomScale = 0.25
-        canvas.maximumZoomScale = 4
-        canvas.tool = PKInkingTool(.pen, color: .label, width: 3)
-        canvas.delegate = context.coordinator
-        context.coordinator.picker.addObserver(canvas)
-        return canvas
-    }
-    func updateUIView(_ canvas: PKCanvasView, context: Context) {
-        context.coordinator.parent = self
-        canvas.drawingGestureRecognizer.isEnabled = editable
-        if context.coordinator.lastData != data {
-            context.coordinator.lastData = data
-            canvas.drawing = (try? PKDrawing(data: data)) ?? PKDrawing()
-        }
-        context.coordinator.picker.setVisible(editable, forFirstResponder: canvas)
-    }
-    final class Coordinator: NSObject, PKCanvasViewDelegate {
-        var parent: InkCanvas
-        var lastData = Data()
-        let picker = PKToolPicker()
-        init(_ parent: InkCanvas) { self.parent = parent }
-        func canvasViewDrawingDidChange(_ canvasView: PKCanvasView) {
-            let data = canvasView.drawing.dataRepresentation()
-            guard data != lastData else { return }
-            lastData = data
-            parent.data = data
-        }
-    }
-}
-
-final class DrawingCanvasView: PKCanvasView {
-    var picker: PKToolPicker?
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
-        guard window != nil else { return }
-        becomeFirstResponder()
-        picker?.setVisible(true, forFirstResponder: self)
     }
 }

--- a/apps/mobile-native/Tests/InkEditingTests.swift
+++ b/apps/mobile-native/Tests/InkEditingTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+import PencilKit
+@testable import DoodleNoteNative
+
+@MainActor final class InkEditingTests: XCTestCase {
+    func testNonemptyEditUndoRedoSerializeAndReopen() throws {
+        let session = InkEditingSession(), id = UUID()
+        let first = InkFixture.drawing()
+        session.load(first.dataRepresentation(), id: id, editable: true)
+        var updated = first
+        updated.strokes.append(first.strokes[0])
+        var persisted = Data()
+        session.changed = { persisted = $0 }
+        session.replace(with: updated)
+        XCTAssertEqual(try PKDrawing(data: persisted).strokes.count, 4)
+        session.undo()
+        XCTAssertEqual(try PKDrawing(data: persisted).strokes.count, 3)
+        session.redo()
+        XCTAssertEqual(try PKDrawing(data: persisted).strokes.count, 4)
+        let reopened = InkEditingSession()
+        reopened.load(persisted, id: id, editable: true)
+        XCTAssertEqual(reopened.canvas.drawing.strokes.count, 4)
+        XCTAssertNil(reopened.problem)
+    }
+
+    func testStrokeGroupsChangesAndRepeatedLayoutLoadKeepsUndo() throws {
+        let session = InkEditingSession(), id = UUID()
+        session.load(Data(), id: id, editable: true)
+        session.canvasViewDidBeginUsingTool(session.canvas)
+        session.canvas.drawing = InkFixture.drawing()
+        session.canvasViewDrawingDidChange(session.canvas)
+        let result = session.bytes
+        session.load(result, id: id, editable: true)
+        session.canvasViewDidEndUsingTool(session.canvas)
+        XCTAssertEqual(session.undoSteps.count, 1)
+        session.undo()
+        XCTAssertTrue(session.canvas.drawing.strokes.isEmpty)
+        session.redo()
+        XCTAssertEqual(session.canvas.drawing.strokes.count, 3)
+    }
+
+    func testCorruptAndReadOnlyInkNeverPublishesEmptyReplacement() throws {
+        let session = InkEditingSession(), original = Data([0, 1, 2, 3])
+        var writes = 0
+        session.changed = { _ in writes += 1 }
+        let corruptID = UUID()
+        session.load(original, id: corruptID, editable: true)
+        session.load(original, id: corruptID, editable: true)
+        XCTAssertFalse(session.canvas.drawingGestureRecognizer.isEnabled)
+        XCTAssertNotNil(session.problem)
+        session.replace(with: InkFixture.drawing())
+        session.canvasViewDrawingDidChange(session.canvas)
+        XCTAssertEqual(session.bytes, original)
+        XCTAssertEqual(writes, 0)
+        let valid = InkFixture.drawing().dataRepresentation()
+        session.load(valid, id: UUID(), editable: false)
+        session.replace(with: PKDrawing())
+        XCTAssertEqual(session.bytes, valid)
+        XCTAssertFalse(session.canvas.drawingGestureRecognizer.isEnabled)
+        XCTAssertTrue(session.canvas.isScrollEnabled)
+        XCTAssertEqual(writes, 0)
+    }
+
+    func testUndoDuringActiveGestureDoesNotResurrectHistoryAtEnd() {
+        let session = InkEditingSession()
+        session.load(Data(), id: UUID(), editable: true)
+        session.canvasViewDidBeginUsingTool(session.canvas)
+        session.canvas.drawing = InkFixture.drawing()
+        session.canvasViewDrawingDidChange(session.canvas)
+        session.undo()
+        XCTAssertTrue(session.canvas.drawing.strokes.isEmpty)
+        XCTAssertTrue(session.undoSteps.isEmpty)
+        XCTAssertEqual(session.redoSteps.count, 1)
+        session.canvasViewDidEndUsingTool(session.canvas)
+        XCTAssertTrue(session.undoSteps.isEmpty)
+        XCTAssertEqual(session.redoSteps.count, 1)
+        session.redo()
+        XCTAssertEqual(session.canvas.drawing.strokes.count, 3)
+        XCTAssertEqual(session.undoSteps.count, 1)
+    }
+
+    func testChangingNotesCannotUndoIntoAnotherNote() {
+        let session = InkEditingSession()
+        session.load(Data(), id: UUID(), editable: true)
+        session.replace(with: InkFixture.drawing())
+        session.canvasViewDidBeginUsingTool(session.canvas)
+        session.load(Data(), id: UUID(), editable: true)
+        session.canvasViewDidEndUsingTool(session.canvas)
+        session.undo()
+        XCTAssertTrue(session.canvas.drawing.strokes.isEmpty)
+        XCTAssertTrue(session.undoSteps.isEmpty)
+    }
+
+    func testFailedInkSavePreservesPreviousAndPendingDrawingForRetry() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let library = NoteLibrary(root: root)
+        await library.waitUntilLoaded()
+        let id = try XCTUnwrap(library.create())
+        let original = InkFixture.drawing().dataRepresentation()
+        library.update(id) { $0.ink = original; $0.text = "Personal text" }
+        await library.flush()
+        let disk = try XCTUnwrap(library.disk), file = disk.directory(for: id).appendingPathComponent("note.json")
+        let source = try Data(contentsOf: file)
+        let recovery = root.appendingPathComponent("synthetic-preserved-original.json")
+        try source.write(to: recovery)
+        try FileManager.default.removeItem(at: file)
+        try FileManager.default.createDirectory(at: file, withIntermediateDirectories: false)
+        var changed = InkFixture.drawing(); changed.strokes.append(changed.strokes[0])
+        let newer = changed.dataRepresentation()
+        library.update(id) { $0.ink = newer }
+        let saved = await library.flush()
+        XCTAssertFalse(saved)
+        XCTAssertEqual(library.note(id)?.ink, newer)
+        XCTAssertEqual(try JSONDecoder().decode(NoteRecord.self, from: Data(contentsOf: recovery)).ink, original)
+        try FileManager.default.removeItem(at: file)
+        try source.write(to: file)
+        library.retrySaving()
+        let retried = await library.flush()
+        XCTAssertTrue(retried)
+        let reopened = try XCTUnwrap(disk.load().notes.first)
+        XCTAssertEqual(try PKDrawing(data: reopened.ink).strokes.count, 4)
+        XCTAssertEqual(reopened.text, "Personal text")
+    }
+}

--- a/apps/mobile-native/UITests/NoteEditingTests.swift
+++ b/apps/mobile-native/UITests/NoteEditingTests.swift
@@ -60,6 +60,7 @@ import XCTest
         app.alerts.textFields.firstMatch.typeText(name)
         app.alerts.buttons["Create"].tap()
         app.buttons["newNote"].tap()
+        app.buttons["Note details"].tap()
         XCTAssertTrue(app.buttons["noteFolder"].waitForExistence(timeout: 5))
         app.buttons["noteFolder"].tap()
         app.buttons[name].firstMatch.tap()

--- a/apps/mobile-native/UITests/PencilEditingUITests.swift
+++ b/apps/mobile-native/UITests/PencilEditingUITests.swift
@@ -37,7 +37,7 @@ import XCTest
         XCTAssertTrue(app.textViews["personalNotes"].waitForExistence(timeout: 5))
         app.typeKey("2", modifierFlags: .command)
         XCTAssertTrue(app.buttons["drawingTools"].waitForExistence(timeout: 5))
-        let image = XCTAttachment(screenshot: app.screenshot())
+        let image = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
         image.name = "Nonempty editable ink and accessible recording controls"
         image.lifetime = .keepAlways; add(image)
         XCUIDevice.shared.orientation = .landscapeLeft
@@ -46,7 +46,7 @@ import XCTest
         app.buttons["inkZoom"].tap(); app.buttons["Fit page"].tap()
         XCTAssertTrue(app.buttons["drawingTools"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.buttons["recordButton"].isHittable)
-        let landscape = XCTAttachment(screenshot: app.screenshot())
+        let landscape = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
         landscape.name = "Adaptive landscape drawing layout"
         landscape.lifetime = .keepAlways; add(landscape)
         XCUIDevice.shared.orientation = .portrait
@@ -58,7 +58,7 @@ import XCTest
         XCTAssertTrue(app.buttons["drawingTools"].waitForExistence(timeout: 5))
         app.buttons["inkZoom"].tap(); app.buttons["Fit page"].tap()
         XCTAssertEqual(app.descendants(matching: .any).matching(identifier: "inkCanvas").firstMatch.value as? String, "4 strokes")
-        let reopened = XCTAttachment(screenshot: app.screenshot())
+        let reopened = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
         reopened.name = "Persisted nonempty drawing after relaunch"
         reopened.lifetime = .keepAlways; add(reopened)
         app.buttons["Notes"].tap()
@@ -78,7 +78,7 @@ import XCTest
         app.buttons["drawingTools"].tap()
         app.buttons["addSampleInk"].tap()
         XCTAssertTrue(app.buttons["recordButton"].isHittable)
-        let image = XCTAttachment(screenshot: app.screenshot())
+        let image = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
         image.name = "Accessibility text size with drawing controls"
         image.lifetime = .keepAlways; add(image)
     }

--- a/apps/mobile-native/UITests/PencilEditingUITests.swift
+++ b/apps/mobile-native/UITests/PencilEditingUITests.swift
@@ -1,0 +1,86 @@
+import XCTest
+
+@MainActor final class PencilEditingUITests: XCTestCase {
+    func testNonemptyInkToolsUndoReopenAndAdaptiveNavigation() {
+        let app = XCUIApplication()
+        app.launchArguments = ["--ui-testing", "--ink-fixture"]
+        app.launch()
+        XCTAssertTrue(app.buttons["newNote"].waitForExistence(timeout: 10))
+        app.buttons["newNote"].tap()
+        let title = app.textFields["noteTitle"].exists ? app.textFields["noteTitle"] : app.textViews["noteTitle"]
+        let unique = "Pencil \(UUID().uuidString.prefix(6))"
+        title.tap(); title.typeText(unique)
+        let notes = app.textViews["personalNotes"]
+        notes.tap(); notes.typeText("Ideas and sketches stay alongside the meeting transcript.")
+        app.buttons["Done typing"].tap()
+        app.buttons["Ink"].tap()
+        app.buttons["drawingTools"].tap()
+        app.buttons["addSampleInk"].tap()
+        XCTAssertTrue(app.buttons["undoInk"].isEnabled)
+        app.buttons["undoInk"].tap()
+        XCTAssertTrue(app.buttons["redoInk"].isEnabled)
+        app.buttons["redoInk"].tap()
+        app.buttons["inkZoom"].tap()
+        app.buttons["Fit page"].tap()
+        XCTAssertTrue(app.buttons["recordButton"].isHittable)
+        let canvas = app.descendants(matching: .any).matching(identifier: "inkCanvas").firstMatch
+        XCTAssertTrue(canvas.exists)
+        let start = canvas.coordinate(withNormalizedOffset: CGVector(dx: 0.2, dy: 0.45))
+        let end = canvas.coordinate(withNormalizedOffset: CGVector(dx: 0.7, dy: 0.5))
+        start.press(forDuration: 0.1, thenDragTo: end)
+        XCTAssertEqual(canvas.value as? String, "4 strokes")
+        app.buttons["undoInk"].tap()
+        XCTAssertEqual(canvas.value as? String, "3 strokes")
+        app.buttons["redoInk"].tap()
+        XCTAssertEqual(canvas.value as? String, "4 strokes")
+        app.typeKey("1", modifierFlags: .command)
+        XCTAssertTrue(app.textViews["personalNotes"].waitForExistence(timeout: 5))
+        app.typeKey("2", modifierFlags: .command)
+        XCTAssertTrue(app.buttons["drawingTools"].waitForExistence(timeout: 5))
+        let image = XCTAttachment(screenshot: app.screenshot())
+        image.name = "Nonempty editable ink and accessible recording controls"
+        image.lifetime = .keepAlways; add(image)
+        XCUIDevice.shared.orientation = .landscapeLeft
+        let rotated = NSPredicate { _, _ in app.frame.width > app.frame.height }
+        XCTAssertEqual(XCTWaiter.wait(for: [XCTNSPredicateExpectation(predicate: rotated, object: nil)], timeout: 8), .completed)
+        app.buttons["inkZoom"].tap(); app.buttons["Fit page"].tap()
+        XCTAssertTrue(app.buttons["drawingTools"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["recordButton"].isHittable)
+        let landscape = XCTAttachment(screenshot: app.screenshot())
+        landscape.name = "Adaptive landscape drawing layout"
+        landscape.lifetime = .keepAlways; add(landscape)
+        XCUIDevice.shared.orientation = .portrait
+        app.terminate(); app.launch()
+        XCTAssertTrue(app.staticTexts[unique].firstMatch.waitForExistence(timeout: 10))
+        app.staticTexts[unique].firstMatch.tap()
+        XCTAssertEqual(app.textViews["personalNotes"].value as? String, "Ideas and sketches stay alongside the meeting transcript.")
+        app.buttons["Ink"].tap()
+        XCTAssertTrue(app.buttons["drawingTools"].waitForExistence(timeout: 5))
+        app.buttons["inkZoom"].tap(); app.buttons["Fit page"].tap()
+        XCTAssertEqual(app.descendants(matching: .any).matching(identifier: "inkCanvas").firstMatch.value as? String, "4 strokes")
+        let reopened = XCTAttachment(screenshot: app.screenshot())
+        reopened.name = "Persisted nonempty drawing after relaunch"
+        reopened.lifetime = .keepAlways; add(reopened)
+        app.buttons["Notes"].tap()
+        XCTAssertTrue(app.textViews["personalNotes"].exists)
+    }
+    func testAccessibilityTextSizeKeepsToolsAndRecordingReachable() {
+        let app = XCUIApplication()
+        app.launchArguments = ["--ui-testing", "--ink-fixture", "-UIPreferredContentSizeCategoryName", "UICTContentSizeCategoryAccessibilityXXXL"]
+        app.launch()
+        XCTAssertTrue(app.buttons["newNote"].waitForExistence(timeout: 10))
+        app.buttons["newNote"].tap()
+        XCTAssertTrue(app.buttons["recordButton"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["recordButton"].isHittable)
+        app.buttons["Ink"].tap()
+        XCTAssertTrue(app.buttons["drawingTools"].isHittable)
+        XCTAssertFalse(app.buttons["drawingTools"].label.isEmpty)
+        app.buttons["drawingTools"].tap()
+        app.buttons["addSampleInk"].tap()
+        XCTAssertTrue(app.buttons["recordButton"].isHittable)
+        let image = XCTAttachment(screenshot: app.screenshot())
+        image.name = "Accessibility text size with drawing controls"
+        image.lifetime = .keepAlways; add(image)
+    }
+
+}

--- a/apps/mobile-native/docs/pencil-editing.md
+++ b/apps/mobile-native/docs/pencil-editing.md
@@ -1,0 +1,42 @@
+# Pencil and adaptive editing (ONY-247)
+
+The fresh native editor retains an editable PencilKit canvas across content-pane and layout changes. The drawing remains in the existing versioned note document, with the same immutable source/revision and retry contracts. No ink format migration, cloud transport, OCR or automatic handwriting indexing is introduced.
+
+## Input and layout
+
+Drawing tools are docked above the canvas: pen, pencil, marker, vector eraser, lasso, color and width choices, plus finger-drawing selection, undo/redo and zoom. The drawing controls scroll horizontally at narrow widths instead of clipping. There is no floating Pencil palette that can cover recording actions. Pinch/pan and Fit page/100%/200% remain available; read-only drawings retain scrolling and zoom.
+
+At regular widths of at least 740 points, personal notes/ink/summary and the transcript use separate columns. Narrow widths and accessibility text sizes use one content pane at a time. Personal notes remain the system TextEditor, supporting native keyboard editing, dictation and system Scribble where Apple enables it. Converted Scribble text is ordinary personal text. Switching to ink dismisses text focus; Done typing dismisses the keyboard. Command-1 through Command-4 choose personal notes, drawing, transcript and summary. Drawing undo/redo use Command-Z and Shift-Command-Z. Personal text keeps its system editing/undo behavior.
+
+Title and recording controls remain outside the drawing surface. Note details (folder and spoken language) expand when needed; the recording timer and interruption warning remain visible. Recording continues while switching content panes or navigating away; navigation flushes queued notes, and does not silently stop capture. Destructive storage controls retain the existing capture/preparation guards.
+
+## Preservation and undo
+
+A retained InkEditingSession owns the canvas and per-note gesture history. A complete drawing gesture is one undo action. Pane disappearance finishes a pending gesture. Native UIKit drawing undo is disabled so it cannot diverge from the session history; explicit tools and keyboard commands use the same history. History is session-local, bounded to 20 prior changes and roughly 32 MiB, retaining one previous full drawing for a larger change. It is not an infinite durable edit history. Durable document revisions remain governed by the existing library storage contract.
+
+The editor only assigns a decoded drawing after successful PencilKit decoding. Corrupt/unsupported bytes remain unchanged and display an unavailable state; editing text in the note does not replace those bytes. Read-only migration notes cannot mutate drawing content. Switching note identity clears session undo so one note cannot recover another note's drawing.
+
+Drawing changes use the library's coalesced persistence queue. A failed write retains the original durable document and the newest in-memory drawing with a visible save error/retry path. Keep the app open when a save fails, free storage and retry. This does not promise recovery of changes that never reached storage after force termination. Serialization still encodes PencilKit data on the main actor, while durable JSON writes run through the repository actor; large real drawings and sustained sessions need device measurement before release qualification.
+
+## Verification and Check this:
+
+Automated unit fixtures use nonempty PencilKit strokes, edit/undo/redo/reopen, gesture grouping, repeated layout loads, corrupt/read-only preservation, cross-note history isolation, and a synthetic failed-write/retry/reopen path. UI fixtures use only the dedicated `--ui-testing` library. `--ink-fixture` exposes a DEBUG-only sample-drawing command and synthetic transcript; it never reads a user's drawing or sends network data.
+
+Generate and run focused tests:
+
+```sh
+xcodegen generate --spec apps/mobile-native/project.yml
+xcodebuild test -project apps/mobile-native/DoodleNoteNative.xcodeproj -scheme DoodleNoteNative -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' -derivedDataPath /tmp/ony247-derived CODE_SIGNING_ALLOWED=NO -only-testing:DoodleNoteNativeTests/InkEditingTests -only-testing:DoodleNoteNativeUITests/PencilEditingUITests
+```
+
+Check this on an authorized physical iPad/Pencil and keyboard, plus an iPhone:
+
+1. Create a note, write personal text using the keyboard and system Scribble, then draw with pressure and palm contact. Expect editable strokes and personal text to remain separate, with no automatic OCR of saved ink.
+2. Draw several strokes, erase/select/move a stroke, undo/redo, switch panes and rotate. Expect complete gestures to undo, original strokes to survive and recording controls to remain reachable. Relaunch after saved status and confirm ink remains editable.
+3. Start an authorized test recording, switch notes/ink and navigate away. Expect recording to continue explicitly, live transcript to remain usable, and returning to the note to retain edits. Check recording-stop access with the keyboard visible.
+4. Use Command-1/2/3/4 and drawing Command-Z/Shift-Command-Z. Expect correct focus, no drawing/text cross-undo and no unexpected recording command.
+5. Increase Dynamic Type, enable VoiceOver and use iPad split-screen plus iPhone portrait/landscape. Expect reachable labeled tools, navigable content and scrollable drawing. Inspect large drawings, zoom extremes and save-failure retry on test data.
+
+Physical Scribble, pressure, palm rejection, Pencil latency, keyboard/VoiceOver ergonomics and long-session memory/storage behavior are not established by simulator tests. Sean's exact iPad/Pencil generation remains unknown; magnetic charging does not establish hover or model-specific gesture support. No such capability is claimed or required by this implementation. The provisional iOS/iPadOS 26 development floor remains unchanged and ONY-241/ONY-265 continue to gate release device compatibility and qualification. Source development proceeds under Sean's explicit sequencing exception; no physical QA is marked complete.
+
+Primary implementation references: [PencilKit canvas](https://developer.apple.com/documentation/pencilkit/pkcanvasview), [PencilKit drawing](https://developer.apple.com/documentation/pencilkit/pkdrawing), and installed iOS 26 SDK UIScribbleInteraction/PKCanvasView declarations. System Scribble is an input capability of supported system text controls, not an ink-to-text conversion service in DoodleNote.


### PR DESCRIPTION
## Summary

The native editor now keeps editable PencilKit drawings across pane changes, rotation and reopen. Docked tools, gesture-based undo/redo, keyboard navigation and an adaptive notes/transcript workspace support personal notes alongside a meeting transcript without covering recording controls.

Corrupt drawings retain their original bytes, read-only notes keep pan/zoom, and failed saves retain the pending drawing for retry. System Scribble remains native text input; saved ink is not automatically transcribed or indexed.

## Affected surfaces

Fresh `apps/mobile-native` editor, new Editing components, unit/UI tests and `docs/pencil-editing.md`. No historical iOS code, storage schema, cloud transport or deployment changes.

## Verification

- Signed iPhone simulator: 90 unit + 6 UI tests passed, zero failures/skips. Includes synthetic pinned speaker-model and real simulator Keychain tests.
- Nonempty ink fixture: draw an additional stroke, undo/redo, Command-1/2 navigation, rotate, save/relaunch and inspect preserved typed text/ink. Largest accessibility text-size UI passed.
- Focused tests cover active-gesture undo, repeated corrupt load, cross-note history, failed disk write and retry.
- Signed iPad simulator: 90 unit + 6 UI tests passed, zero failures/skips. Final screenshot-only followup also passed both iPad Pencil UI cases.
- iPad log: `/tmp/ony247-final-ipad.log`; result: `/tmp/ony247-derived/Logs/Test/Test-DoodleNoteNative-2026.09.06_20-53-57--0500.xcresult`.
- Final screenshot run: `/tmp/ony247-framebuffer-ipad2.log`; result: `/tmp/ony247-derived/Logs/Test/Test-DoodleNoteNative-2026.09.06_20-58-05--0500.xcresult`.
- Actual synthetic-ink landscape screenshot: `/tmp/ony247-framebuffer-attachments/A117A44C-D15D-474F-956F-7BF8F588DA3F.png`. Full-screen capture corrects XCTest app-only landscape cropping; product layout was unchanged.
- Command: `TEST_RUNNER_DOODLENOTE_SPEAKER_MODEL=<local synthetic model> xcodebuild test -project apps/mobile-native/DoodleNoteNative.xcodeproj -scheme DoodleNoteNative -destination 'platform=iOS Simulator,id=<owned simulator>' -derivedDataPath /tmp/ony247-derived CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=- CODE_SIGN_ENTITLEMENTS=<temporary simulator-only plist>`.
- iPhone log: `/tmp/ony247-final-iphone2.log`; result: `/tmp/ony247-derived/Logs/Test/Test-DoodleNoteNative-2026.09.06_20-50-42--0500.xcresult`.

## Privacy, compatibility, and release impact

Only synthetic drawings/transcripts are used in QA. No new network data flow, permission, migration or production signing configuration. The provisional iOS/iPadOS 26 floor is unchanged. PencilKit serialization remains on the main actor and large physical drawings need measurement. Source development follows Sean's explicit sequencing exception; ONY-241/ONY-265 physical qualification remains open.

## Check this:

1. On an authorized iPad/Pencil, write personal text using Scribble, draw/erase/select, undo/redo and reopen; expect separate editable text and preserved strokes.
2. Use a hardware keyboard and rotate/split the app; expect Command-1/2/3/4 navigation, drawing Command-Z/Shift-Command-Z and reachable recording actions.
3. During an authorized test recording, switch panes and navigate away/back; expect continued capture and retained edits.
4. Check VoiceOver, Dynamic Type, palm rejection, pressure, Pencil latency and long sessions on physical devices. Simulator checks do not qualify these behaviors.

Remaining gate: root source review/merge decision and the documented physical-device release qualification. This draft does not mark those checks complete.
