### PR TITLE
[ONY-261] Preserve mobile note versions and ink in desktop and web clients

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -29,7 +29,8 @@
     "@tiptap/extension-image": "^3.30.5",
     "electron-updater": "^6.8.9",
     "node-llama-cpp": "^3.20.0",
-    "sherpa-onnx-node": "^1.13.4"
+    "sherpa-onnx-node": "^1.13.4",
+    "@repo/cloud-reader": "workspace:*"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",
@@ -60,5 +61,10 @@
   },
   "optionalDependencies": {
     "@node-llama-cpp/win-x64": "3.19.0"
+  },
+  "dependenciesMeta": {
+    "@repo/cloud-reader": {
+      "injected": true
+    }
   }
 }

--- a/apps/desktop/src/main/cloud-reader-client.test.ts
+++ b/apps/desktop/src/main/cloud-reader-client.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { cloudReaderClient } from './cloud-reader-client'
+test('desktop cloud reader confines token to fixed origin and never flattens selected versions', async () => {
+  const calls: Array<{ url: string; init?: RequestInit }> = []
+  const client = cloudReaderClient(
+    () => ({ token: 'synthetic-token', enabled: true, baseUrl: 'https://fixture.example' }),
+    async (input, init) => {
+      calls.push({ url: String(input), init })
+      return Response.json({ status: 'ok' })
+    }
+  )
+  const action = {
+    kind: 'choose',
+    operationId: 'op',
+    noteId: 'note',
+    selectedRevision: 'revision',
+    expectedRevision: 'head',
+    expectedLifecycleGeneration: 'generation',
+    libraryId: 'library'
+  }
+  await client({ kind: 'action', value: action })
+  assert.equal(calls[0].url, 'https://fixture.example/api/sync/reader?')
+  assert.deepEqual(JSON.parse(String(calls[0].init?.body)), action)
+  assert.equal(
+    (calls[0].init?.headers as Record<string, string>).Authorization,
+    'Bearer synthetic-token'
+  )
+  assert.equal(calls[0].init?.redirect, 'error')
+  assert.equal(calls[0].init?.cache, 'no-store')
+  await assert.rejects(client({ kind: 'http', url: 'https://attacker.example' }), /Invalid/)
+})
+test('desktop reader blocks disabled sync and stale account responses with safe errors', async () => {
+  const auth = { token: 'one', enabled: false, baseUrl: 'https://fixture.example' }
+  let fetched = false
+  const client = cloudReaderClient(
+    () => auth,
+    async () => {
+      fetched = true
+      auth.token = 'two'
+      return Response.json({ private: 'content' })
+    }
+  )
+  await assert.rejects(client({ kind: 'list' }), /enable Cloud Sync/)
+  assert.equal(fetched, false)
+  auth.enabled = true
+  await assert.rejects(client({ kind: 'list' }), /Cloud notes unavailable/)
+  const failed = cloudReaderClient(
+    () => auth,
+    async () => {
+      throw new Error('secret-provider-diagnostic')
+    }
+  )
+  await assert.rejects(
+    failed({ kind: 'list' }),
+    (e) => e instanceof Error && !e.message.includes('secret')
+  )
+})

--- a/apps/desktop/src/main/cloud-reader-client.ts
+++ b/apps/desktop/src/main/cloud-reader-client.ts
@@ -1,0 +1,61 @@
+import type { ReaderAction, ReaderQuery } from '@repo/cloud-reader/types'
+export type CloudReaderRequest =
+  | { kind: 'list'; after?: string }
+  | { kind: 'detail'; query: ReaderQuery }
+  | { kind: 'action'; value: ReaderAction }
+  | { kind: 'preview'; libraryId: string; noteId: string; revisionId: string; versionId: string }
+export function cloudReaderClient(
+  credentials: () => { token: string | null; enabled: boolean; baseUrl: string },
+  fetcher: typeof fetch = fetch
+) {
+  return async (value: unknown): Promise<unknown> => {
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+      throw new Error('Invalid cloud request.')
+    const r = value as CloudReaderRequest
+    const auth = { ...credentials() }
+    if (!auth.token || !auth.enabled)
+      throw new Error('Connect and enable Cloud Sync in Settings to read mobile notes.')
+    const q = new URLSearchParams()
+    let body: unknown
+    if (r.kind === 'list') {
+      if (r.after) q.set('after', String(r.after))
+    } else if (r.kind === 'detail') {
+      if (!r.query?.noteId) throw new Error('Invalid cloud request.')
+      for (const key of ['noteId', 'revisionId', 'after'] as const)
+        if (r.query[key]) q.set(key, String(r.query[key]))
+    } else if (r.kind === 'preview') {
+      for (const key of ['libraryId', 'noteId', 'revisionId', 'versionId'] as const) {
+        if (typeof r[key] !== 'string') throw new Error('Invalid cloud request.')
+        q.set(key, r[key])
+      }
+      q.set('mode', 'preview')
+      q.set('part', 'preview')
+    } else if (r.kind === 'action') {
+      body = r.value
+      if (!body) throw new Error('Invalid cloud request.')
+    } else throw new Error('Invalid cloud request.')
+    try {
+      const response = await fetcher(`${auth.baseUrl}/api/sync/reader?${q}`, {
+        method: body ? 'POST' : 'GET',
+        headers: {
+          Authorization: `Bearer ${auth.token}`,
+          ...(body ? { 'Content-Type': 'application/json' } : {})
+        },
+        body: body ? JSON.stringify(body) : undefined,
+        signal: AbortSignal.timeout(30000),
+        redirect: 'error',
+        cache: 'no-store'
+      })
+      if (!response.ok) throw new Error('unavailable')
+      const result =
+        r.kind === 'preview' ? new Uint8Array(await response.arrayBuffer()) : await response.json()
+      const current = credentials()
+      if (current.token !== auth.token || !current.enabled) throw new Error('workspace_changed')
+      return result
+    } catch {
+      throw new Error(
+        'Cloud notes unavailable. Check your connection, account and sync subscription, then retry.'
+      )
+    }
+  }
+}

--- a/apps/desktop/src/main/sync-service.ts
+++ b/apps/desktop/src/main/sync-service.ts
@@ -1,3 +1,4 @@
+import { cloudReaderClient } from './cloud-reader-client'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { createServer, type Server } from 'node:http'
 import { hostname } from 'node:os'
