### PR TITLE
Add live-caption language selection (multilingual streaming model)

### DIFF
--- a/apps/desktop/src/main/engine-process.test.ts
+++ b/apps/desktop/src/main/engine-process.test.ts
@@ -149,3 +149,22 @@ describe('EngineProcess dispose', { skip: process.platform === 'win32' }, () => 
     await waitFor(() => logLines(log).includes('SIGTERM'), 'immediate SIGTERM', 2_000)
   })
 })
+
+describe('EngineProcess live args', { skip: process.platform === 'win32' }, () => {
+  it('passes --language through to the live command', async () => {
+    const { binary, log } = fakeEngine(
+      [
+        "log('argv ' + process.argv.slice(2).join(' '))",
+        "emit({ event: 'ready', mode: 'live' })",
+        "process.on('SIGTERM', () => process.exit(0))",
+        'process.stdin.resume()'
+      ].join('\n')
+    )
+    const engine = new EngineProcess(binary, 1_000)
+    cleanups.push(() => engine.dispose())
+    engine.start('live', undefined, { language: 'auto' })
+    await waitFor(() => logLines(log).some((l) => l.startsWith('argv')), 'argv line')
+    const argv = logLines(log).find((l) => l.startsWith('argv')) ?? ''
+    assert.ok(argv.includes('--language auto'), argv)
+  })
+})

