### PR TITLE
Prevent duplicate Windows updater owners and diagnose installer failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,16 @@ jobs:
       - name: Test recorder with packaged Electron runtime
         run: node apps/desktop/scripts/test-electron-runtime.cjs apps/desktop/release/win-unpacked/DoodleNote.exe
 
+      - name: Verify one Windows app instance per profile
+        shell: pwsh
+        run: |
+          $qaDirectory = Join-Path $env:RUNNER_TEMP "doodle-electron-qa"
+          npm install --prefix $qaDirectory --no-audit --no-fund --ignore-scripts playwright@1.62.1
+          if ($LASTEXITCODE -ne 0) { throw "Playwright setup failed" }
+          $env:DOODLE_PLAYWRIGHT_MODULE = Join-Path $qaDirectory "node_modules/playwright"
+          node apps/desktop/scripts/test-single-instance.cjs apps/desktop/release/win-unpacked/DoodleNote.exe
+          if ($LASTEXITCODE -ne 0) { throw "Single-instance Windows smoke failed" }
+
       - name: Smoke packaged Windows native modules
         shell: pwsh
         run: |

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "private": true,
   "description": "DoodleNote desktop app for privacy-first local capture, transcription, and AI meeting notes",
   "main": "./out/main/index.js",

--- a/apps/desktop/scripts/test-single-instance.cjs
+++ b/apps/desktop/scripts/test-single-instance.cjs
@@ -1,0 +1,51 @@
+// Uses an isolated profile; never points either process at a user's library.
+const { _electron } = require(process.env.DOODLE_PLAYWRIGHT_MODULE || 'playwright')
+const { mkdtempSync } = require('node:fs')
+const { join, resolve } = require('node:path')
+const { tmpdir } = require('node:os')
+const { spawnSync } = require('node:child_process')
+const assert = require('node:assert/strict')
+
+async function main() {
+  const executable = resolve(process.argv[2])
+  const appDirectory = process.argv[3]
+  const profile = mkdtempSync(join(tmpdir(), 'doodle-instance-qa-'))
+  const args = [...(appDirectory ? [resolve(appDirectory)] : []), `--user-data-dir=${profile}`]
+  let first, second
+  try {
+    first = await _electron.launch({ executablePath: executable, args, timeout: 30000 })
+    await first.firstWindow()
+    await first.evaluate(({ app }) => {
+      globalThis.secondInstanceCount = 0
+      app.on('second-instance', () => globalThis.secondInstanceCount++)
+    })
+    const firstPid = await first.evaluate(() => process.pid)
+    try {
+      second = await _electron.launch({ executablePath: executable, args, timeout: 10000 })
+    } catch {
+      // A losing instance exits before Playwright can attach to it.
+    }
+    assert.ok(!second, 'A second process must not open the same library and run another updater')
+    assert.equal(first.process().exitCode, null, 'The original app must remain running')
+    assert.equal(
+      await first.evaluate(() => globalThis.secondInstanceCount),
+      1,
+      'The original app must receive the second launch'
+    )
+    assert.equal(await first.evaluate(() => process.pid), firstPid)
+    console.log('Single-instance Windows launch passed')
+  } finally {
+    for (const app of [second, first]) {
+      if (app && app.process().exitCode === null)
+        spawnSync('taskkill', ['/PID', String(app.process().pid), '/T', '/F'], {
+          windowsHide: true
+        })
+    }
+  }
+}
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -117,6 +117,18 @@ if (process.env.DOODLE_USER_DATA && !app.isPackaged) {
   app.setPath('userData', process.env.DOODLE_USER_DATA)
 }
 
+// One owner per Windows profile: two mains would share the update cache and
+// could independently launch installers or write the same meeting library.
+if (process.platform === 'win32') {
+  if (!app.requestSingleInstanceLock()) app.exit(0)
+  app.on('second-instance', () => {
+    // Do not recreate a window while the installer is waiting for us to quit.
+    void app.whenReady().then(() => {
+      if (!isQuittingForUpdate()) focusMainWindow()
+    })
+  })
+}
+
 // Must run before app ready: lets <img src="doodle-media://…"> load without
 // mixed-content blocking (the dev renderer is served over http). doodle-audio
 // additionally needs stream support so <audio> can range-request recordings.

--- a/apps/desktop/src/main/update-coordinator.test.ts
+++ b/apps/desktop/src/main/update-coordinator.test.ts
@@ -2,6 +2,30 @@ import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { UpdateCoordinator } from './update-coordinator'
 