@@ -73,6 +74,8 @@ export class SyncService {
   }
 
   registerIpc(): void {
+    const reader = cloudReaderClient(() => ({ token: this.token(), enabled: this.config.enabled, baseUrl: this.baseUrl }))
+    ipcMain.handle('sync:reader', (_event, request: unknown) => reader(request))
     ipcMain.handle(SYNC_GET_STATUS_CHANNEL, () => this.status())
     ipcMain.handle(SYNC_CONNECT_CHANNEL, () => this.connect())
     ipcMain.handle(SYNC_DISCONNECT_CHANNEL, () => this.disconnect())

--- a/apps/desktop/src/main/sync-service.ts
+++ b/apps/desktop/src/main/sync-service.ts
@@ -74,7 +74,11 @@ export class SyncService {
   }
 
   registerIpc(): void {
-    const reader = cloudReaderClient(() => ({ token: this.token(), enabled: this.config.enabled, baseUrl: this.baseUrl }))
+    const reader = cloudReaderClient(() => ({
+      token: this.token(),
+      enabled: this.config.enabled,
+      baseUrl: this.baseUrl
+    }))
     ipcMain.handle('sync:reader', (_event, request: unknown) => reader(request))
     ipcMain.handle(SYNC_GET_STATUS_CHANNEL, () => this.status())
     ipcMain.handle(SYNC_CONNECT_CHANNEL, () => this.connect())

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -412,6 +412,7 @@ const calendarApi: CalendarApi = {
 }
 
 const syncApi: SyncApi = {
+  reader(request: unknown): Promise<unknown> { return ipcRenderer.invoke('sync:reader', request) },
   share(meetingId: string): Promise<ShareResult> {
     return ipcRenderer.invoke(SYNC_SHARE_CHANNEL, meetingId) as Promise<ShareResult>
   },

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -412,7 +412,9 @@ const calendarApi: CalendarApi = {
 }
 
 const syncApi: SyncApi = {
-  reader(request: unknown): Promise<unknown> { return ipcRenderer.invoke('sync:reader', request) },
+  reader(request: unknown): Promise<unknown> {
+    return ipcRenderer.invoke('sync:reader', request)
+  },
   share(meetingId: string): Promise<ShareResult> {
     return ipcRenderer.invoke(SYNC_SHARE_CHANNEL, meetingId) as Promise<ShareResult>
   },

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: doodle-media:; media-src 'self' blob:"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: doodle-media:; media-src 'self' blob:"
     />
   </head>
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -564,7 +564,13 @@ function App(): React.JSX.Element {
           <div className="sidebar-spacer" />
 
           <div className="sidebar-bottom">
-            <button type="button" className={view === 'cloud' ? 'nav-item on' : 'nav-item'} onClick={() => setView('cloud')}>Mobile cloud notes</button>
+            <button
+              type="button"
+              className={view === 'cloud' ? 'nav-item on' : 'nav-item'}
+              onClick={() => setView('cloud')}
+            >
+              Mobile cloud notes
+            </button>
             <div className="privacy-badge">
               <LockIcon size={12} /> Local &amp; private
             </div>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,3 +1,4 @@
+import { CloudNotesView } from './CloudNotesView'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type {
   CalendarEvent,
@@ -27,7 +28,7 @@ import {
   TrashIcon
 } from './icons'
 
-type ViewId = 'home' | 'editor' | 'settings' | 'dev'
+type ViewId = 'home' | 'editor' | 'settings' | 'dev' | 'cloud'
 
 /** The "meeting is starting" banner disappears 10 min past the start. */
 const BANNER_TTL_PAST_START_MS = 10 * 60_000
@@ -563,6 +564,7 @@ function App(): React.JSX.Element {
           <div className="sidebar-spacer" />
 
           <div className="sidebar-bottom">
+            <button type="button" className={view === 'cloud' ? 'nav-item on' : 'nav-item'} onClick={() => setView('cloud')}>Mobile cloud notes</button>
             <div className="privacy-badge">
               <LockIcon size={12} /> Local &amp; private
             </div>
@@ -580,6 +582,7 @@ function App(): React.JSX.Element {
         </aside>
 
         <main className="content">
+          {view === 'cloud' && <CloudNotesView />}
           <div className={view === 'home' ? 'content-slot' : 'content-slot hidden'}>
             <HomeView
               meetings={meetings}

--- a/apps/desktop/src/renderer/src/CloudNotesView.tsx
+++ b/apps/desktop/src/renderer/src/CloudNotesView.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react'
 import { Reader } from '@repo/cloud-reader'
 import type { ReaderTransport, ReaderDetail, ReaderNote } from '@repo/cloud-reader/types'
 const transport: ReaderTransport = {
@@ -20,6 +21,6 @@ const transport: ReaderTransport = {
       })) as Uint8Array
     )
 }
-export function CloudNotesView() {
+export function CloudNotesView(): JSX.Element {
   return <Reader transport={transport} />
 }

--- a/apps/desktop/src/renderer/src/CloudNotesView.tsx
+++ b/apps/desktop/src/renderer/src/CloudNotesView.tsx
@@ -1,0 +1,25 @@
+import { Reader } from '@repo/cloud-reader'
+import type { ReaderTransport, ReaderDetail, ReaderNote } from '@repo/cloud-reader/types'
+const transport: ReaderTransport = {
+  list: async (after) =>
+    (await window.sync.reader({ kind: 'list', after })) as {
+      notes: ReaderNote[]
+      next: string | null
+    },
+  detail: async (query) => (await window.sync.reader({ kind: 'detail', query })) as ReaderDetail,
+  action: async (value) =>
+    (await window.sync.reader({ kind: 'action', value })) as { status: string },
+  preview: async (note, revisionId, versionId) =>
+    new Uint8Array(
+      (await window.sync.reader({
+        kind: 'preview',
+        libraryId: note.libraryId,
+        noteId: note.id,
+        revisionId,
+        versionId
+      })) as Uint8Array
+    )
+}
+export function CloudNotesView() {
+  return <Reader transport={transport} />
+}

--- a/apps/desktop/src/shared/sync-api.ts
+++ b/apps/desktop/src/shared/sync-api.ts
@@ -32,6 +32,7 @@ export interface SyncStatus {
 export type ShareResult = { url: string } | { error: string }
 
 export interface SyncApi {
+  reader(request: unknown): Promise<unknown>
   /** Push the meeting (fresh) and mint/fetch its public share link. */
   share(meetingId: string): Promise<ShareResult>
   getStatus(): Promise<SyncStatus>

--- a/apps/web/app/api/app/mobile-notes/route.ts
+++ b/apps/web/app/api/app/mobile-notes/route.ts
@@ -1,0 +1,28 @@
+import { handleSessionReader } from "@/lib/reader-session";
+import { getAppWorkspace } from "@/lib/app-workspace";
+import { entitlementFor } from "@/lib/billing";
+import { handleMobileReader, readerError } from "@/lib/mobile-reader";
+import { syncV2Enabled } from "@/lib/sync-v2";
+export const dynamic = "force-dynamic";
+async function handle(request: Request) {
+  if (!syncV2Enabled()) return readerError(404, "reader_unavailable");
+  try {
+    return await handleSessionReader(request, {
+      session: async () => {
+        const workspace = await getAppWorkspace(request.headers);
+        return workspace
+          ? {
+              userId: workspace.session.user.id,
+              activeOrganizationId: workspace.activeOrganization.id,
+              organizationIds: workspace.organizations.map((org) => org.id),
+            }
+          : null;
+      },
+      entitled: async (userId) => (await entitlementFor(userId)).entitled,
+      read: (organizationId) => handleMobileReader(request, organizationId),
+    });
+  } catch {
+    return readerError(503, "reader_unavailable");
+  }
+}
+export { handle as GET, handle as POST };

--- a/apps/web/app/api/sync/reader/route.ts
+++ b/apps/web/app/api/sync/reader/route.ts
@@ -1,0 +1,23 @@
+import { authenticateEntitledSyncRequest } from "@/lib/sync-auth";
+import {
+  handleMobileReader,
+  readerError,
+  readerHeaders,
+} from "@/lib/mobile-reader";
+import { syncV2Enabled } from "@/lib/sync-v2";
+export const dynamic = "force-dynamic";
+async function handle(request: Request) {
+  if (!syncV2Enabled()) return readerError(404, "reader_unavailable");
+  try {
+    const auth = await authenticateEntitledSyncRequest(request);
+    if (auth.response) {
+      for (const [k, v] of Object.entries(readerHeaders))
+        auth.response.headers.set(k, v);
+      return auth.response;
+    }
+    return await handleMobileReader(request, auth.device.organizationId);
+  } catch {
+    return readerError(503, "reader_unavailable");
+  }
+}
+export { handle as GET, handle as POST };

--- a/apps/web/app/app/meetings-library.tsx
+++ b/apps/web/app/app/meetings-library.tsx
@@ -263,6 +263,7 @@ export async function MeetingsLibrary({
 
       <section className="min-w-0">
         <div className="flex flex-wrap items-end justify-between gap-3">
+          <Link href="/app/mobile-notes" className="text-sm font-medium text-sage-deep hover:underline">Mobile notes and version history →</Link>
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.16em] text-stone">
               {workspace.activeOrganization.id === workspace.personal.id

--- a/apps/web/app/app/mobile-notes/page.tsx
+++ b/apps/web/app/app/mobile-notes/page.tsx
@@ -1,0 +1,15 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { getAppWorkspace } from "@/lib/app-workspace";
+import { WebMobileReader } from "./reader";
+export default async function MobileNotes() {
+  const workspace = await getAppWorkspace(await headers());
+  if (!workspace) redirect("/login");
+  return (
+    <main>
+      <Link href="/app">← All meetings</Link>
+      <WebMobileReader organizationId={workspace.activeOrganization.id} />
+    </main>
+  );
+}

--- a/apps/web/app/app/mobile-notes/reader.tsx
+++ b/apps/web/app/app/mobile-notes/reader.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { useMemo } from "react";
+import { Reader } from "@repo/cloud-reader";
+import type { ReaderTransport } from "@repo/cloud-reader/types";
+export function WebMobileReader({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const transport = useMemo<ReaderTransport>(() => {
+    async function request(
+      params: Record<string, string | undefined>,
+      body?: unknown,
+    ) {
+      const q = new URLSearchParams({ organizationId });
+      for (const [k, v] of Object.entries(params)) if (v) q.set(k, v);
+      const response = await fetch(`/api/app/mobile-notes?${q}`, {
+        method: body ? "POST" : "GET",
+        cache: "no-store",
+        headers: body ? { "Content-Type": "application/json" } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      if (!response.ok)
+        throw new Error(
+          response.status === 402
+            ? "An active Cloud Sync subscription is required."
+            : response.status === 401
+              ? "Sign in again to read cloud notes."
+              : response.status === 404
+                ? "Cloud reader or note unavailable. Refresh to check."
+                : "Cloud request failed. Check your connection and retry.",
+        );
+      return response;
+    }
+    return {
+      list: async (after) => (await request({ after })).json(),
+      detail: async (query) => (await request({ ...query })).json(),
+      action: async (value) => (await request({}, value)).json(),
+      preview: async (note, revision, version) =>
+        new Uint8Array(
+          await (
+            await request({
+              mode: "preview",
+              libraryId: note.libraryId,
+              noteId: note.id,
+              revisionId: revision,
+              versionId: version,
+              part: "preview",
+            })
+          ).arrayBuffer(),
+        ),
+    };
+  }, [organizationId]);
+  return <Reader key={organizationId} transport={transport} />;
+}

--- a/apps/web/docs/mobile-readers.md
+++ b/apps/web/docs/mobile-readers.md
@@ -1,0 +1,95 @@
+# Desktop and web mobile-note readers (ONY-261)
+
+The desktop sidebar's **Mobile cloud notes** view and web library's **Mobile notes
+and version history** link open the same reader. It displays personal notes,
+selected summary, named transcript speakers and private ink previews. There is no
+cloud recording audio; the reader explicitly says playback is unavailable. Local
+notes, recording and legacy sync workflows remain available independently.
+
+The reader keeps rich notes out of the legacy desktop MeetingRecord editor. Text
+and Pencil edits are explicitly unsupported here, rather than serializing a
+partial projection back into mobile content. The service retains every unknown
+snapshot field, source version, summary version and asset reference. Displaying
+known fields does not create an editable replacement. Legacy adopted snapshots
+remain in history but cannot be selected as native replacements.
+
+Supported reconciliation:
+1. Open a note and select a retained current, conflict or historical version.
+2. **Use selected version** creates a new revision by copying the stored snapshot
+   verbatim on the server. It preserves the alternate versions. Head and lifecycle
+   preconditions prevent concurrent or stale choices from overwriting newer work.
+3. **Move to Trash**, **Restore note**, and a separately confirmed **Delete
+   permanently** use ONY-258's deletion identity/server-clock contract. Purged or
+   expired content cannot be selected to resurrect it. Failed requests can be
+   retried with the same operation identity; changed state requires refresh.
+
+The reader loads notes and version history in bounded pages. Signed cursors bind
+workspace and note/list scope. Private previews are fetched through authenticated
+routes into memory-only blob URLs, revoked when the preview unmounts. Desktop
+CSP permits blob images for this path; it adds no remote public image origin.
+Desktop IPC keeps sync credentials in the main process, limits requests to the
+configured sync service path, disables redirects and discards responses when the
+linked account changes. Disconnecting or disabling sync stops new reader access.
+The view requires a connection; no durable offline snapshot or preview cache is
+created by this issue. A failed request displays a retry state.
+
+Web sessions must independently pass workspace membership and the existing paid
+sync entitlement check. Mutation requests must be same-origin. Bearer requests
+use existing entitled device authentication. Neither route accepts a client user
+identity or permission claim. JSON errors and private responses are no-store;
+preview URLs/tokens/provider diagnostics are never returned to the browser.
+
+## Compatibility and rollout
+
+Minimum compatible **source** is this PR plus ONY-258/259 and migration0015.
+The pre-reader desktop source uses version0.4.22; do not claim that version number
+alone identifies a compatible installed build.
+The next separately approved desktop release must include this commit. Web support
+requires the deployed reader source, migrations through0015 and existing v2 rollout
+configuration. Private previews additionally require the private-ink configuration
+and verified private store described in `private-ink-storage.md`.
+
+`DOODLENOTE_SYNC_V2_ENABLED` remains the reader gate. When off, its endpoints return
+404 before database access. With an old schema, installed-capability detection
+returns a controlled unavailable response. Source code and additive migration0015
+were tested locally; no production migration, private store creation or configuration
+was performed. Merging main automatically deploys web code, so a future approved
+merge includes that effect. Root owns merge authorization and sequencing.
+
+Older clients retain their legacy workflows. ONY-258 database guards prevent them
+from overwriting or deleting enriched notes through legacy routes. They do not gain
+Pencil editing by negotiation. Reader actions copy complete stored revisions, while
+unsupported arbitrary JSON edits are rejected. No recording audio or voice-profile
+sync is introduced.
+
+Rollback before rollout: return to the previous reviewed code artifact while the
+reader gate remains disabled. After assets exist, retain ONY-259's schema, cleanup
+worker and private credentials even if the API is disabled. Do not drop retained
+revisions or asset metadata. Migration0015 only adds a function and can remain
+installed when reader code is rolled back. No production rollback is authorized
+by these source instructions.
+
+## Verification and remaining QA
+
+- `pnpm --filter @repo/db test`: real migrated PGlite tests preserve unknown fields
+  and immutable ink refs, paginate versions, and reject foreign/stale/trashed/purged
+  selections. Existing sync mixed-client/long-transcript tests remain required.
+- `pnpm --filter web test`: membership/entitlement/origin, bearer denial, old-schema
+  behavior, private response headers and scoped cursor tests.
+- `pnpm --filter desktop test`: main-process credential confinement, disabled sync,
+  account-switch response rejection and existing desktop regressions.
+- `BROWSER_BIN=/path/to/chrome-headless-shell node packages/cloud-reader/scripts/browser-smoke.mjs`:
+  a synthetic local browser fixture actually renders the shared reader and exercises
+  selection, Trash and restore. It uploads nothing and is not a physical Pencil test.
+  On this host installed headless-shell1223 works; full Chrome timed out with
+  `CVDisplayLinkCreateWithCGDisplay -6670` and is not counted as passing evidence.
+- Web/desktop builds and typechecks plus web lint validate host integration. Each
+  host injects the shared reader package against its own React peer version.
+
+Check this after separately approved server/store setup: create handwriting,
+typed notes, corrected speakers and summaries on iPad; read them in web/desktop;
+select a retained version, exercise a concurrent edit and Trash/restore; reopen
+on iPad and confirm original editing/history remains. Verify a wrong-account
+preview returns no bytes and audio remains explicitly unavailable. Actual physical
+mixed-client/private-provider QA remains unperformed. Source and synthetic tests
+do not make this issue complete or released.

--- a/apps/web/lib/mobile-reader.ts
+++ b/apps/web/lib/mobile-reader.ts
@@ -1,0 +1,91 @@
+import { decodeReaderCursor, encodeReaderCursor } from "./reader-cursor";
+import {
+  getDb,
+  readerAvailable,
+  listReaderNotes,
+  readerDetail,
+  readerAction,
+  type Db,
+} from "@repo/db";
+import { handlePrivateInk } from "./private-ink";
+import { privateInkEnabled, privateInkStore } from "./private-ink-store";
+import { readBoundedJSON, syncV2Enabled } from "./sync-v2";
+export const readerHeaders = {
+  "Cache-Control": "private, no-store, max-age=0",
+  Vary: "Authorization, Cookie",
+  "X-Content-Type-Options": "nosniff",
+};
+export const readerError = (status: number, error: string) =>
+  Response.json({ error }, { status, headers: readerHeaders });
+export async function handleMobileReader(
+  request: Request,
+  organizationId: string,
+  db: Db = getDb(),
+) {
+  if (!syncV2Enabled()) return readerError(404, "reader_unavailable");
+  try {
+    encodeReaderCursor(organizationId, undefined, "0");
+    if (!(await readerAvailable(db)))
+      return readerError(503, "reader_unavailable");
+    const q = new URL(request.url).searchParams;
+    if (request.method === "GET" && q.get("mode") === "preview") {
+      if (!privateInkEnabled()) return readerError(503, "preview_unavailable");
+      if (q.get("part") !== "preview")
+        return readerError(400, "invalid_request");
+      const response = await handlePrivateInk(
+        request,
+        db,
+        organizationId,
+        privateInkStore(),
+      );
+      for (const [key, value] of Object.entries(readerHeaders))
+        response.headers.set(key, value);
+      return response;
+    }
+    if (request.method === "POST")
+      return Response.json(
+        await readerAction(db, organizationId, await readBoundedJSON(request)),
+        { headers: readerHeaders },
+      );
+    if (request.method !== "GET") return readerError(405, "invalid_method");
+    const after = q.get("after")
+      ? decodeReaderCursor(
+          organizationId,
+          q.get("noteId") ?? undefined,
+          q.get("after")!,
+        )
+      : undefined;
+    const result = q.has("noteId")
+      ? await readerDetail(
+          db,
+          organizationId,
+          q.get("noteId")!,
+          q.get("revisionId") ?? undefined,
+          after,
+        )
+      : await listReaderNotes(db, organizationId, after);
+    if (result?.next)
+      result.next = encodeReaderCursor(
+        organizationId,
+        q.get("noteId") ?? undefined,
+        result.next,
+      );
+    return result
+      ? Response.json(result, { headers: readerHeaders })
+      : readerError(404, "note_unavailable");
+  } catch (error) {
+    const invalid =
+      error instanceof Error &&
+      [
+        "invalid_action",
+        "invalid_id",
+        "invalid_cursor",
+        "invalid_body",
+        "payload_limit",
+      ].includes(error.message);
+    return readerError(
+      invalid ? 400 : 503,
+      invalid ? "request_rejected" : "reader_unavailable",
+    );
+  }
+}

--- a/apps/web/lib/reader-cursor.ts
+++ b/apps/web/lib/reader-cursor.ts
@@ -1,0 +1,43 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+function key() {
+  const value = process.env.DOODLENOTE_SYNC_CURSOR_SECRET;
+  if (!value || value.length < 32) throw new Error("reader_configuration");
+  return value;
+}
+export function encodeReaderCursor(
+  org: string,
+  note: string | undefined,
+  after: string,
+) {
+  const data = Buffer.from(
+    JSON.stringify({ v: 1, org, scope: note ?? "list", after }),
+  ).toString("base64url");
+  return (
+    data + "." + createHmac("sha256", key()).update(data).digest("base64url")
+  );
+}
+export function decodeReaderCursor(
+  org: string,
+  note: string | undefined,
+  cursor: string,
+) {
+  if (cursor.length > 1000) throw new Error("invalid_cursor");
+  const [data, signature, ...extra] = cursor.split(".");
+  const expected = createHmac("sha256", key()).update(data).digest(),
+    actual = Buffer.from(signature ?? "", "base64url");
+  if (
+    extra.length ||
+    actual.length !== expected.length ||
+    !timingSafeEqual(actual, expected)
+  )
+    throw new Error("invalid_cursor");
+  const value = JSON.parse(Buffer.from(data, "base64url").toString());
+  if (
+    value.v !== 1 ||
+    value.org !== org ||
+    value.scope !== (note ?? "list") ||
+    typeof value.after !== "string"
+  )
+    throw new Error("invalid_cursor");
+  return value.after as string;
+}

--- a/apps/web/lib/reader-session.ts
+++ b/apps/web/lib/reader-session.ts
@@ -1,0 +1,31 @@
+import { readerError } from "./mobile-reader";
+export interface ReaderSession {
+  userId: string;
+  activeOrganizationId: string;
+  organizationIds: string[];
+}
+/** Membership and entitlement are resolved by server callbacks, never request JSON. */
+export async function handleSessionReader(
+  request: Request,
+  dependencies: {
+    session: () => Promise<ReaderSession | null>;
+    entitled: (userId: string) => Promise<boolean>;
+    read: (organizationId: string) => Promise<Response>;
+  },
+) {
+  if (
+    request.method === "POST" &&
+    request.headers.get("origin") !== new URL(request.url).origin
+  )
+    return readerError(403, "request_rejected");
+  const session = await dependencies.session();
+  if (!session) return readerError(401, "sign_in_required");
+  if (!(await dependencies.entitled(session.userId)))
+    return readerError(402, "sync_subscription_required");
+  const org =
+    new URL(request.url).searchParams.get("organizationId") ??
+    session.activeOrganizationId;
+  if (!session.organizationIds.includes(org))
+    return readerError(404, "workspace_unavailable");
+  return dependencies.read(org);
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -17,7 +17,7 @@ const nextConfig: NextConfig = {
    */
   distDir: process.env.NEXT_DIST_DIR || ".next",
   /** @repo/db ships raw TypeScript — let Next transpile it. */
-  transpilePackages: ["@repo/db", "@repo/agent-contract"],
+  transpilePackages: ["@repo/db", "@repo/agent-contract", "@repo/cloud-reader"],
   /**
    * PGlite loads its WASM/data payloads relative to the module on disk, so it
    * must stay a native `require` instead of being bundled into the server

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,8 @@
     "react-dom": "19.2.4",
     "react-markdown": "^10.1.0",
     "server-only": "^0.0.1",
-    "stripe": "^22.3.0"
+    "stripe": "^22.3.0",
+    "@repo/cloud-reader": "workspace:*"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -33,5 +34,10 @@
     "tailwindcss": "^4",
     "tsx": "^4.23.0",
     "typescript": "^5"
+  },
+  "dependenciesMeta": {
+    "@repo/cloud-reader": {
+      "injected": true
+    }
   }
 }

--- a/apps/web/tests/mobile-reader.test.ts
+++ b/apps/web/tests/mobile-reader.test.ts
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+import { createInMemoryDb } from "@repo/db/testing";
+import { sql, applySync } from "@repo/db";
+import { handleMobileReader } from "../lib/mobile-reader";
+import { encodeReaderCursor, decodeReaderCursor } from "../lib/reader-cursor";
+test("reader cursor cannot cross workspace, note, or list scope", () => {
+  process.env.DOODLENOTE_SYNC_CURSOR_SECRET =
+    "synthetic-reader-key-with-at-least-32-chars";
+  const note = randomUUID(),
+    cursor = encodeReaderCursor("a", note, "42");
+  assert.equal(decodeReaderCursor("a", note, cursor), "42");
+  assert.throws(() => decodeReaderCursor("b", note, cursor));
+  assert.throws(() => decodeReaderCursor("a", undefined, cursor));
+  assert.throws(() => decodeReaderCursor("a", randomUUID(), cursor));
+  assert.throws(() => decodeReaderCursor("a", note, cursor + "tampered"));
+});
+test("reader is old-schema safe, private, and denies unauthenticated bearer access", async () => {
+  delete process.env.DOODLENOTE_SYNC_V2_ENABLED;
+  const { GET } = await import("../app/api/sync/reader/route");
+  const request = new Request("http://localhost/api/sync/reader");
+  assert.equal((await GET(request)).status, 404);
+  process.env.DOODLENOTE_SYNC_V2_ENABLED = "true";
+  assert.equal((await GET(request)).status, 401);
+  const old = await createInMemoryDb({ throughMigration: 14 });
+  try {
+    assert.equal((await handleMobileReader(request, "a", old.db)).status, 503);
+  } finally {
+    await old.close();
+  }
+});
+test("reader known fields coexist with retained unknowns; cross-workspace detail and preview cannot leak", async () => {
+  const f = await createInMemoryDb();
+  try {
+    process.env.DOODLENOTE_SYNC_V2_ENABLED = "true";
+    const { db } = f;
+    await db.execute(
+      sql`insert into organization(id,name,slug,created_at) values('a','A','a',now()),('b','B','b',now())`,
+    );
+    const source = randomUUID(),
+      note = randomUUID();
+    const op = {
+      protocolVersion: 2,
+      libraryId: randomUUID(),
+      noteId: note,
+      operationId: randomUUID(),
+      kind: "upsert",
+      expectedRevision: null,
+      expectedLifecycleGeneration: null,
+      snapshot: {
+        title: "Fixture",
+        kind: "note",
+        createdAt: "2026-09-06",
+        language: "en-US",
+        text: "Typed",
+        sourceRevisionId: source,
+        sourceVersions: [
+          {
+            id: source,
+            title: "Fixture",
+            text: "Typed",
+            passages: [],
+            speakers: [],
+          },
+        ],
+        selectedSummaryId: null,
+        passages: [],
+        speakers: [],
+        summaries: [],
+        inkAttachments: [],
+      },
+    };
+    await applySync(db, "a", op);
+    const url = `http://localhost/api/sync/reader?noteId=${note}`;
+    const response = await handleMobileReader(new Request(url), "a", db);
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("cache-control")!, /no-store/);
+    assert.match(response.headers.get("vary")!, /Cookie/);
+    assert.equal((await response.json()).snapshot.text, "Typed");
+    assert.equal(
+      (await handleMobileReader(new Request(url), "b", db)).status,
+      404,
+    );
+    const forged = await handleMobileReader(
+      new Request(url, {
+        method: "POST",
+        body: JSON.stringify({ ...op, snapshot: { text: "erase" } }),
+      }),
+      "a",
+      db,
+    );
+    assert.equal(forged.status, 400);
+    assert.doesNotMatch(await forged.text(), /select|organization|Typed/);
+    delete process.env.DOODLENOTE_PRIVATE_INK_ENABLED;
+    assert.equal(
+      (
+        await handleMobileReader(
+          new Request(url + "&mode=preview&part=preview"),
+          "a",
+          db,
+        )
+      ).status,
+      503,
+    );
+  } finally {
+    await f.close();
+  }
+});
+
+test("session reader checks authenticated membership and subscription before reading, with same-origin writes", async () => {
+  const { handleSessionReader } = await import("../lib/reader-session");
+  let reads = 0;
+  const deps = {
+    session: async () => ({
+      userId: "trusted",
+      activeOrganizationId: "a",
+      organizationIds: ["a"],
+    }),
+    entitled: async (id: string) => {
+      assert.equal(id, "trusted");
+      return true;
+    },
+    read: async (org: string) => {
+      reads++;
+      assert.equal(org, "a");
+      return Response.json({ ok: true });
+    },
+  };
+  assert.equal(
+    (
+      await handleSessionReader(
+        new Request("https://fixture.example/api?organizationId=b"),
+        deps,
+      )
+    ).status,
+    404,
+  );
+  assert.equal(reads, 0);
+  assert.equal(
+    (
+      await handleSessionReader(new Request("https://fixture.example/api"), {
+        ...deps,
+        entitled: async () => false,
+      })
+    ).status,
+    402,
+  );
+  assert.equal(reads, 0);
+  assert.equal(
+    (
+      await handleSessionReader(new Request("https://fixture.example/api"), {
+        ...deps,
+        session: async () => null,
+      })
+    ).status,
+    401,
+  );
+  assert.equal(
+    (
+      await handleSessionReader(
+        new Request("https://fixture.example/api", {
+          method: "POST",
+          headers: { origin: "https://evil.example" },
+        }),
+        deps,
+      )
+    ).status,
+    403,
+  );
+  assert.equal(reads, 0);
+  assert.equal(
+    (
+      await handleSessionReader(
+        new Request("https://fixture.example/api", {
+          method: "POST",
+          headers: { origin: "https://fixture.example" },
+        }),
+        deps,
+      )
+    ).status,
+    200,
+  );
+  assert.equal(reads, 1);
+});

--- a/packages/cloud-reader/package.json
+++ b/packages/cloud-reader/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@repo/cloud-reader",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {".": "./src/Reader.tsx", "./types": "./src/types.ts"},
+  "peerDependencies": {"react": "^19"},
+  "devDependencies": {"@types/react": "^19"}
+}

--- a/packages/cloud-reader/scripts/browser-smoke.mjs
+++ b/packages/cloud-reader/scripts/browser-smoke.mjs
@@ -1,0 +1,18 @@
+import {createRequire} from 'node:module';
+import {mkdtemp,writeFile,rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {spawnSync} from 'node:child_process';
+const root=path.resolve(path.dirname(fileURLToPath(import.meta.url)),'../../..');
+const require=createRequire(path.join(root,'apps/desktop/package.json'));
+const esbuild=require(require.resolve('esbuild',{paths:[require.resolve('tsx')]}));
+const temporary=await mkdtemp(path.join(tmpdir(),'dn-reader-'));
+try{
+ await esbuild.build({entryPoints:[path.join(root,'packages/cloud-reader/tests/browser-fixture.tsx')],bundle:true,jsx:'automatic',platform:'browser',outfile:path.join(temporary,'fixture.js'),alias:{'react/jsx-runtime':require.resolve('react/jsx-runtime'),'react/jsx-dev-runtime':require.resolve('react/jsx-dev-runtime'),react:require.resolve('react'),'react-dom/client':require.resolve('react-dom/client')},define:{'process.env.NODE_ENV':'"development"'}});
+ await writeFile(path.join(temporary,'index.html'),'<!doctype html><html><head><meta charset="utf-8"><title>Controlled reader fixture</title></head><body><div id="root"></div><script src="fixture.js"></script></body></html>');
+ const chrome=process.env.BROWSER_BIN??'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+ const result=spawnSync(chrome,['--headless=new','--no-first-run','--disable-gpu','--disable-background-networking','--disable-extensions','--disable-component-update',`--user-data-dir=${path.join(temporary,'profile')}`,'--virtual-time-budget=10000','--dump-dom',`file://${path.join(temporary,'index.html')}`],{encoding:'utf8',timeout:60000,maxBuffer:5*1024*1024});
+ if(result.error||result.status!==0||!result.stdout.includes('data-test-status="passed"'))throw new Error('Browser fixture failed: '+(result.error??result.stdout.slice(-2000))+' '+result.stderr.slice(-1500));
+ console.log('PASS: browser renders typed notes, named speakers, selected summary/private preview, version selection, Trash, restore and stale-workspace response rejection. Synthetic fixture only.');
+}finally{await rm(temporary,{recursive:true,force:true});}

--- a/packages/cloud-reader/src/Reader.tsx
+++ b/packages/cloud-reader/src/Reader.tsx
@@ -1,0 +1,438 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import type {
+  ReaderAction,
+  ReaderDetail,
+  ReaderNote,
+  ReaderTransport,
+} from "./types";
+const object = (value: unknown): Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+const text = (value: unknown, fallback = "") =>
+  typeof value === "string" ? value : fallback;
+const array = (value: unknown) => (Array.isArray(value) ? value : []);
+const panel = {
+  padding: 16,
+  border: "1px solid #a8a29e",
+  borderRadius: 10,
+  marginBottom: 12,
+};
+function Preview({
+  transport,
+  note,
+  revision,
+  version,
+}: {
+  transport: ReaderTransport;
+  note: ReaderNote;
+  revision: string;
+  version: string;
+}) {
+  const [url, setUrl] = useState<string>();
+  const [error, setError] = useState(false);
+  useEffect(() => {
+    setUrl(undefined);
+    setError(false);
+    let active = true;
+    let local: string | undefined;
+    transport
+      .preview(note, revision, version)
+      .then((bytes) => {
+        if (!active) return;
+        local = URL.createObjectURL(
+          new Blob([new Uint8Array(bytes)], { type: "image/png" }),
+        );
+        setUrl(local);
+      })
+      .catch(() => {
+        if (active) setError(true);
+      });
+    return () => {
+      active = false;
+      if (local) URL.revokeObjectURL(local);
+    };
+  }, [transport, note, revision, version]);
+  return error ? (
+    <p role="status">Preview unavailable. Reopen this note to retry.</p>
+  ) : url ? (
+    <img
+      src={url}
+      alt="Handwritten note preview"
+      style={{ maxWidth: "100%", maxHeight: 600 }}
+    />
+  ) : (
+    <p role="status">Loading private preview…</p>
+  );
+}
+/** Renders known fields only; mutation never serializes this display projection. */
+export function Reader({ transport }: { transport: ReaderTransport }) {
+  const [notes, setNotes] = useState<ReaderNote[]>([]),
+    [next, setNext] = useState<string | null>(null);
+  const [detail, setDetail] = useState<ReaderDetail | null>(null),
+    [status, setStatus] = useState("Loading cloud notes…");
+  const [busy, setBusy] = useState(false),
+    [confirmPurge, setConfirmPurge] = useState(false);
+  const request = useRef(0),
+    pending = useRef<ReaderAction | null>(null);
+  const refresh = async () => {
+    const seq = ++request.current;
+    setBusy(true);
+    setDetail(null);
+    setStatus("Loading cloud notes…");
+    try {
+      const result = await transport.list();
+      if (seq !== request.current) return;
+      setNotes(result.notes);
+      setNext(result.next);
+      setStatus(
+        result.notes.length ? "" : "No mobile notes in this workspace.",
+      );
+    } catch (e) {
+      if (seq === request.current) {
+        setNotes([]);
+        setStatus(e instanceof Error ? e.message : "Cloud notes unavailable.");
+      }
+    } finally {
+      if (seq === request.current) setBusy(false);
+    }
+  };
+  useEffect(() => {
+    pending.current = null;
+    void refresh();
+    return () => {
+      request.current++;
+    };
+  }, [transport]); // transport identity is stable in each host
+  const open = async (noteId: string, revisionId?: string) => {
+    const seq = ++request.current;
+    setBusy(true);
+    setDetail(null);
+    setConfirmPurge(false);
+    setStatus("Loading note…");
+    try {
+      const result = await transport.detail({ noteId, revisionId });
+      if (seq !== request.current) return;
+      setDetail(result);
+      setStatus("");
+      pending.current = null;
+    } catch (e) {
+      if (seq === request.current)
+        setStatus(e instanceof Error ? e.message : "Note unavailable.");
+    } finally {
+      if (seq === request.current) setBusy(false);
+    }
+  };
+  const perform = async (kind: ReaderAction["kind"]) => {
+    if (!detail || busy) return;
+    const seq = ++request.current;
+    const n = detail.note;
+    const value: ReaderAction = {
+      kind,
+      libraryId: n.libraryId,
+      noteId: n.id,
+      operationId: pending.current?.operationId ?? crypto.randomUUID(),
+      expectedRevision: n.headRevision,
+      expectedLifecycleGeneration: n.generation,
+      ...(kind === "choose"
+        ? { selectedRevision: detail.selectedRevision! }
+        : {}),
+      ...((kind === "restore" || kind === "purge") && n.deletionId
+        ? { deletionId: n.deletionId }
+        : {}),
+    };
+    if (pending.current && pending.current.kind !== kind)
+      value.operationId = crypto.randomUUID();
+    pending.current = value;
+    setBusy(true);
+    try {
+      const receipt = await transport.action(value);
+      if (seq !== request.current) return;
+      if (receipt.status !== "ok") {
+        pending.current = null;
+        setDetail(null);
+        setStatus(
+          "This note changed or is no longer available. Refresh before trying again.",
+        );
+        return;
+      }
+      pending.current = null;
+      setConfirmPurge(false);
+      await refresh();
+    } catch (e) {
+      if (seq === request.current)
+        setStatus(
+          e instanceof Error ? e.message : "Request failed. Retry is safe.",
+        );
+    } finally {
+      if (seq === request.current) setBusy(false);
+    }
+  };
+  const snapshot = object(detail?.snapshot);
+  const speakers = new Map(
+    array(snapshot.speakers).map((value) => {
+      const s = object(value);
+      return [text(s.id), text(s.displayName, "Speaker")];
+    }),
+  );
+  const summaries = array(snapshot.summaries).map(object);
+  const summary = summaries.find((s) => s.id === snapshot.selectedSummaryId);
+  const legacy = Boolean(snapshot.meeting) && !snapshot.sourceRevisionId;
+  return (
+    <section
+      style={{
+        padding: 24,
+        maxWidth: 1100,
+        margin: "0 auto",
+        width: "100%",
+        boxSizing: "border-box",
+      }}
+      aria-label="Mobile cloud notes"
+    >
+      <h1>Mobile cloud notes</h1>
+      <p>
+        Read notes from this linked workspace. Recording audio remains on the
+        device that captured it.
+      </p>
+      <button onClick={() => void refresh()} disabled={busy}>
+        Refresh
+      </button>
+      {status && <p role="status">{status}</p>}
+      <div
+        style={{ display: "flex", flexWrap: "wrap", gap: 20, marginTop: 16 }}
+      >
+        <nav aria-label="Cloud note list" style={{ flex: "1 1 230px" }}>
+          <ul style={{ listStyle: "none", padding: 0 }}>
+            {notes.map((n) => (
+              <li key={n.id} style={{ marginBottom: 8 }}>
+                <button
+                  onClick={() => void open(n.id)}
+                  disabled={busy}
+                  style={{ width: "100%", textAlign: "left", padding: 10 }}
+                >
+                  {n.title} {n.state === "trashed" ? "(Trash)" : ""}
+                </button>
+              </li>
+            ))}
+          </ul>
+          {next && (
+            <button
+              disabled={busy}
+              onClick={async () => {
+                const seq = ++request.current;
+                setBusy(true);
+                try {
+                  const more = await transport.list(next);
+                  if (seq !== request.current) return;
+                  setNotes((old) => [
+                    ...old,
+                    ...more.notes.filter(
+                      (n) => !old.some((o) => o.id === n.id),
+                    ),
+                  ]);
+                  setNext(more.next);
+                } catch {
+                  if (seq === request.current)
+                    setStatus("Could not load more notes. Retry.");
+                } finally {
+                  if (seq === request.current) setBusy(false);
+                }
+              }}
+            >
+              More notes
+            </button>
+          )}
+        </nav>
+        {detail && (
+          <article
+            style={{ flex: "3 1 450px", minWidth: 0 }}
+            aria-label="Selected note"
+          >
+            <h2>{detail.note.title}</h2>
+            <p role="note">
+              Text and Pencil editing are not supported here. Original fields
+              and all retained versions stay in the cloud. Use the mobile app to
+              edit.
+            </p>
+            <p>
+              State: {detail.note.state}
+              {detail.note.expiresAt
+                ? ` · Recoverable until ${new Date(detail.note.expiresAt).toLocaleString()}`
+                : ""}
+            </p>
+            <label>
+              Retained version{" "}
+              <select
+                disabled={busy}
+                value={detail.selectedRevision ?? ""}
+                onChange={(e) => void open(detail.note.id, e.target.value)}
+              >
+                {detail.selectedRevision &&
+                  !detail.versions.some(
+                    (v) => v.id === detail.selectedRevision,
+                  ) && (
+                    <option value={detail.selectedRevision}>
+                      Selected older version
+                    </option>
+                  )}
+                {detail.versions.map((v) => (
+                  <option key={v.id} value={v.id}>
+                    {new Date(v.createdAt).toLocaleString()} · {v.kind}
+                    {v.id === detail.note.contentRevision ? " · current" : ""}
+                  </option>
+                ))}
+              </select>
+            </label>
+            {detail.next && (
+              <button
+                disabled={busy}
+                onClick={async () => {
+                  const seq = ++request.current;
+                  setBusy(true);
+                  try {
+                    const more = await transport.detail({
+                      noteId: detail.note.id,
+                      revisionId: detail.selectedRevision ?? undefined,
+                      after: detail.next!,
+                    });
+                    if (seq !== request.current) return;
+                    setDetail({
+                      ...detail,
+                      versions: [...detail.versions, ...more.versions],
+                      next: more.next,
+                    });
+                  } catch {
+                    if (seq === request.current)
+                      setStatus("History unavailable. Retry.");
+                  } finally {
+                    if (seq === request.current) setBusy(false);
+                  }
+                }}
+              >
+                Older versions
+              </button>
+            )}
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 8,
+                margin: "12px 0",
+              }}
+            >
+              {detail.note.state === "active" ? (
+                <>
+                  <button
+                    disabled={
+                      busy ||
+                      legacy ||
+                      detail.selectedRevision === detail.note.contentRevision
+                    }
+                    onClick={() => void perform("choose")}
+                  >
+                    Use selected version
+                  </button>
+                  <button disabled={busy} onClick={() => void perform("trash")}>
+                    Move to Trash
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    disabled={busy}
+                    onClick={() => void perform("restore")}
+                  >
+                    Restore note
+                  </button>
+                  <button disabled={busy} onClick={() => setConfirmPurge(true)}>
+                    Delete permanently…
+                  </button>
+                </>
+              )}
+            </div>
+            {confirmPurge && (
+              <div role="alert" style={panel}>
+                <p>
+                  Permanently delete this cloud note and all its versions and
+                  handwriting? This cannot be undone.
+                </p>
+                <button disabled={busy} onClick={() => void perform("purge")}>
+                  Confirm permanent deletion
+                </button>{" "}
+                <button onClick={() => setConfirmPurge(false)}>Cancel</button>
+              </div>
+            )}
+            {legacy ? (
+              <p>
+                This retained desktop version uses an older format. It is
+                preserved; reopen it in its original client. It cannot replace a
+                mobile version here.
+              </p>
+            ) : (
+              <>
+                <section style={panel}>
+                  <h3>Personal notes</h3>
+                  <pre
+                    style={{ whiteSpace: "pre-wrap", fontFamily: "inherit" }}
+                  >
+                    {text(snapshot.text, "No personal notes.")}
+                  </pre>
+                </section>
+                <section style={panel}>
+                  <h3>Selected summary</h3>
+                  <pre
+                    style={{ whiteSpace: "pre-wrap", fontFamily: "inherit" }}
+                  >
+                    {summary ? text(summary.markdown) : "No selected summary."}
+                  </pre>
+                </section>
+                <section style={panel}>
+                  <h3>Transcript</h3>
+                  <p>
+                    Audio playback is unavailable here; audio is not synced.
+                  </p>
+                  {array(snapshot.passages).map((value, i) => {
+                    const p = object(value);
+                    return (
+                      <p key={text(p.id, String(i))}>
+                        <strong>
+                          {speakers.get(text(p.speakerId)) ??
+                            "Unidentified speaker"}
+                        </strong>
+                        {typeof p.startMs === "number"
+                          ? ` (${Math.floor(p.startMs / 60000)}:${String(Math.floor(p.startMs / 1000) % 60).padStart(2, "0")})`
+                          : ""}
+                        <br />
+                        {text(p.text)}
+                      </p>
+                    );
+                  })}
+                </section>
+                <section style={panel}>
+                  <h3>Handwriting</h3>
+                  {array(snapshot.inkAttachments).length === 0 ? (
+                    <p>No handwriting.</p>
+                  ) : (
+                    array(snapshot.inkAttachments).map((value) => {
+                      const v = object(value);
+                      return (
+                        <Preview
+                          key={`${detail.selectedRevision}:${text(v.versionId)}`}
+                          transport={transport}
+                          note={detail.note}
+                          revision={detail.selectedRevision!}
+                          version={text(v.versionId)}
+                        />
+                      );
+                    })
+                  )}
+                </section>
+              </>
+            )}
+          </article>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/cloud-reader/src/types.ts
+++ b/packages/cloud-reader/src/types.ts
@@ -1,0 +1,48 @@
+export interface ReaderNote {
+  id: string;
+  libraryId: string;
+  title: string;
+  state: "active" | "trashed" | "purged";
+  contentRevision: string | null;
+  headRevision: string;
+  generation: string;
+  deletionId: string | null;
+  expiresAt: string | null;
+}
+export interface ReaderVersion {
+  id: string;
+  kind: string;
+  createdAt: string;
+}
+export interface ReaderDetail {
+  note: ReaderNote;
+  versions: ReaderVersion[];
+  next: string | null;
+  selectedRevision: string | null;
+  snapshot: unknown;
+}
+export interface ReaderAction {
+  kind: "choose" | "trash" | "restore" | "purge";
+  libraryId: string;
+  noteId: string;
+  operationId: string;
+  expectedRevision: string;
+  expectedLifecycleGeneration: string;
+  selectedRevision?: string;
+  deletionId?: string;
+}
+export interface ReaderQuery {
+  noteId?: string;
+  revisionId?: string;
+  after?: string;
+}
+export interface ReaderTransport {
+  list(after?: string): Promise<{ notes: ReaderNote[]; next: string | null }>;
+  detail(query: ReaderQuery): Promise<ReaderDetail>;
+  action(value: ReaderAction): Promise<{ status: string }>;
+  preview(
+    note: ReaderNote,
+    revision: string,
+    version: string,
+  ): Promise<Uint8Array>;
+}

--- a/packages/cloud-reader/tests/browser-fixture.tsx
+++ b/packages/cloud-reader/tests/browser-fixture.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {createRoot} from 'react-dom/client';
+import {Reader} from '../src/Reader';
+import type {ReaderTransport,ReaderNote} from '../src/types';
+const note:ReaderNote={id:'note',libraryId:'library',title:'Synthetic design meeting',state:'active',headRevision:'current',contentRevision:'current',generation:'generation',deletionId:null,expiresAt:null};
+const calls:string[]=[];
+const transport:ReaderTransport={
+ list:async()=>({notes:[{...note}],next:null}),
+ detail:async q=>({note:{...note},versions:[{id:'current',kind:'upsert',createdAt:'2026-09-06T10:00:00Z'},{id:'alternate',kind:'conflict',createdAt:'2026-09-06T09:00:00Z'}],next:null,selectedRevision:q.revisionId??'current',snapshot:{text:'Typed notes are preserved.',selectedSummaryId:'summary',summaries:[{id:'summary',markdown:'Selected summary remains readable.'}],speakers:[{id:'a',displayName:'Avery'},{id:'b',displayName:'Morgan'}],passages:[{id:'p1',speakerId:'a',startMs:0,text:'Discuss the project.'},{id:'p2',speakerId:'b',startMs:12000,text:'Keep the original handwriting.'}],inkAttachments:[{id:'ink',versionId:'version'}],future:{opaque:'preserved only server side'}}}),
+ action:async value=>{calls.push(value.kind);if(value.kind==='trash'){note.state='trashed';note.deletionId='deletion';}if(value.kind==='restore'){note.state='active';note.deletionId=null;}return {status:'ok'};},
+ preview:async()=>Uint8Array.from(atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGD4DwABBAEAX+XDSwAAAABJRU5ErkJggg=='),c=>c.charCodeAt(0)),
+};
+const root=createRoot(document.getElementById('root')!);root.render(<Reader transport={transport}/>);
+async function until(condition:()=>boolean){for(let i=0;i<100;i++){if(condition())return;await new Promise(r=>setTimeout(r,20));}throw new Error('Timed out waiting for reader');}
+function click(label:string){const button=[...document.querySelectorAll('button')].find(b=>b.textContent?.includes(label));if(!button)throw new Error('Missing '+label);button.click();}
+async function run(){
+ await until(()=>document.body.textContent?.includes(note.title)===true);click(note.title);
+ await until(()=>document.body.textContent?.includes('Avery')===true);
+ for(const value of ['Morgan','Typed notes are preserved.','Selected summary remains readable.','Audio playback is unavailable','Text and Pencil editing are not supported'])if(!document.body.textContent?.includes(value))throw new Error('Missing '+value);
+ await until(()=>Boolean(document.querySelector('img[src^="blob:"]')));
+ const select=document.querySelector('select')!;select.value='alternate';select.dispatchEvent(new Event('change',{bubbles:true}));
+ await until(()=>document.querySelector<HTMLSelectElement>('select')?.value==='alternate');click('Use selected version');await until(()=>calls.includes('choose'));
+ await until(()=>!document.querySelector('article'));click(note.title);await until(()=>Boolean(document.querySelector('article')));click('Move to Trash');await until(()=>calls.includes('trash'));
+ await until(()=>!document.querySelector('article'));click(note.title);await until(()=>document.body.textContent?.includes('State: trashed')===true);click('Restore note');await until(()=>calls.includes('restore'));
+ await until(()=>!document.querySelector('article'));click(note.title);await until(()=>document.body.textContent?.includes('Avery')===true);
+ const selectAgain=document.querySelector('select')!;selectAgain.value='alternate';selectAgain.dispatchEvent(new Event('change',{bubbles:true}));
+ await until(()=>document.querySelector<HTMLSelectElement>('select')?.value==='alternate');
+ let finish:((value:{status:string})=>void)|undefined;
+ transport.action=()=>new Promise(resolve=>{finish=resolve;});click('Use selected version');await until(()=>Boolean(finish));
+ const newTransport:ReaderTransport={...transport,list:async()=>({notes:[{...note,id:'new',title:'New workspace note'}],next:null})};
+ root.render(<Reader transport={newTransport}/>);await until(()=>document.body.textContent?.includes('New workspace note')===true);
+ finish!({status:'ok'});await new Promise(resolve=>setTimeout(resolve,50));
+ if(document.body.textContent?.includes('Synthetic design meeting'))throw new Error('Old workspace response escaped');
+ document.body.dataset.testStatus='passed';document.body.dataset.actions=calls.join(',');
+}
+run().catch(error=>{document.body.dataset.testStatus='failed';const p=document.createElement('p');p.textContent=String(error);document.body.append(p);});

--- a/packages/db/drizzle/0015_mobile_readers.sql
+++ b/packages/db/drizzle/0015_mobile_readers.sql
@@ -1,0 +1,57 @@
+-- Server-side selection copies immutable JSON verbatim, including future fields.
+CREATE FUNCTION sync_choose_revision(org text, operation jsonb, operation_hash text)
+RETURNS jsonb LANGUAGE plpgsql AS $$
+DECLARE
+  n sync_notes;
+  previous sync_operations;
+  selected sync_revisions;
+  revision uuid := gen_random_uuid();
+  sequence bigint;
+  receipt jsonb;
+BEGIN
+  sequence := sync_next_sequence(org);
+  SELECT * INTO n FROM sync_notes
+    WHERE id=(operation->>'noteId')::uuid AND library_id=(operation->>'libraryId')::uuid
+      AND organization_id=org FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('status','not_found'); END IF;
+  IF n.state='purged' THEN RETURN jsonb_build_object('status','purged'); END IF;
+  SELECT * INTO previous FROM sync_operations WHERE id=(operation->>'operationId')::uuid;
+  IF FOUND THEN
+    IF previous.organization_id<>org OR previous.note_id<>n.id OR previous.payload_hash<>operation_hash THEN
+      RETURN jsonb_build_object('status','operation_reused');
+    END IF;
+    RETURN previous.receipt;
+  END IF;
+  IF n.state<>'active' OR n.lifecycle_generation<>(operation->>'expectedLifecycleGeneration')::uuid
+    OR n.head_revision IS DISTINCT FROM (operation->>'expectedRevision')::uuid THEN
+    RETURN jsonb_build_object('status','changed');
+  END IF;
+  SELECT * INTO selected FROM sync_revisions WHERE id=(operation->>'selectedRevision')::uuid
+    AND organization_id=org AND note_id=n.id AND snapshot IS NOT NULL;
+  IF NOT FOUND THEN RETURN jsonb_build_object('status','not_found'); END IF;
+  -- Legacy revisions are preserved in history but cannot masquerade as a native snapshot.
+  IF selected.kind='legacy' THEN RETURN jsonb_build_object('status','unsupported_version'); END IF;
+  INSERT INTO sync_revisions(id,note_id,organization_id,sequence,parent_id,kind,snapshot)
+    VALUES(revision,n.id,org,sequence,n.head_revision,'reconcile',selected.snapshot);
+  UPDATE sync_notes SET head_revision=revision WHERE id=n.id;
+  receipt := jsonb_build_object('status','ok','revision',revision,'headRevision',revision,
+    'lifecycleGeneration',n.lifecycle_generation,'state',n.state);
+  INSERT INTO sync_operations(id,organization_id,note_id,payload_hash,receipt)
+    VALUES((operation->>'operationId')::uuid,org,n.id,operation_hash,receipt);
+  RETURN receipt;
+END $$;
+--> statement-breakpoint
+-- Lifecycle events have no snapshot. Follow their actual parent, not the newest
+-- conflict, to find the note's selected content after Trash/restore.
+CREATE FUNCTION sync_reader_head(nid uuid) RETURNS TABLE(id uuid, snapshot jsonb)
+LANGUAGE sql STABLE AS $$
+  WITH RECURSIVE chain AS (
+    SELECT r.id,r.parent_id,r.snapshot,ARRAY[r.id] AS visited
+      FROM sync_notes n JOIN sync_revisions r ON r.id=n.head_revision
+      WHERE n.id=nid AND r.note_id=nid
+    UNION ALL
+    SELECT p.id,p.parent_id,p.snapshot,c.visited||p.id
+      FROM chain c JOIN sync_revisions p ON p.id=c.parent_id
+      WHERE c.snapshot IS NULL AND p.note_id=nid AND NOT p.id=ANY(c.visited)
+  ) SELECT chain.id,chain.snapshot FROM chain WHERE chain.snapshot IS NOT NULL LIMIT 1;
+$$;

--- a/packages/db/drizzle/meta/0015_snapshot.json
+++ b/packages/db/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,2516 @@
+{
+  "id": "e92bb9bb-8449-4b80-a0fc-54d37f574e15",
+  "prevId": "ac4ce016-9341-4d32-b13d-35d1145cf1bb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_tokens": {
+      "name": "agent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Agent'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_tokens_user_id_idx": {
+          "name": "agent_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "agent_tokens_user_id_user_id_fk": {
+          "name": "agent_tokens_user_id_user_id_fk",
+          "tableFrom": "agent_tokens",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_tokens_organization_id_organization_id_fk": {
+          "name": "agent_tokens_organization_id_organization_id_fk",
+          "tableFrom": "agent_tokens",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_tokens_token_hash_unique": {
+          "name": "agent_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_data_deletions": {
+      "name": "billing_data_deletions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_data_deletions_due_idx": {
+          "name": "billing_data_deletions_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "billing_data_deletions_user_id_user_id_fk": {
+          "name": "billing_data_deletions_user_id_user_id_fk",
+          "tableFrom": "billing_data_deletions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_notifications": {
+      "name": "billing_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_notifications_dedupe_key_uidx": {
+          "name": "billing_notifications_dedupe_key_uidx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "billing_notifications_pending_idx": {
+          "name": "billing_notifications_pending_idx",
+          "columns": [
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "billing_notifications_user_id_user_id_fk": {
+          "name": "billing_notifications_user_id_user_id_fk",
+          "tableFrom": "billing_notifications",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.folders": {
+      "name": "folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "folders_organization_id_idx": {
+          "name": "folders_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "folders_organization_id_organization_id_fk": {
+          "name": "folders_organization_id_organization_id_fk",
+          "tableFrom": "folders",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ink_cleanup": {
+      "name": "ink_cleanup",
+      "schema": "",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ink_versions": {
+      "name": "ink_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded": {
+          "name": "uploaded",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ink_versions_note_id_sync_notes_id_fk": {
+          "name": "ink_versions_note_id_sync_notes_id_fk",
+          "tableFrom": "ink_versions",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "tableTo": "sync_notes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_stars": {
+      "name": "meeting_stars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meeting_stars_meeting_user_uidx": {
+          "name": "meeting_stars_meeting_user_uidx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "meeting_stars_user_id_idx": {
+          "name": "meeting_stars_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "meeting_stars_meeting_id_meetings_id_fk": {
+          "name": "meeting_stars_meeting_id_meetings_id_fk",
+          "tableFrom": "meeting_stars",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "tableTo": "meetings",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "meeting_stars_user_id_user_id_fk": {
+          "name": "meeting_stars_user_id_user_id_fk",
+          "tableFrom": "meeting_stars",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_tag_links": {
+      "name": "meeting_tag_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meeting_tag_links_meeting_tag_uidx": {
+          "name": "meeting_tag_links_meeting_tag_uidx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "meeting_tag_links_meeting_id_idx": {
+          "name": "meeting_tag_links_meeting_id_idx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "meeting_tag_links_meeting_id_meetings_id_fk": {
+          "name": "meeting_tag_links_meeting_id_meetings_id_fk",
+          "tableFrom": "meeting_tag_links",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "tableTo": "meetings",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "meeting_tag_links_tag_id_meeting_tags_id_fk": {
+          "name": "meeting_tag_links_tag_id_meeting_tags_id_fk",
+          "tableFrom": "meeting_tag_links",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "meeting_tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_tags": {
+      "name": "meeting_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meeting_tags_organization_name_uidx": {
+          "name": "meeting_tags_organization_name_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "meeting_tags_organization_id_idx": {
+          "name": "meeting_tags_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "meeting_tags_organization_id_organization_id_fk": {
+          "name": "meeting_tags_organization_id_organization_id_fk",
+          "tableFrom": "meeting_tags",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetings": {
+      "name": "meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled meeting'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'meeting'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_expires_at": {
+          "name": "share_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_include_transcript": {
+          "name": "share_include_transcript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetings_organization_id_idx": {
+          "name": "meetings_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "meetings_organization_id_organization_id_fk": {
+          "name": "meetings_organization_id_organization_id_fk",
+          "tableFrom": "meetings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "meetings_folder_id_folders_id_fk": {
+          "name": "meetings_folder_id_folders_id_fk",
+          "tableFrom": "meetings",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "tableTo": "folders",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meetings_share_token_unique": {
+          "name": "meetings_share_token_unique",
+          "columns": [
+            "share_token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notes": {
+      "name": "notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_content": {
+          "name": "raw_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enhanced_content": {
+          "name": "enhanced_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notes_meeting_id_meetings_id_fk": {
+          "name": "notes_meeting_id_meetings_id_fk",
+          "tableFrom": "notes",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "tableTo": "meetings",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notes_meeting_id_unique": {
+          "name": "notes_meeting_id_unique",
+          "columns": [
+            "meeting_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grandfathered": {
+          "name": "grandfathered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_user_id_user_id_fk": {
+          "name": "subscriptions_user_id_user_id_fk",
+          "tableFrom": "subscriptions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_customer_id_unique": {
+          "name": "subscriptions_stripe_customer_id_unique",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "columns": [
+            "stripe_subscription_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_clocks": {
+      "name": "sync_clocks",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_clocks_organization_id_organization_id_fk": {
+          "name": "sync_clocks_organization_id_organization_id_fk",
+          "tableFrom": "sync_clocks",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_devices": {
+      "name": "sync_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Desktop'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_devices_user_id_idx": {
+          "name": "sync_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sync_devices_user_id_user_id_fk": {
+          "name": "sync_devices_user_id_user_id_fk",
+          "tableFrom": "sync_devices",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "sync_devices_organization_id_organization_id_fk": {
+          "name": "sync_devices_organization_id_organization_id_fk",
+          "tableFrom": "sync_devices",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sync_devices_token_hash_unique": {
+          "name": "sync_devices_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_libraries": {
+      "name": "sync_libraries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_libraries_organization_id_organization_id_fk": {
+          "name": "sync_libraries_organization_id_organization_id_fk",
+          "tableFrom": "sync_libraries",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_notes": {
+      "name": "sync_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_revision": {
+          "name": "head_revision",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_generation": {
+          "name": "lifecycle_generation",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "deletion_id": {
+          "name": "deletion_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_notes_library_id_sync_libraries_id_fk": {
+          "name": "sync_notes_library_id_sync_libraries_id_fk",
+          "tableFrom": "sync_notes",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "tableTo": "sync_libraries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "sync_notes_organization_id_organization_id_fk": {
+          "name": "sync_notes_organization_id_organization_id_fk",
+          "tableFrom": "sync_notes",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_operations": {
+      "name": "sync_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt": {
+          "name": "receipt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_operations_organization_id_organization_id_fk": {
+          "name": "sync_operations_organization_id_organization_id_fk",
+          "tableFrom": "sync_operations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "sync_operations_note_id_sync_notes_id_fk": {
+          "name": "sync_operations_note_id_sync_notes_id_fk",
+          "tableFrom": "sync_operations",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "tableTo": "sync_notes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_revisions": {
+      "name": "sync_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_revisions_org_sequence": {
+          "name": "sync_revisions_org_sequence",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sync_revisions_note_id_sync_notes_id_fk": {
+          "name": "sync_revisions_note_id_sync_notes_id_fk",
+          "tableFrom": "sync_revisions",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "tableTo": "sync_notes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "sync_revisions_organization_id_organization_id_fk": {
+          "name": "sync_revisions_organization_id_organization_id_fk",
+          "tableFrom": "sync_revisions",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcript_segments": {
+      "name": "transcript_segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker": {
+          "name": "speaker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "absolute_start_ms": {
+          "name": "absolute_start_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcript_segments_meeting_id_idx": {
+          "name": "transcript_segments_meeting_id_idx",
+          "columns": [
+            {
+              "expression": "meeting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "transcript_segments_meeting_id_meetings_id_fk": {
+          "name": "transcript_segments_meeting_id_meetings_id_fk",
+          "tableFrom": "transcript_segments",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "tableTo": "meetings",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verified_caller_ids": {
+      "name": "verified_caller_ids",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "outgoing_caller_id_sid": {
+          "name": "outgoing_caller_id_sid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "verified_caller_ids_user_id_user_id_fk": {
+          "name": "verified_caller_ids_user_id_user_id_fk",
+          "tableFrom": "verified_caller_ids",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "account_issuer_accountId_uidx": {
+          "name": "account_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1788741254610,
       "tag": "0014_mean_wild_child",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1788744785745,
+      "tag": "0015_mobile_readers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/scripts/verify-sync-postgres.py
+++ b/packages/db/scripts/verify-sync-postgres.py
@@ -46,10 +46,13 @@ def main():
             journal=json.loads((ROOT/'drizzle/meta/_journal.json').read_text())['entries']
             for entry in journal:
                 migration=(ROOT/'drizzle'/f"{entry['tag']}.sql").read_text()
-                if entry['idx'] in (13,14):
+                if entry['idx'] in (13,14,15):
                     sql('BEGIN;'+migration+'ROLLBACK;')
-                    table="sync_notes" if entry["idx"]==13 else "ink_versions"
-                    assert sql(f"SELECT to_regclass('{table}') IS NULL;")=='t'
+                    if entry['idx']==15:
+                        assert sql("SELECT to_regprocedure('sync_choose_revision(text,jsonb,text)') IS NULL;")=='t'
+                    else:
+                        table="sync_notes" if entry["idx"]==13 else "ink_versions"
+                        assert sql(f"SELECT to_regclass('{table}') IS NULL;")=='t'
                     sql('BEGIN;'+migration+'COMMIT;')
                 else:
                     sql(migration)
@@ -68,6 +71,15 @@ def main():
                 outcomes=list(pool.map(lambda op:apply('a',op),edits))
             assert sorted(r['status'] for r in outcomes)==['conflict','ok'], outcomes
             assert sql(f"SELECT count(*) FROM sync_revisions WHERE note_id='{note}';")=='3'
+            current=next(r for r in outcomes if r['status']=='ok')
+            choices=[dict(kind='choose',libraryId=lib,noteId=note,operationId=uid(),
+                          expectedRevision=current['headRevision'],expectedLifecycleGeneration=first['lifecycleGeneration'],
+                          selectedRevision=first['headRevision']) for _ in range(2)]
+            def choose(op):
+                return json.loads(sql(f"SELECT sync_choose_revision('a','{json.dumps(op)}'::jsonb,'{op['operationId']}');"))
+            with concurrent.futures.ThreadPoolExecutor(2) as pool:
+                chosen=list(pool.map(choose,choices))
+            assert sorted(r['status'] for r in chosen)==['changed','ok'], chosen
             version=uid()
             manifests=[]
             for org in ('a','b'):
@@ -83,7 +95,7 @@ def main():
                 outcomes=list(pool.map(reserve,manifests))
             assert sorted(outcomes)==['pending','version_reused'], outcomes
             assert sql(f"SELECT count(*) FROM ink_versions WHERE id='{version}';")=='1'
-            print('PASS: migration rollback/reapply, cross-workspace library/version races, concurrent same-base edits preserve conflict')
+            print('PASS: migration rollback/reapply, cross-workspace library/version races, concurrent same-base edits preserve conflict and stale reader choices fail closed')
         finally:
             subprocess.run([str(BIN/'pg_ctl'), '-D', data, '-m', 'fast', '-w', 'stop'], check=True, capture_output=True)
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21,3 +21,5 @@ export * from './sync-contract';
 export * from './sync-service';
 
 export * from './ink-assets';
+
+export * from './mobile-reader';

--- a/packages/db/src/mobile-reader.test.ts
+++ b/packages/db/src/mobile-reader.test.ts
@@ -1,0 +1,355 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+import { sql } from "drizzle-orm";
+import { createInMemoryDb } from "./testing";
+import { applySync } from "./sync-service";
+import { inkRows } from "./ink-assets";
+import {
+  readerAction,
+  readerDetail,
+  listReaderNotes,
+  readerAvailable,
+} from "./mobile-reader";
+import type { SyncOperation } from "./sync-contract";
+async function fixture() {
+  const instance = await createInMemoryDb();
+  await instance.db.execute(
+    sql`insert into organization(id,name,slug,created_at) values('a','A','a',now()),('b','B','b',now())`,
+  );
+  const source = randomUUID();
+  const op: SyncOperation = {
+    protocolVersion: 2,
+    libraryId: randomUUID(),
+    noteId: randomUUID(),
+    operationId: randomUUID(),
+    expectedRevision: null,
+    expectedLifecycleGeneration: null,
+    kind: "upsert",
+    snapshot: {
+      title: "Synthetic mobile note",
+      kind: "note",
+      createdAt: "2026-09-06T00:00:00Z",
+      language: "en-US",
+      text: "Personal",
+      sourceRevisionId: source,
+      sourceVersions: [
+        {
+          id: source,
+          title: "Synthetic mobile note",
+          text: "Personal",
+          passages: [],
+          speakers: [],
+        },
+      ],
+      selectedSummaryId: null,
+      passages: [],
+      speakers: [],
+      summaries: [],
+      inkAttachments: [],
+    },
+  };
+  const receipt = (await applySync(instance.db, "a", op)) as {
+    headRevision: string;
+    lifecycleGeneration: string;
+  };
+  return { ...instance, op, receipt };
+}
+test("reader preserves unknown snapshot fields and source history while explicitly choosing a version", async () => {
+  const f = await fixture();
+  try {
+    const { db, op, receipt } = f;
+    const version = randomUUID(),
+      attachment = randomUUID();
+    await db.execute(
+      sql`insert into ink_versions(id,attachment_id,note_id,organization_id,library_id,generation,manifest,state) values(${version}::uuid,${attachment}::uuid,${op.noteId}::uuid,'a',${op.libraryId}::uuid,${receipt.lifecycleGeneration}::uuid,'{}','ready')`,
+    );
+    await db.execute(
+      sql`update sync_revisions set snapshot=jsonb_set(snapshot,'{inkAttachments}',jsonb_build_array(jsonb_build_object('id',${attachment}::text,'versionId',${version}::text))) where id=${receipt.headRevision}::uuid`,
+    );
+    await db.execute(
+      sql`update sync_revisions set snapshot=snapshot||'{"future":{"opaque":[1,{"speakerCorrection":"kept"}]}}'::jsonb where id=${receipt.headRevision}::uuid`,
+    );
+    const base = await readerDetail(db, "a", op.noteId);
+    assert.ok(base);
+    const edit = (await applySync(db, "a", {
+      ...op,
+      operationId: randomUUID(),
+      expectedRevision: receipt.headRevision,
+      expectedLifecycleGeneration: receipt.lifecycleGeneration,
+    })) as { headRevision: string };
+    const action = {
+      kind: "choose",
+      libraryId: op.libraryId,
+      noteId: op.noteId,
+      operationId: randomUUID(),
+      expectedRevision: edit.headRevision,
+      expectedLifecycleGeneration: receipt.lifecycleGeneration,
+      selectedRevision: receipt.headRevision,
+    };
+    const chosen = (await readerAction(db, "a", action)) as {
+      status: string;
+      headRevision: string;
+    };
+    assert.equal(chosen.status, "ok");
+    assert.deepEqual(await readerAction(db, "a", action), chosen);
+    const current = await readerDetail(db, "a", op.noteId);
+    assert.deepEqual(current?.snapshot, base.snapshot);
+    assert.equal(current?.versions.length, 3);
+    assert.equal(
+      (
+        (await readerAction(db, "a", {
+          ...action,
+          operationId: randomUUID(),
+        })) as { status: string }
+      ).status,
+      "changed",
+    );
+    assert.equal(
+      ((await readerAction(db, "b", action)) as { status: string }).status,
+      "not_found",
+    );
+    assert.equal(await readerDetail(db, "b", op.noteId), null);
+    assert.deepEqual((await listReaderNotes(db, "b")).notes, []);
+    await assert.rejects(
+      readerAction(db, "a", { ...action, snapshot: { text: "flatten" } }),
+      /invalid_action/,
+    );
+  } finally {
+    await f.close();
+  }
+});
+test("reader Trash/restore/purge and stale choices never resurrect snapshots", async () => {
+  const f = await fixture();
+  try {
+    const { db, op, receipt } = f;
+    const base = {
+      libraryId: op.libraryId,
+      noteId: op.noteId,
+      operationId: randomUUID(),
+      expectedRevision: receipt.headRevision,
+      expectedLifecycleGeneration: receipt.lifecycleGeneration,
+    };
+    const trash = (await readerAction(db, "a", { ...base, kind: "trash" })) as {
+      headRevision: string;
+      lifecycleGeneration: string;
+      deletionId: string;
+    };
+    assert.equal(
+      (await readerDetail(db, "a", op.noteId))?.note.state,
+      "trashed",
+    );
+    assert.equal(
+      (
+        (await readerAction(db, "a", {
+          ...base,
+          operationId: randomUUID(),
+          kind: "choose",
+          selectedRevision: receipt.headRevision,
+        })) as { status: string }
+      ).status,
+      "changed",
+    );
+    const restore = (await readerAction(db, "a", {
+      ...base,
+      operationId: randomUUID(),
+      kind: "restore",
+      expectedRevision: trash.headRevision,
+      expectedLifecycleGeneration: trash.lifecycleGeneration,
+      deletionId: trash.deletionId,
+    })) as { headRevision: string; lifecycleGeneration: string };
+    assert.equal(
+      (await readerDetail(db, "a", op.noteId))?.note.state,
+      "active",
+    );
+    const again = (await readerAction(db, "a", {
+      ...base,
+      operationId: randomUUID(),
+      kind: "trash",
+      expectedRevision: restore.headRevision,
+      expectedLifecycleGeneration: restore.lifecycleGeneration,
+    })) as typeof trash;
+    await readerAction(db, "a", {
+      ...base,
+      operationId: randomUUID(),
+      kind: "purge",
+      expectedRevision: again.headRevision,
+      expectedLifecycleGeneration: again.lifecycleGeneration,
+      deletionId: again.deletionId,
+    });
+    assert.equal(await readerDetail(db, "a", op.noteId), null);
+    assert.equal((await listReaderNotes(db, "a")).notes.length, 0);
+    assert.equal(
+      (
+        (await readerAction(db, "a", {
+          ...base,
+          kind: "choose",
+          selectedRevision: receipt.headRevision,
+        })) as { status: string }
+      ).status,
+      "purged",
+    );
+    assert.ok(
+      inkRows(
+        await db.execute(
+          sql`select snapshot from sync_revisions where note_id=${op.noteId}::uuid`,
+        ),
+      ).every((r) => r.snapshot === null),
+    );
+  } finally {
+    await f.close();
+  }
+});
+test("reader migration capability is absent on the old schema", async () => {
+  const f = await createInMemoryDb({ throughMigration: 14 });
+  try {
+    assert.equal(await readerAvailable(f.db), false);
+  } finally {
+    await f.close();
+  }
+});
+
+test("reader history paginates every retained version and rejects foreign revision selection", async () => {
+  const f = await fixture();
+  try {
+    const { db, op, receipt } = f;
+    await db.execute(
+      sql`insert into sync_revisions(note_id,organization_id,sequence,kind,snapshot) select ${op.noteId}::uuid,'a',i,'conflict',${JSON.stringify(op.snapshot)}::jsonb from generate_series(2,56) i`,
+    );
+    const first = await readerDetail(db, "a", op.noteId);
+    assert.equal(first?.versions.length, 50);
+    assert.ok(first?.next);
+    const second = await readerDetail(
+      db,
+      "a",
+      op.noteId,
+      undefined,
+      first!.next!,
+    );
+    assert.equal(second?.versions.length, 6);
+    assert.equal(
+      new Set([...first!.versions, ...second!.versions].map((v) => v.id)).size,
+      56,
+    );
+    const other = {
+      ...op,
+      libraryId: randomUUID(),
+      noteId: randomUUID(),
+      operationId: randomUUID(),
+    };
+    const foreign = (await applySync(db, "b", other)) as {
+      headRevision: string;
+    };
+    const result = (await readerAction(db, "a", {
+      kind: "choose",
+      libraryId: op.libraryId,
+      noteId: op.noteId,
+      operationId: randomUUID(),
+      expectedRevision: receipt.headRevision,
+      expectedLifecycleGeneration: receipt.lifecycleGeneration,
+      selectedRevision: foreign.headRevision,
+    })) as { status: string };
+    assert.equal(result.status, "not_found");
+  } finally {
+    await f.close();
+  }
+});
+
+test("Trash and restore display the selected head lineage, never a newer unresolved conflict", async () => {
+  const f = await fixture();
+  try {
+    const { db, op, receipt } = f;
+    const edit = {
+      ...op,
+      operationId: randomUUID(),
+      expectedRevision: receipt.headRevision,
+      expectedLifecycleGeneration: receipt.lifecycleGeneration,
+    };
+    const current = (await applySync(db, "a", edit)) as {
+      headRevision: string;
+    };
+    const conflict = (await applySync(db, "a", {
+      ...edit,
+      operationId: randomUUID(),
+    })) as { revision: string };
+    assert.notEqual(current.headRevision, conflict.revision);
+    const base = {
+      libraryId: op.libraryId,
+      noteId: op.noteId,
+      expectedRevision: current.headRevision,
+      expectedLifecycleGeneration: receipt.lifecycleGeneration,
+    };
+    const trashed = (await readerAction(db, "a", {
+      ...base,
+      kind: "trash",
+      operationId: randomUUID(),
+    })) as {
+      headRevision: string;
+      lifecycleGeneration: string;
+      deletionId: string;
+    };
+    assert.equal(
+      (await readerDetail(db, "a", op.noteId))?.selectedRevision,
+      current.headRevision,
+    );
+    await readerAction(db, "a", {
+      ...base,
+      kind: "restore",
+      operationId: randomUUID(),
+      expectedRevision: trashed.headRevision,
+      expectedLifecycleGeneration: trashed.lifecycleGeneration,
+      deletionId: trashed.deletionId,
+    });
+    const restored = await readerDetail(db, "a", op.noteId);
+    assert.equal(restored?.selectedRevision, current.headRevision);
+    assert.equal(restored?.note.contentRevision, current.headRevision);
+  } finally {
+    await f.close();
+  }
+});
+
+test("reader discards a snapshot if purge commits during the read", async () => {
+  const f = await fixture();
+  try {
+    const { db, op, receipt } = f;
+    const base = {
+      libraryId: op.libraryId,
+      noteId: op.noteId,
+      expectedRevision: receipt.headRevision,
+      expectedLifecycleGeneration: receipt.lifecycleGeneration,
+    };
+    const trash = (await readerAction(db, "a", {
+      ...base,
+      kind: "trash",
+      operationId: randomUUID(),
+    })) as {
+      headRevision: string;
+      lifecycleGeneration: string;
+      deletionId: string;
+    };
+    let count = 0;
+    const raced = new Proxy(db, {
+      get(target, key) {
+        if (key === "execute")
+          return async (query: Parameters<typeof db.execute>[0]) => {
+            const result = await target.execute(query);
+            count++;
+            if (count === 3)
+              await readerAction(db, "a", {
+                ...base,
+                kind: "purge",
+                operationId: randomUUID(),
+                expectedRevision: trash.headRevision,
+                expectedLifecycleGeneration: trash.lifecycleGeneration,
+                deletionId: trash.deletionId,
+              });
+            return result;
+          };
+        return Reflect.get(target, key);
+      },
+    });
+    assert.equal(await readerDetail(raced, "a", op.noteId), null);
+  } finally {
+    await f.close();
+  }
+});

--- a/packages/db/src/mobile-reader.ts
+++ b/packages/db/src/mobile-reader.ts
@@ -1,0 +1,147 @@
+import { createHash } from "node:crypto";
+import { sql } from "drizzle-orm";
+import type { Db } from "./client";
+import { inkId, inkRows } from "./ink-assets";
+import { canonical, validateSyncOperation } from "./sync-contract";
+import { applySync } from "./sync-service";
+export async function readerAvailable(db: Db) {
+  return Boolean(
+    inkRows(
+      await db.execute(
+        sql`select to_regprocedure('sync_choose_revision(text,jsonb,text)') is not null as available`,
+      ),
+    )[0]?.available,
+  );
+}
+function note(row: Record<string, unknown>) {
+  return {
+    id: row.id,
+    libraryId: row.library_id,
+    title: row.title ?? "Untitled note",
+    state: row.state,
+    headRevision: row.head_revision,
+    contentRevision: row.content_revision,
+    generation: row.lifecycle_generation,
+    deletionId: row.deletion_id,
+    expiresAt: row.expires_at,
+  };
+}
+export async function listReaderNotes(db: Db, org: string, after?: string) {
+  if (after) inkId(after);
+  const rows = inkRows(
+    await db.execute(sql`select n.*,h.id as content_revision,h.snapshot->>'title' as title from sync_notes n
+ left join lateral sync_reader_head(n.id) h on true
+ where n.organization_id=${org} and n.state<>'purged' and (n.state<>'trashed' or n.expires_at>now())
+ and (${after ?? null}::uuid is null or n.id>${after ?? null}::uuid) order by n.id limit 51`),
+  );
+  return {
+    notes: rows.slice(0, 50).map(note),
+    next: rows.length > 50 ? String(rows[49]!.id) : null,
+  };
+}
+export async function readerDetail(
+  db: Db,
+  org: string,
+  id: string,
+  revision?: string,
+  after?: string,
+) {
+  inkId(id);
+  if (revision) inkId(revision);
+  if (after && !/^\d{1,16}$/.test(after)) throw new Error("invalid_cursor");
+  const n = inkRows(
+    await db.execute(
+      sql`select n.*,h.id as content_revision,h.snapshot->>'title' as title from sync_notes n left join lateral sync_reader_head(n.id) h on true where n.id=${id}::uuid and n.organization_id=${org}`,
+    ),
+  )[0];
+  if (
+    !n ||
+    n.state === "purged" ||
+    (n.state === "trashed" &&
+      new Date(String(n.expires_at)).getTime() <= Date.now())
+  )
+    return null;
+  const versions = inkRows(
+    await db.execute(
+      sql`select id,kind,created_at,sequence from sync_revisions where note_id=${id}::uuid and organization_id=${org} and snapshot is not null and (${after ?? null}::bigint is null or sequence<${after ?? null}::bigint) order by sequence desc limit 51`,
+    ),
+  );
+  const selected = inkRows(
+    await db.execute(
+      sql`select id,snapshot from sync_revisions where note_id=${id}::uuid and organization_id=${org} and snapshot is not null and id=${revision ?? n.content_revision ?? null}::uuid limit 1`,
+    ),
+  )[0];
+  if (revision && !selected) return null;
+  const stillCurrent = inkRows(
+    await db.execute(sql`select id from sync_notes where id=${id}::uuid and organization_id=${org}
+    and state=${n.state} and lifecycle_generation=${n.lifecycle_generation}::uuid
+    and head_revision is not distinct from ${n.head_revision}::uuid
+    and state<>'purged' and (state<>'trashed' or expires_at>now())`),
+  );
+  if (!stillCurrent.length) return null;
+  return {
+    note: {
+      ...note(n),
+      title:
+        (selected?.snapshot as { title?: string })?.title ??
+        n.title ??
+        "Untitled note",
+    },
+    versions: versions
+      .slice(0, 50)
+      .map((v) => ({ id: v.id, kind: v.kind, createdAt: v.created_at })),
+    next: versions.length > 50 ? String(versions[49]!.sequence) : null,
+    selectedRevision: selected?.id ?? null,
+    snapshot: selected?.snapshot ?? null,
+  };
+}
+export async function readerAction(db: Db, org: string, value: unknown) {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new Error("invalid_action");
+  const a = value as Record<string, unknown>;
+  if (
+    Object.keys(a).some(
+      (k) =>
+        ![
+          "kind",
+          "libraryId",
+          "noteId",
+          "operationId",
+          "expectedRevision",
+          "expectedLifecycleGeneration",
+          "selectedRevision",
+          "deletionId",
+        ].includes(k),
+    )
+  )
+    throw new Error("invalid_action");
+  for (const key of [
+    "libraryId",
+    "noteId",
+    "operationId",
+    "expectedRevision",
+    "expectedLifecycleGeneration",
+  ])
+    inkId(a[key]);
+  if (a.kind === "choose") {
+    inkId(a.selectedRevision);
+    if (a.deletionId) throw new Error("invalid_action");
+    const serialized = canonical(a);
+    const hash = createHash("sha256").update(serialized).digest("hex");
+    return inkRows(
+      await db.execute(
+        sql`select sync_choose_revision(${org},${serialized}::jsonb,${hash}) as receipt`,
+      ),
+    )[0]!.receipt;
+  }
+  if (
+    !["trash", "restore", "purge"].includes(String(a.kind)) ||
+    a.selectedRevision
+  )
+    throw new Error("invalid_action");
+  return applySync(
+    db,
+    org,
+    validateSyncOperation({ ...a, protocolVersion: 2 }),
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       '@repo/ai':
         specifier: workspace:*
         version: link:../../packages/ai
+      '@repo/cloud-reader':
+        specifier: workspace:*
+        version: link:../../packages/cloud-reader
       '@repo/meetings-store':
         specifier: workspace:*
         version: link:../../packages/meetings-store
@@ -46,6 +49,9 @@ importers:
       sherpa-onnx-node:
         specifier: ^1.13.4
         version: 1.13.4
+    dependenciesMeta:
+      '@repo/cloud-reader':
+        injected: true
     devDependencies:
       '@electron-toolkit/eslint-config-prettier':
         specifier: ^3.0.0
@@ -132,6 +138,9 @@ importers:
       '@repo/agent-contract':
         specifier: workspace:*
         version: link:../../packages/agent-contract
+      '@repo/cloud-reader':
+        specifier: workspace:*
+        version: file:packages/cloud-reader(react@19.2.4)
       '@repo/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -159,6 +168,9 @@ importers:
       stripe:
         specifier: ^22.3.0
         version: 22.3.0(@types/node@20.19.43)
+    dependenciesMeta:
+      '@repo/cloud-reader':
+        injected: true
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -224,6 +236,16 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  packages/cloud-reader:
+    dependencies:
+      react:
+        specifier: ^19
+        version: 19.2.7
+    devDependencies:
+      '@types/react':
+        specifier: ^19
+        version: 19.2.17
 
   packages/db:
     dependencies:
@@ -1462,6 +1484,11 @@ packages:
   '@reflink/reflink@0.1.19':
     resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
     engines: {node: '>= 10'}
+
+  '@repo/cloud-reader@file:packages/cloud-reader':
+    resolution: {directory: packages/cloud-reader, type: directory}
+    peerDependencies:
+      react: ^19
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
@@ -6297,6 +6324,10 @@ snapshots:
       '@reflink/reflink-win32-arm64-msvc': 0.1.19
       '@reflink/reflink-win32-x64-msvc': 0.1.19
     optional: true
+
+  '@repo/cloud-reader@file:packages/cloud-reader(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 


### PR DESCRIPTION
## Linear Issue
- [ONY-261](https://linear.app/onyxdevlabs/issue/ONY-261/preserve-mobile-note-versions-and-ink-in-desktop-and-web-clients)

## Outcome
Desktop and web users can read mobile-created notes without flattening their ink, named speakers, summaries or retained versions. A shared reader supports explicit version selection and Trash/restore/permanent deletion. Unsupported text/Pencil editing stays read-only.

## What Changed
- Desktop sidebar and web-library reader entry points, paginated cloud note/history views, typed notes, selected summaries, named transcript speakers and authenticated private previews. Audio is explicitly unavailable because it is not synced.
- Desktop credential transport stays in the main process; session web requests independently enforce membership, entitlement and same-origin writes. No public handwriting URLs or persistent preview cache.
- Additive migration0015 copies selected snapshots verbatim under head/lifecycle preconditions, preserving unknown fields and asset references. Lifecycle-only revisions follow their actual selected content ancestry, not the newest unresolved conflict.
- Workspace/note-bound signed cursors, final concurrent-purge checks, stale-account response guards, and safe retry actions. New routes fail closed when v2 is disabled or the reader schema is unavailable.
- Shared React reader injected against each host's React peer, narrow desktop blob-image CSP support, compatibility/rollout documentation and controlled browser fixture.

## Acceptance Criteria Evidence
- [x] Display typed notes, selected summary, speaker names, private preview and no-audio state: actual headless-browser fixture plus host builds.
- [x] Preserve unknown/richer fields, immutable ink refs and all retained versions: migrated SQL tests; clients do not submit their display projection. Unsupported edits are rejected/read-only.
- [x] Explicit retained-version selection and Trash/restore/purge: database, concurrent selection and browser tests. Purged/expired/foreign/stale versions cannot resurrect content.
- [x] Bearer/session workspace and entitlement enforcement, private response caching, no token/URL exposure, disabled sync and account-switch rejection: endpoint/session/desktop tests.
- [x] Old-schema gate, existing legacy sync protection tests and minimum compatible source documentation.
- [ ] Actual iPad-create → web/desktop-read/reconcile → iPad-reopen QA and live private-provider verification remain pending. Synthetic fixtures and source builds do not prove those boundaries.

## Verification
- `pnpm --filter @repo/db test`: 24 passed, 0 failed/skipped.
- `pnpm --filter web test`: 116 passed, 0 failed/skipped.
- `pnpm --filter desktop test`: 165 passed, 6 existing environment-dependent skips, 0 failed.
- `pnpm --filter web typecheck`, `pnpm --filter desktop typecheck`, `pnpm --filter @repo/db typecheck`, web and desktop lint: passed.
- Web and desktop builds: passed.
- `python3 packages/db/scripts/verify-sync-postgres.py`: isolated local PostgreSQL migration13–15 rollback/reapply, library/version races, concurrent edits and stale reader choices passed.
- `BROWSER_BIN=/path/to/chrome-headless-shell node packages/cloud-reader/scripts/browser-smoke.mjs`: passed with installed headless-shell1223; renders content/preview and exercises version selection, Trash/restore and stale workspace mutation response. Full system Chrome failed to launch due CVDisplayLink -6670 and is not counted as a pass.
- `git diff --check`: passed. Exact head `385e0142b997ec30d7456706a29e7dccb658ba6d`: [CI checks and Windows packaging](https://github.com/Onyx-Dev-Labs/doodle-note/actions/runs/34074729329), [CodeQL](https://github.com/Onyx-Dev-Labs/doodle-note/actions/runs/34074729319), and Vercel preview all passed. Initial desktop lint failure was corrected on this same branch; local desktop lint/typecheck were rerun successfully.

## Local QA / Check this:
1. Open **Mobile cloud notes** in desktop with Cloud Sync linked/enabled, or **Mobile notes and version history** from `/app`. In an approved configured environment, select a note: expect personal notes, the selected summary, named speakers and private ink preview; audio remains unavailable.
2. Select an alternate version and use it. Refresh/reopen: expect a new current revision while both historical versions and ink references remain. Concurrent edits require refresh instead of silent overwrite.
3. Move to Trash, restore, then separately confirm permanent deletion. Expired/purged notes cannot be revived by a stale open reader or retry.
4. Disconnect/switch account, revoke entitlement or request another workspace's preview: expect no private content. Check the shared UI fixture at a narrow window and keyboard navigation; no unsupported text/Pencil editor appears.

## Risks and Release Notes
**Main merges automatically deploy web code to Vercel Production**, including the new reader links/routes. Root coordinates the user's ongoing merge authorization; this PR does not apply production migrations or enable v2/private storage. Reader endpoints remain disabled without existing v2 configuration and return controlled unavailable responses before migration0015. Private previews also require ONY-259's separately verified private store/configuration.

No native files, production database, store/permission configuration, paid resources, desktop distribution or physical-device state were changed. This branch is based on main769e6cf after PR132 landed; it contains only ONY-261 work. Open desktop PR115/117/119 collision files were avoided.

Rollback reader code while retaining ONY-259's cleanup-aware worker/schema/credentials once any private assets exist. Do not drop history/ink metadata. Migration0015 only adds functions and may remain installed during code rollback. Desktop version0.4.22 in package metadata alone is not a compatible release claim; a separately approved build containing this source is required.

## Follow-ups
Required physical mixed-client and private-provider QA remains open. ONY-262 consumes the existing native sync contract; native Pencil editing is not implemented in this reader.