--- a/apps/desktop/src/main/engine-process.ts
+++ b/apps/desktop/src/main/engine-process.ts
@@ -305,7 +305,14 @@ export class EngineProcess {
     this.discard()
 
     // Instant path: the persistent engine has models loaded and is idle.
-    if (command === 'live' && this.serveReady && this.serveChild && !this.serveSessionActive) {
+    // ponytail: serve only preloads the English model; multilingual takes the classic spawn.
+    if (
+      command === 'live' &&
+      !opts.language &&
+      this.serveReady &&
+      this.serveChild &&
+      !this.serveSessionActive
+    ) {
       this.serveSessionActive = true
       this.emit({ event: 'started', command, filePath, binaryPath: this.binaryPath })
       const ok = this.serveWrite({
@@ -347,6 +354,7 @@ export class EngineProcess {
     if (command === 'live') {
       args.push('--source', opts.source ?? 'both')
       args.push('--exit-on-stdin-close')
+      if (opts.language) args.push('--language', opts.language)
       if (opts.inputDevice) args.push('--input-device', opts.inputDevice)
       if (opts.audioDir) args.push('--audio-dir', opts.audioDir)
       if (opts.systemBackend) args.push('--system-backend', opts.systemBackend)

--- a/apps/desktop/src/main/import-logic.test.ts
+++ b/apps/desktop/src/main/import-logic.test.ts
@@ -4,7 +4,33 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { test } from 'node:test'
-import { transcribeFileToSegments } from './import-logic'
+import { batchTranscribeArgs, transcribeFileToSegments } from './import-logic'
+
+test('batchTranscribeArgs: only multilingual (v3) overrides the engine default', () => {
+  assert.deepEqual(batchTranscribeArgs('/m.wav'), [
+    'transcribe',
+    '--file',
+    '/m.wav',
+    '--channels',
+    'split'
+  ])
+  assert.deepEqual(batchTranscribeArgs('/m.wav', 'v2'), [
+    'transcribe',
+    '--file',
+    '/m.wav',
+    '--channels',
+    'split'
+  ])
+  assert.deepEqual(batchTranscribeArgs('/m.wav', 'v3'), [
+    'transcribe',
+    '--file',
+    '/m.wav',
+    '--channels',
+    'split',
+    '--model',
+    'v3'
+  ])
+})
 
 /**
  * Integration test against the REAL engine binary and real speech (macOS

--- a/apps/desktop/src/main/import-logic.ts
+++ b/apps/desktop/src/main/import-logic.ts
@@ -30,15 +30,25 @@ export interface BatchProgress {
  *  on first use can take a while on slow connections. */
 const TIMEOUT_MS = 30 * 60_000
 
+/** v2 is the engine's default English model; v3 recognizes 25 European languages. */
+export type BatchAsrModel = 'v2' | 'v3'
+
+export function batchTranscribeArgs(filePath: string, model?: BatchAsrModel): string[] {
+  const args = ['transcribe', '--file', filePath, '--channels', 'split']
+  if (model === 'v3') args.push('--model', 'v3')
+  return args
+}
+
 export function transcribeFileToSegments(
   enginePath: string,
   filePath: string,
-  onProgress?: (progress: BatchProgress) => void
+  onProgress?: (progress: BatchProgress) => void,
+  model?: BatchAsrModel
 ): Promise<BatchTranscription> {
   return new Promise((resolve, reject) => {
     let child: ReturnType<typeof spawn>
     try {
-      child = spawn(enginePath, ['transcribe', '--file', filePath, '--channels', 'split'], {
+      child = spawn(enginePath, batchTranscribeArgs(filePath, model), {
         stdio: ['ignore', 'pipe', 'pipe']
       })
     } catch (err) {

--- a/apps/desktop/src/main/import-service.ts
+++ b/apps/desktop/src/main/import-service.ts
@@ -16,6 +16,7 @@ import { AudioService } from './audio-service'
 import { IMPORTABLE_EXTENSIONS } from './import-media'
 import {
   transcribeFileToSegments,
+  type BatchAsrModel,
   type BatchProgress,
   type BatchTranscription
 } from './import-logic'
@@ -42,7 +43,9 @@ export class ImportService {
     private readonly platformTranscriber?: (
       filePath: string,
       onProgress?: (progress: BatchProgress) => void
-    ) => Promise<BatchTranscription>
+    ) => Promise<BatchTranscription>,
+    /** Engine model to batch-transcribe with; absent = engine default (v2). */
+    private readonly asrModel?: () => BatchAsrModel
   ) {}
 
   registerIpc(): void {
@@ -188,6 +191,6 @@ export class ImportService {
   ): Promise<BatchTranscription> {
     return this.platformTranscriber
       ? this.platformTranscriber(filePath, onProgress)
-      : transcribeFileToSegments(this.enginePath, filePath, onProgress)
+      : transcribeFileToSegments(this.enginePath, filePath, onProgress, this.asrModel?.())
   }
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -405,7 +405,8 @@ app.whenReady().then(() => {
     broadcast,
     winBatchTranscriber
       ? (filePath, onProgress) => winBatchTranscriber!.transcribe(filePath, onProgress)
-      : undefined
+      : undefined,
+    () => notesService?.batchAsrModel() ?? 'v2'
   )
   importService.registerIpc()
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -353,6 +353,7 @@ app.whenReady().then(() => {
     // macOS, the main-process PCM tee on Windows). Renderer-set audioDir is
     // ignored — main owns the location.
     delete opts.audioDir
+    if (request.command === 'live') opts.language = notesService?.liveAsrLanguage()
     if (request.command === 'live' && opts.meetingId && opts.persistAudio !== false) {
       opts.audioDir = audioService.beginSession(opts.meetingId) ?? undefined
     }

--- a/apps/desktop/src/main/notes-service.ts
+++ b/apps/desktop/src/main/notes-service.ts
@@ -39,7 +39,8 @@ import {
   type GlobalChatEntry,
   type NotesModelsResponse,
   type NotesSettingsUpdate,
-  type NotesSettingsView
+  type NotesSettingsView,
+  type TranscriptionLanguage
 } from '../shared/notes-api'
 import type { MeetingRecord } from '../shared/meetings-api'
 import { isStoredCloudProvider } from '../shared/meeting-recovery'
@@ -73,6 +74,8 @@ interface StoredCloudSettings {
 interface StoredSettings {
   engineChoice: 'local' | 'cloud'
   activeLocalModelId?: string
+  /** Absent means 'english', the pre-existing behavior. */
+  transcriptionLanguage?: TranscriptionLanguage
   /** The user's own name, shown instead of "You" on their transcript lines. */
   profileName?: string
   cloud?: StoredCloudSettings
@@ -470,10 +473,16 @@ export class NotesService {
 
   /* ---- settings ---- */
 
+  /** Engine model for batch transcription (import + re-transcribe). */
+  batchAsrModel(): 'v2' | 'v3' {
+    return this.settings.transcriptionLanguage === 'multilingual' ? 'v3' : 'v2'
+  }
+
   private settingsView(): NotesSettingsView {
     const { engineChoice, activeLocalModelId, profileName, cloud } = this.settings
     return {
       engineChoice,
+      transcriptionLanguage: this.settings.transcriptionLanguage ?? 'english',
       ...(activeLocalModelId ? { activeLocalModelId } : {}),
       ...(profileName ? { profileName } : {}),
       ...(cloud
@@ -494,6 +503,13 @@ export class NotesService {
 
     if (update.engineChoice === 'local' || update.engineChoice === 'cloud') {
       this.settings.engineChoice = update.engineChoice
+    }
+
+    if (
+      update.transcriptionLanguage === 'english' ||
+      update.transcriptionLanguage === 'multilingual'
+    ) {
+      this.settings.transcriptionLanguage = update.transcriptionLanguage
     }
 
     if (typeof update.profileName === 'string') {
@@ -565,6 +581,9 @@ export class NotesService {
       if (typeof raw.profileName === 'string') {
         const name = sanitizeSpeakerName(raw.profileName)
         if (name) settings.profileName = name
+      }
+      if (raw.transcriptionLanguage === 'multilingual') {
+        settings.transcriptionLanguage = 'multilingual'
       }
       const cloud = raw.cloud
       if (

--- a/apps/desktop/src/main/notes-service.ts
+++ b/apps/desktop/src/main/notes-service.ts
@@ -40,7 +40,8 @@ import {
   type NotesModelsResponse,
   type NotesSettingsUpdate,
   type NotesSettingsView,
-  type TranscriptionLanguage
+  type TranscriptionLanguage,
+  isTranscriptionLanguage
 } from '../shared/notes-api'
 import type { MeetingRecord } from '../shared/meetings-api'
 import { isStoredCloudProvider } from '../shared/meeting-recovery'
@@ -475,7 +476,14 @@ export class NotesService {
 
   /** Engine model for batch transcription (import + re-transcribe). */
   batchAsrModel(): 'v2' | 'v3' {
-    return this.settings.transcriptionLanguage === 'multilingual' ? 'v3' : 'v2'
+    return (this.settings.transcriptionLanguage ?? 'english') === 'english' ? 'v2' : 'v3'
+  }
+
+  /** Language hint for live captions; undefined keeps the English streaming model. */
+  liveAsrLanguage(): string | undefined {
+    const language = this.settings.transcriptionLanguage
+    if (!language || language === 'english') return undefined
+    return language === 'multilingual' ? 'auto' : language
   }
 
   private settingsView(): NotesSettingsView {
@@ -505,10 +513,7 @@ export class NotesService {
       this.settings.engineChoice = update.engineChoice
     }
 
-    if (
-      update.transcriptionLanguage === 'english' ||
-      update.transcriptionLanguage === 'multilingual'
-    ) {
+    if (isTranscriptionLanguage(update.transcriptionLanguage)) {
       this.settings.transcriptionLanguage = update.transcriptionLanguage
     }
 
@@ -582,8 +587,8 @@ export class NotesService {
         const name = sanitizeSpeakerName(raw.profileName)
         if (name) settings.profileName = name
       }
-      if (raw.transcriptionLanguage === 'multilingual') {
-        settings.transcriptionLanguage = 'multilingual'
+      if (isTranscriptionLanguage(raw.transcriptionLanguage)) {
+        settings.transcriptionLanguage = raw.transcriptionLanguage
       }
       const cloud = raw.cloud
       if (

--- a/apps/desktop/src/renderer/src/MeetingView.tsx
+++ b/apps/desktop/src/renderer/src/MeetingView.tsx
@@ -107,6 +107,9 @@ function sessionReducer(state: SessionState, ev: EngineEvent): SessionState {
       if (ev.stage === 'transcribing') {
         return { ...state, transcribing: true, statusText: '' }
       }
+      if (ev.stage === 'loading_models') {
+        return { ...state, statusText: 'Loading speech model…' }
+      }
       // The engine confirms a stop instantly with `finishing` — reflect it
       // instantly, or the still-ticking timer makes stop look ignored and
       // users hammer the button.
@@ -115,6 +118,12 @@ function sessionReducer(state: SessionState, ev: EngineEvent): SessionState {
       }
       return { ...state, statusText: (ev.stage ?? 'working').replace(/_/g, ' ') }
     }
+    case 'download':
+      if (!active) return state
+      return {
+        ...state,
+        statusText: `Downloading speech model — ${Math.round((ev.progress ?? 0) * 100)}%`
+      }
     case 'ready':
       if (!active) return state
       return { ...state, phase: 'recording', statusText: '' }

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -17,7 +17,8 @@ import {
   type EngineChoice,
   type NotesModelInfo,
   type NotesModelsResponse,
-  type NotesSettingsView
+  type NotesSettingsView,
+  type TranscriptionLanguage
 } from '../../shared/notes-api'
 import mascotUrl from './assets/mascot-square.png'
 
@@ -548,6 +549,11 @@ export default function ModelsView({
     setSettings(view)
   }
 
+  const chooseTranscriptionLanguage = async (language: TranscriptionLanguage): Promise<void> => {
+    const view = await window.notes.setSettings({ transcriptionLanguage: language })
+    setSettings(view)
+  }
+
   const saveCloudKey = async (): Promise<void> => {
     setError(null)
     const view = await window.notes.setSettings({
@@ -947,6 +953,38 @@ export default function ModelsView({
                   <button type="button" className="pill-btn" onClick={() => void saveProfileName()}>
                     {profileSaved ? 'Saved' : 'Save'}
                   </button>
+                </div>
+              </section>
+
+              <section className="keys-section">
+                <h3>Transcription language</h3>
+                <p className="models-sub">
+                  Applies to imported recordings and &ldquo;Re-transcribe&rdquo;. Multilingual
+                  recognizes 25 European languages (Danish, German, French, Spanish, …). Live
+                  captions during a meeting stay English either way — re-transcribe afterwards for
+                  the full-quality transcript.
+                </p>
+                <div className="theme-seg" role="radiogroup" aria-label="Transcription language">
+                  {(
+                    [
+                      ['english', 'English (fastest)'],
+                      ['multilingual', 'Multilingual']
+                    ] as const
+                  ).map(([value, label]) => {
+                    const active = (settings?.transcriptionLanguage ?? 'english') === value
+                    return (
+                      <button
+                        key={value}
+                        type="button"
+                        role="radio"
+                        aria-checked={active}
+                        className={active ? 'theme-seg-btn on' : 'theme-seg-btn'}
+                        onClick={() => void chooseTranscriptionLanguage(value)}
+                      >
+                        {label}
+                      </button>
+                    )
+                  })}
                 </div>
               </section>
 

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -18,7 +18,8 @@ import {
   type NotesModelInfo,
   type NotesModelsResponse,
   type NotesSettingsView,
-  type TranscriptionLanguage
+  type TranscriptionLanguage,
+  TRANSCRIPTION_LANGUAGES
 } from '../../shared/notes-api'
 import mascotUrl from './assets/mascot-square.png'
 
@@ -959,32 +960,24 @@ export default function ModelsView({
               <section className="keys-section">
                 <h3>Transcription language</h3>
                 <p className="models-sub">
-                  Applies to imported recordings and &ldquo;Re-transcribe&rdquo;. Multilingual
-                  recognizes 25 European languages (Danish, German, French, Spanish, …). Live
-                  captions during a meeting stay English either way — re-transcribe afterwards for
-                  the full-quality transcript.
+                  Pick the language you speak, or Auto-detect. Applies to live captions, imported
+                  recordings, and &ldquo;Re-transcribe&rdquo;; the first non-English session
+                  downloads its model. Live captions on Windows stay English.
                 </p>
-                <div className="theme-seg" role="radiogroup" aria-label="Transcription language">
-                  {(
-                    [
-                      ['english', 'English (fastest)'],
-                      ['multilingual', 'Multilingual']
-                    ] as const
-                  ).map(([value, label]) => {
-                    const active = (settings?.transcriptionLanguage ?? 'english') === value
-                    return (
-                      <button
-                        key={value}
-                        type="button"
-                        role="radio"
-                        aria-checked={active}
-                        className={active ? 'theme-seg-btn on' : 'theme-seg-btn'}
-                        onClick={() => void chooseTranscriptionLanguage(value)}
-                      >
+                <div className="key-form">
+                  <select
+                    aria-label="Transcription language"
+                    value={settings?.transcriptionLanguage ?? 'english'}
+                    onChange={(e) =>
+                      void chooseTranscriptionLanguage(e.target.value as TranscriptionLanguage)
+                    }
+                  >
+                    {TRANSCRIPTION_LANGUAGES.map(([code, label]) => (
+                      <option key={code} value={code}>
                         {label}
-                      </button>
-                    )
-                  })}
+                      </option>
+                    ))}
+                  </select>
                 </div>
               </section>
 

--- a/apps/desktop/src/shared/engine-events.ts
+++ b/apps/desktop/src/shared/engine-events.ts
@@ -68,6 +68,8 @@ export interface EngineStartOptions {
   realtime?: boolean
   /** e.g. "v2" | "v3" */
   model?: string
+  /** live only (macOS): "auto" or a FLEURS code like "de-DE" selects the multilingual streaming model; omit = English. */
+  language?: string
   /** live only: which capture sources (default "both") */
   source?: 'mic' | 'system' | 'both'
   /** live only: auto-stop after N seconds (dev/testing) */

--- a/apps/desktop/src/shared/notes-api.ts
+++ b/apps/desktop/src/shared/notes-api.ts
@@ -46,6 +46,14 @@ export const CLOUD_PROVIDERS: ReadonlyArray<{
 ]
 export type EngineChoice = 'local' | 'cloud'
 
+/**
+ * Batch-transcription language mode. 'english' runs the fastest English-only
+ * model; 'multilingual' recognizes 25 European languages (Danish, German,
+ * French, …). Applies to imported recordings and re-transcription; live
+ * captions always use the English streaming model.
+ */
+export type TranscriptionLanguage = 'english' | 'multilingual'
+
 /** One catalog model + its state on this machine. */
 export interface NotesModelInfo {
   id: string
@@ -76,6 +84,7 @@ export interface ActivateModelResult {
 export interface NotesSettingsView {
   engineChoice: EngineChoice
   activeLocalModelId?: string
+  transcriptionLanguage: TranscriptionLanguage
   /** The user's own name, used to label their transcript lines. */
   profileName?: string
   cloud?: {
@@ -90,6 +99,7 @@ export interface NotesSettingsView {
 /** Partial update; omitted fields are left untouched. */
 export interface NotesSettingsUpdate {
   engineChoice?: EngineChoice
+  transcriptionLanguage?: TranscriptionLanguage
   /** The user's own name; empty string clears it back to "You". */
   profileName?: string
   /**

--- a/apps/desktop/src/shared/notes-api.ts
+++ b/apps/desktop/src/shared/notes-api.ts
@@ -47,12 +47,27 @@ export const CLOUD_PROVIDERS: ReadonlyArray<{
 export type EngineChoice = 'local' | 'cloud'
 
 /**
- * Batch-transcription language mode. 'english' runs the fastest English-only
- * model; 'multilingual' recognizes 25 European languages (Danish, German,
- * French, …). Applies to imported recordings and re-transcription; live
- * captions always use the English streaming model.
+ * Transcription language. 'english' runs the fastest English-only models;
+ * 'multilingual' auto-detects the spoken language; a FLEURS code such as
+ * 'de-DE' pins live captions to that language. Imports and re-transcription
+ * always auto-detect among 25 European languages when not 'english'.
+ * Live captions on Windows stay English.
  */
-export type TranscriptionLanguage = 'english' | 'multilingual'
+export const TRANSCRIPTION_LANGUAGES = [
+  ['english', 'English (fastest)'],
+  ['multilingual', 'Auto-detect'],
+  ['de-DE', 'Deutsch'],
+  ['fr-FR', 'Français'],
+  ['es-ES', 'Español'],
+  ['it-IT', 'Italiano'],
+  ['pt-BR', 'Português'],
+  ['nl-NL', 'Nederlands'],
+  ['pl-PL', 'Polski']
+] as const
+export type TranscriptionLanguage = (typeof TRANSCRIPTION_LANGUAGES)[number][0]
+export function isTranscriptionLanguage(value: unknown): value is TranscriptionLanguage {
+  return TRANSCRIPTION_LANGUAGES.some(([code]) => code === value)
+}
 
 /** One catalog model + its state on this machine. */
 export interface NotesModelInfo {

--- a/engine/Sources/engine/EngineMain.swift
+++ b/engine/Sources/engine/EngineMain.swift
@@ -6,7 +6,7 @@ struct EngineMain {
         let args = Array(CommandLine.arguments.dropFirst())
         guard let command = args.first else {
             Events.error(
-                "usage: engine <transcribe|stream|live|merge-audio|info> [--file <path>] [--model v2|v3] [--realtime] [--source mic|system|both] [--seconds N] [--audio-dir <path>] [--dir <path>]"
+                "usage: engine <transcribe|stream|live|merge-audio|info> [--file <path>] [--model v2|v3] [--realtime] [--source mic|system|both] [--language <code|auto>] [--seconds N] [--audio-dir <path>] [--dir <path>]"
             )
             exit(64)
         }

--- a/engine/Sources/engine/LiveCommand.swift
+++ b/engine/Sources/engine/LiveCommand.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import AudioToolbox
 import CoreAudio
 import CoreMedia
+import CoreML
 import FluidAudio
 import Foundation
 import ScreenCaptureKit
@@ -61,6 +62,7 @@ enum LiveCommand {
             inputDevice: options.values["input-device"],
             audioDir: options.values["audio-dir"],
             systemBackend: options.values["system-backend"],
+            language: options.values["language"],
             micManager: nil,
             systemManager: nil,
             stopper: stopper
@@ -95,8 +97,9 @@ enum LiveSession {
         inputDevice: String? = nil,
         audioDir: String? = nil,
         systemBackend: String? = nil,
-        micManager: StreamingUnifiedAsrManager?,
-        systemManager: StreamingUnifiedAsrManager?,
+        language: String? = nil,
+        micManager: (any LiveAsr)?,
+        systemManager: (any LiveAsr)?,
         stopper: Stopper
     ) async throws {
         let wantMic = source == "mic" || source == "both"
@@ -131,12 +134,12 @@ enum LiveSession {
         var systemPipeline: ChannelPipeline?
         if wantMic {
             micPipeline = ChannelPipeline(
-                channel: "mic", manager: micManager,
+                channel: "mic", manager: micManager, language: language,
                 recorder: sessionRecorder?.recorder(for: "mic"))
         }
         if wantSystem {
             systemPipeline = ChannelPipeline(
-                channel: "system", manager: systemManager,
+                channel: "system", manager: systemManager, language: language,
                 recorder: sessionRecorder?.recorder(for: "system"))
         }
 
@@ -350,14 +353,98 @@ enum LiveSession {
     }
 }
 
+// MARK: - Live ASR backends
+
+/// What ChannelPipeline needs from a streaming recognizer.
+protocol LiveAsr: Actor {
+    nonisolated var modelName: String { get }
+    func loadModels() async throws
+    func appendAudio(_ buffer: AVAudioPCMBuffer) async throws
+    func processBufferedAudio() async throws
+    func consumeTokenTimings() async -> [TokenTiming]
+    func finish() async throws -> String
+    func setPartialTranscriptCallback(_ callback: @escaping @Sendable (String) -> Void) async
+}
+
+extension StreamingUnifiedAsrManager: LiveAsr {
+    nonisolated var modelName: String { "parakeet-unified-en-0.6b" }
+}
+
+/// Nemotron multilingual streaming (~40 languages) behind the same seam as the
+/// English Unified model. `language` is a FLEURS code ("de-DE") or "auto".
+actor MultilingualLiveAsr: LiveAsr {
+    nonisolated let modelName = "nemotron-streaming-multilingual-0.6b"
+    // ANE compilation of this encoder fails on M1 (macOS 26) and CoreML retries it on
+    // every launch (~80 s before any caption); on the GPU it loads in seconds.
+    // ponytail: unconditional GPU — gate on chip generation if ANE proves faster on M2+.
+    private let inner: StreamingNemotronMultilingualAsrManager
+    private let language: String
+    private var emittedTimings = 0
+    private var finalTimings: [TokenTiming]?
+
+    init(language: String) {
+        let configuration = MLModelConfiguration()
+        configuration.computeUnits = .cpuAndGPU
+        self.inner = StreamingNemotronMultilingualAsrManager(configuration: configuration)
+        self.language = language
+    }
+
+    func loadModels() async throws {
+        let gate = PercentGate()
+        // One full multilingual ship for every language (scores identically to the
+        // per-language pruned ships) so pinning a language never triggers a new download.
+        // ponytail: 1120 ms tier — smallest chunk that keeps punctuation over long sessions.
+        let dir = try await StreamingNemotronMultilingualAsrManager.downloadVariant(
+            languageCode: "auto", chunkMs: 1120
+        ) { progress in
+            if let pct = gate.advance(progress.fractionCompleted) {
+                Events.emit(["event": "download", "progress": Double(pct) / 100.0])
+            }
+        }
+        try await inner.loadModels(from: dir)
+        await inner.setLanguage(language == "auto" ? nil : language)
+    }
+
+    func appendAudio(_ buffer: AVAudioPCMBuffer) async throws {
+        try await inner.appendAudio(buffer)
+    }
+
+    func processBufferedAudio() async throws {
+        _ = try await inner.process(samples: [])
+    }
+
+    /// The inner manager exposes cumulative timings; hand out only the new tail.
+    func consumeTokenTimings() async -> [TokenTiming] {
+        let all: [TokenTiming]
+        if let finalTimings {
+            all = finalTimings
+        } else {
+            all = await inner.getTokenTimings()
+        }
+        let tail = Array(all.dropFirst(emittedTimings))
+        emittedTimings += tail.count
+        return tail
+    }
+
+    func finish() async throws -> String {
+        let (text, timings) = try await inner.finishWithTokenTimings()
+        finalTimings = timings
+        return text
+    }
+
+    func setPartialTranscriptCallback(_ callback: @escaping @Sendable (String) -> Void) async {
+        await inner.setPartialCallback(callback)
+    }
+}
+
 // MARK: - Per-channel streaming pipeline
 
-/// Owns one StreamingUnifiedAsrManager and a serial ingest queue bridging capture
+/// Owns one streaming recognizer and a serial ingest queue bridging capture
 /// callbacks (arbitrary threads) into the actor. Capture stays realtime even if
 /// ASR hiccups — buffers queue in the AsyncStream.
 final class ChannelPipeline {
     let channel: String
-    private let manager: StreamingUnifiedAsrManager
+    private let manager: any LiveAsr
     private let recorder: ChannelRecorder?
     private let bufferStream: AsyncStream<AVAudioPCMBuffer>
     private let bufferContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation
@@ -383,13 +470,20 @@ final class ChannelPipeline {
 
     init(
         channel: String,
-        manager: StreamingUnifiedAsrManager? = nil,
+        manager: (any LiveAsr)? = nil,
+        language: String? = nil,
         recorder: ChannelRecorder? = nil,
         probe: ((AVAudioPCMBuffer) -> Void)? = nil
     ) {
         self.channel = channel
         self.preloaded = manager != nil
-        self.manager = manager ?? StreamingUnifiedAsrManager()
+        if let manager {
+            self.manager = manager
+        } else if let language {
+            self.manager = MultilingualLiveAsr(language: language)
+        } else {
+            self.manager = StreamingUnifiedAsrManager()
+        }
         self.recorder = recorder
         self.probe = probe
         (self.bufferStream, self.bufferContinuation) = AsyncStream.makeStream(of: AVAudioPCMBuffer.self)
@@ -399,7 +493,7 @@ final class ChannelPipeline {
     /// Called AFTER capture starts — audio queues until begin() drains it.
     func prepare() async throws {
         if !preloaded {
-            Events.emit(["event": "status", "stage": "loading_models", "channel": channel, "model": "parakeet-unified-en-0.6b"])
+            Events.emit(["event": "status", "stage": "loading_models", "channel": channel, "model": manager.modelName])
             try await manager.loadModels()
         }
         let ch = channel


### PR DESCRIPTION
Builds on #117 (its commit is included here; rebases to the language-only delta once #117 lands).

## What

The transcription-language setting now also drives **live captions** and becomes a language picker: *English (fastest)*, *Auto-detect*, Deutsch, Français, Español, Italiano, Português, Nederlands, Polski.

- **Engine** — `live --language <code|auto>` swaps the English Parakeet Unified model for FluidAudio's `StreamingNemotronMultilingualAsrManager` (~40 languages) behind a small `LiveAsr` seam. One full multilingual ship (1120 ms tier) serves every language, so pinning a language never triggers another download. Runs on GPU compute units: ANE compilation of this encoder fails on M1 (macOS 26) and CoreML retries it on every launch (~80 s before the first caption); on GPU it loads in ~15 s after the first run.
- **Desktop** — a pinned language or Auto-detect maps to `--language` for live sessions; multilingual sessions bypass the serve preload (which only holds the English model). Imports and Re-transcribe keep using TDT v3 (auto-detect) for anything non-English. The live view now shows *Downloading speech model — 42 %* / *Loading speech model…* instead of silently recording into a model that is not there yet.
- Windows live captions stay English (the Windows batch transcriber never received the model choice in #117 either — separate fix).

## Test

- `pnpm --filter desktop typecheck`, `test` (149 pass, incl. new `--language` arg test), `lint`
- `engine live --source mic --language de-DE` and `--language auto`: multilingual model downloads (~650 MB) on first use, later loads ≈ 15 s, partials/timings/final emitted on both channels
- In-app: Settings → General → Transcription language → Deutsch → record → German captions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ea8qVB2oa5XLpTy9bxK926