+test('an installer handoff failure preserves the download and permits one retry', async () => {
+  const controller = new UpdateCoordinator(
+    {
+      checkForUpdates: async () => ({ isUpdateAvailable: true, updateInfo: { version: '0.4.23' } }),
+      downloadUpdate: async () => ['installer.exe']
+    },
+    '0.4.22',
+    true,
+    () => {}
+  )
+  assert.equal(controller.beginInstall(), false)
+  await controller.check()
+  await new Promise<void>((resolve) => setImmediate(resolve))
+  assert.equal(controller.beginInstall(), true)
+  assert.equal(controller.state.status, 'installing')
+  assert.equal(controller.beginInstall(), false)
+  controller.installFailed()
+  assert.equal(controller.state.status, 'downloaded')
+  assert.equal(controller.state.latestVersion, '0.4.23')
+  assert.ok(controller.state.error)
+  assert.equal(controller.beginInstall(), true)
+  assert.equal(controller.state.error, undefined)
+})
+
 function deferred<T>(): {
   promise: Promise<T>
   resolve: (value: T) => void

--- a/apps/desktop/src/main/update-coordinator.ts
+++ b/apps/desktop/src/main/update-coordinator.ts
@@ -45,7 +45,8 @@ export class UpdateCoordinator<T extends { cancel(): void }> {
       !this.state.supported ||
       this.state.status === 'checking' ||
       this.download ||
-      this.state.status === 'downloaded'
+      this.state.status === 'downloaded' ||
+      this.state.status === 'installing'
     )
       return this.state
     const generation = ++this.generation
@@ -99,6 +100,20 @@ export class UpdateCoordinator<T extends { cancel(): void }> {
     this.timer = setTimeout(() => {
       this.cancel('error', 'The update download stopped responding. Please try again.')
     }, this.timeoutMs)
+  }
+
+  beginInstall(): boolean {
+    if (this.state.status !== 'downloaded') return false
+    this.set({ status: 'installing', error: undefined })
+    return true
+  }
+
+  installFailed(): void {
+    if (this.state.status !== 'installing') return
+    this.set({
+      status: 'downloaded',
+      error: 'Could not start the installer. Please try restarting to update again.'
+    })
   }
 
   progress(progress: { percent: number; transferred: number }): void {

--- a/apps/desktop/src/main/update-diagnostics.test.ts
+++ b/apps/desktop/src/main/update-diagnostics.test.ts
@@ -1,0 +1,28 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { writeUpdateDiagnostic } from './update-diagnostics'
+
+test('update diagnostics retain only version and lifecycle data and rotate a bounded log', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'update-log-test-'))
+  try {
+    const file = join(dir, 'updates.log')
+    writeUpdateDiagnostic(file, 'launch', '0.4.23', 'secret/path?token=private')
+    const entry = JSON.parse(readFileSync(file, 'utf8'))
+    assert.equal(entry.event, 'launch')
+    assert.equal(entry.version, '0.4.23')
+    assert.equal(entry.targetVersion, undefined)
+    assert.doesNotMatch(readFileSync(file, 'utf8'), /secret|private/)
+    writeFileSync(file, 'x'.repeat(512 * 1024))
+    writeUpdateDiagnostic(file, 'installer-error', '0.4.23')
+    assert.ok(existsSync(file + '.previous'))
+    assert.equal(JSON.parse(readFileSync(file, 'utf8')).event, 'installer-error')
+    assert.doesNotThrow(() =>
+      writeUpdateDiagnostic(join(dir, 'missing', 'updates.log'), 'launch', '0.4.23')
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/apps/desktop/src/main/update-diagnostics.ts
+++ b/apps/desktop/src/main/update-diagnostics.ts
@@ -1,0 +1,34 @@
+import { appendFileSync, existsSync, renameSync, rmSync, statSync } from 'node:fs'
+import type { UpdateState } from '../shared/update-api'
+
+export type UpdateDiagnosticEvent =
+  UpdateState['status'] | 'launch' | 'before-quit' | 'quit' | 'installer-error' | 'cleanup-timeout'
+
+/** Local, bounded lifecycle evidence. Never accepts paths, URLs or error messages. */
+export function writeUpdateDiagnostic(
+  file: string,
+  event: UpdateDiagnosticEvent,
+  version: string,
+  targetVersion?: string
+): void {
+  const safeVersion = (value?: string): string | undefined =>
+    value && /^\d{1,4}\.\d{1,4}\.\d{1,4}(?:-[a-zA-Z0-9.-]{1,32})?$/.test(value) ? value : undefined
+  try {
+    if (existsSync(file) && statSync(file).size >= 512 * 1024) {
+      rmSync(file + '.previous', { force: true })
+      renameSync(file, file + '.previous')
+    }
+    appendFileSync(
+      file,
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        pid: process.pid,
+        event,
+        version: safeVersion(version),
+        targetVersion: safeVersion(targetVersion)
+      }) + '\n'
+    )
+  } catch {
+    // Diagnostics must never prevent a user from updating or quitting.
+  }
+}

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -9,6 +9,9 @@ import {
 } from '../shared/update-api'
 import { applyUpdatePolicy } from './update-policy'
 import { UpdateCoordinator } from './update-coordinator'
+import { join } from 'node:path'
+import { writeUpdateDiagnostic } from './update-diagnostics'
+import type { UpdateState } from '../shared/update-api'
 
 const { autoUpdater } = updaterPkg
 
@@ -38,20 +41,40 @@ export function initAutoUpdater(
    *  normal teardown (the llama addon SIGABRTs if a model is loaded). */
   beforeInstall?: () => Promise<void>
 ): void {
+  let readyNotification: Notification | null = null
+  let previousStatus: UpdateState['status'] | undefined
+  const logFile = join(app.getPath('userData'), 'updates.log')
+  const log = (event: Parameters<typeof writeUpdateDiagnostic>[1], targetVersion?: string): void =>
+    writeUpdateDiagnostic(logFile, event, app.getVersion(), targetVersion)
+  log('launch')
+  app.on('before-quit', () => log('before-quit'))
+  app.on('quit', () => log('quit'))
   const coordinator = new UpdateCoordinator(
     autoUpdater,
     app.getVersion(),
     app.isPackaged,
     (state) => {
+      if (state.status !== previousStatus) log(state.status, state.latestVersion)
+      previousStatus = state.status
       broadcast(UPDATE_STATE_EVENT_CHANNEL, state)
-      if (state.status !== 'downloaded') return
+      if (state.status === 'installing') {
+        try {
+          readyNotification?.close()
+        } catch {
+          // A dismissed notification must not block installation.
+        }
+        readyNotification = null
+      }
+      if (state.status !== 'downloaded' || state.error) return
       try {
         if (!Notification.isSupported()) return
+        readyNotification?.close()
         const notification = new Notification({
           title: `DoodleNote ${state.latestVersion} is ready`,
           body: 'Click to restart and update now.'
         })
         notification.on('click', () => void installNow())
+        readyNotification = notification
         notification.show()
       } catch {
         // Settings still offers Restart to update.
@@ -60,17 +83,34 @@ export function initAutoUpdater(
   )
 
   const installNow = async (): Promise<void> => {
-    if (coordinator.state.status !== 'downloaded' || quittingForUpdate) return
+    if (quittingForUpdate || !coordinator.beginInstall()) return
     quittingForUpdate = true
     // The update quit must be a NORMAL quit (the installer takes over after
     // it), so the hard-exit workaround doesn't protect this path — unload
     // the model first, bounded so a hung dispose can't block the update.
+    let cleanupTimer: ReturnType<typeof setTimeout> | undefined
     try {
-      await Promise.race([beforeInstall?.(), new Promise((resolve) => setTimeout(resolve, 3_000))])
+      await Promise.race([
+        beforeInstall?.(),
+        new Promise<void>((resolve) => {
+          cleanupTimer = setTimeout(() => {
+            log('cleanup-timeout')
+            resolve()
+          }, 3_000)
+        })
+      ])
     } catch {
       // install regardless
+    } finally {
+      clearTimeout(cleanupTimer)
     }
-    autoUpdater.quitAndInstall()
+    try {
+      autoUpdater.quitAndInstall()
+    } catch {
+      log('installer-error')
+      quittingForUpdate = false
+      coordinator.installFailed()
+    }
   }
 
   ipcMain.handle(UPDATE_GET_STATE_CHANNEL, () => coordinator.state)
@@ -90,6 +130,11 @@ export function initAutoUpdater(
   autoUpdater.on('download-progress', (progress) => coordinator.progress(progress))
   autoUpdater.on('error', (error) => {
     console.error('[updater]', error.message)
+    if (coordinator.state.status === 'installing') {
+      log('installer-error')
+      quittingForUpdate = false
+      coordinator.installFailed()
+    }
   })
 
   void coordinator.check()

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -338,7 +338,9 @@ export default function ModelsView({
       case 'downloading':
         return `Downloading v${u.latestVersion ?? ''}… ${u.percent ?? 0}%`
       case 'downloaded':
-        return `v${u.latestVersion} is ready to install`
+        return u.error ?? `v${u.latestVersion} is ready to install`
+      case 'installing':
+        return 'Restarting to install the update…'
       case 'up-to-date':
         return 'You are on the latest version'
       case 'cancelled':
@@ -1014,13 +1016,16 @@ export default function ModelsView({
                         disabled={
                           checkPending ||
                           update?.supported === false ||
-                          update?.status === 'checking'
+                          update?.status === 'checking' ||
+                          update?.status === 'installing'
                         }
                         onClick={() => void checkForUpdates()}
                       >
-                        {update?.status === 'error' || update?.status === 'cancelled'
-                          ? 'Retry update'
-                          : 'Check for updates'}
+                        {update?.status === 'installing'
+                          ? 'Restarting…'
+                          : update?.status === 'error' || update?.status === 'cancelled'
+                            ? 'Retry update'
+                            : 'Check for updates'}
                       </button>
                     )}
                   </div>

--- a/apps/desktop/src/shared/update-api.ts
+++ b/apps/desktop/src/shared/update-api.ts
@@ -9,7 +9,15 @@ export interface UpdateState {
   currentVersion: string
   /** False in dev builds — the feed only serves packaged apps. */
   supported: boolean
-  status: 'idle' | 'checking' | 'up-to-date' | 'downloading' | 'downloaded' | 'cancelled' | 'error'
+  status:
+    | 'idle'
+    | 'checking'
+    | 'up-to-date'
+    | 'downloading'
+    | 'downloaded'
+    | 'installing'
+    | 'cancelled'
+    | 'error'
   /** Version on the feed when newer than current. */
   latestVersion?: string
   /** Download progress 0-100 while status is "downloading". */

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,15 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.23",
+    date: "September 7, 2026",
+    highlights: [
+      "Keep one Windows app instance in control of your library and updates",
+      "Show update restart progress and allow another attempt when the installer handoff reports an error",
+      "Add local update diagnostics to help investigate installation failures",
+    ],
+  },
+  {
     version: "0.4.22",
     date: "September 5, 2026",
     highlights: [

--- a/docs/WINDOWS-RELEASE-QA.md
+++ b/docs/WINDOWS-RELEASE-QA.md
@@ -56,6 +56,30 @@ a flow check; score the entire final transcript separately for accuracy.
 
 ## Production gate
 
+### Installer follow-up in 0.4.23
+
+The two-launch regression reproduced two independent app/updater owners in
+0.4.22. Windows now claims one instance per profile and routes another launch
+to the existing app. The regression script is
+`apps/desktop/scripts/test-single-instance.cjs <packaged-exe>` and uses the same
+external Playwright module setting as the capture smoke above.
+
+The updater now displays an installing state, dismisses its ready notification
+when installation starts, and permits another attempt when the handoff reports
+an error. Local `updates.log` in the app profile records lifecycle events,
+process IDs and version numbers, with rotation at 512 KiB. It does not record
+transcripts, audio, URLs, error messages or credentials.
+
+These changes do not yet establish the cause of the reported NSIS Retry/Cancel
+dialog. Verify the actual installed upgrade and retain the exact dialog text
+plus update lifecycle log if it recurs. The 0.4.22-to-0.4.23 upgrade still runs
+the 0.4.22 updater; the new handoff behavior applies to subsequent updates.
+
+Outstanding production acceptance: code signing, first-attempt installed
+upgrades, varied physical microphones/system audio, long meetings, device
+interruptions, and fresh-machine model setup. Notes-generation speed is a
+follow-up unless generation fails or prevents normal app use.
+
 Record candidate commit, installer hash, observed checks, skipped environments
 and remaining failures. Require a valid Windows Authenticode signature before
 production publication through `release:win`. An unsigned beta is suitable for


### PR DESCRIPTION
Two launches of the packaged Windows app could open the same library with independent updater instances. Claim one instance per Windows profile and route subsequent launches to the existing window, without reopening it during update shutdown.

Show an installing state, dismiss the ready notification on install, and retain the downloaded update for retry when the handoff reports an error. Add bounded local lifecycle diagnostics containing only event, process ID, timestamp and sanitized versions. Prepare Windows beta 0.4.23 and document the remaining release gates.

Validation: the two-process smoke failed on packaged 0.4.22 and passed against the rebuilt app. Installer-retry and bounded-log tests pass. Desktop tests: 164 passed, five skipped, zero failed. Typecheck and targeted lint passed. Add the packaged two-process smoke to Windows CI. Local 0.4.23 packaging and final smoke are in progress.

Limits: the original NSIS Retry/Cancel incident is not reproduced or claimed fixed. An initial shutdown probe was invalidated because Playwright held the debugger connection; corrected instrumentation reached the normal quit event. The next installed update needs physical verification. Production signing remains unconfigured, and this release keeps the production signature gate. macOS does not take the new single-instance lock; shared updater UI/diagnostics apply on both desktop platforms.