### PR TITLE
Track Onyx referrals from doodlenote header and footer

### DIFF
--- a/apps/web/app/ui.tsx
+++ b/apps/web/app/ui.tsx
@@ -55,7 +55,10 @@ export function Wordmark({ size = "text-lg" }: { size?: string }) {
   );
 }
 
-function BuilderAttribution({ compact = false }: { compact?: boolean }) {
+function BuilderAttribution({ compact = false, placement }: {
+  compact?: boolean;
+  placement?: "header" | "footer";
+}) {
   return (
     <p
       className={`whitespace-nowrap font-normal leading-none tracking-normal text-stone ${
@@ -64,7 +67,9 @@ function BuilderAttribution({ compact = false }: { compact?: boolean }) {
     >
       built by{" "}
       <a
-        href={ONYX_URL}
+        href={placement
+          ? `${ONYX_URL}/?utm_source=doodlenote&utm_medium=referral&utm_campaign=built_by_onyx&utm_content=${placement}`
+          : ONYX_URL}
         className="rounded-[2px] text-bark underline decoration-bark/60 underline-offset-2 transition hover:text-sage-deep hover:decoration-sage-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sage-deep"
         rel="noreferrer"
         target="_blank"
@@ -85,6 +90,7 @@ export function BrandLockup({
   wordmarkSize,
   className = "",
   textClassName = "",
+  placement,
 }: {
   compact?: boolean;
   priority?: boolean;
@@ -94,6 +100,7 @@ export function BrandLockup({
   wordmarkSize?: string;
   className?: string;
   textClassName?: string;
+  placement?: "header" | "footer";
 }) {
   const size = iconSize ?? (compact ? 30 : 34);
   const wmSize = wordmarkSize ?? (compact ? "text-base" : "text-lg");
@@ -110,7 +117,7 @@ export function BrandLockup({
       >
         <Wordmark size={wmSize} />
       </Link>
-      <BuilderAttribution compact={compact} />
+      <BuilderAttribution compact={compact} placement={placement} />
     </div>
   );
 
@@ -144,7 +151,7 @@ export function BrandLockup({
 export function SiteHeader({ nav }: { nav?: React.ReactNode }) {
   return (
     <header className="mx-auto flex w-full max-w-3xl items-center justify-between px-6 py-5">
-      <BrandLockup priority />
+      <BrandLockup priority placement="header" />
       <nav className="flex items-center gap-1 sm:gap-2">
         {nav ?? (
           <>
@@ -166,7 +173,7 @@ export function SiteFooter() {
   return (
     <footer className="border-t border-sand">
       <div className="mx-auto flex w-full max-w-7xl flex-col items-center justify-between gap-5 px-6 py-6 text-sm text-stone lg:grid lg:grid-cols-[auto_minmax(0,1fr)_auto] lg:gap-8">
-        <BrandLockup compact />
+        <BrandLockup compact placement="footer" />
         <nav className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 lg:flex-nowrap">
           <Link href="/pricing" className="whitespace-nowrap hover:text-ink">
             Pricing

--- a/apps/web/tests/brand-attribution.test.ts
+++ b/apps/web/tests/brand-attribution.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { SiteHeader } from "../app/ui";
+import { SiteHeader, SiteFooter } from "../app/ui";
 
 const uiSource = readFileSync(
   join(dirname(fileURLToPath(import.meta.url)), "../app/ui.tsx"),
@@ -18,8 +18,8 @@ test("marketing brand lockup includes Onyx builder attribution", () => {
   assert.match(uiSource, /Onyx Dev Labs/);
   assert.match(uiSource, /ONYX_URL = "https:\/\/onyxdev\.io"/);
   assert.match(uiSource, /export function BrandLockup/);
-  assert.match(uiSource, /<BrandLockup priority \/>/);
-  assert.match(uiSource, /<BrandLockup compact \/>/);
+  assert.match(uiSource, /<BrandLockup priority placement="header" \/>/);
+  assert.match(uiSource, /<BrandLockup compact placement="footer" \/>/);
   assert.match(uiSource, /layout\?: "horizontal" \| "stacked"/);
 });
 
@@ -58,4 +58,21 @@ test("brand navigation never nests one link inside another", () => {
     assert.ok(anchorDepth <= 1, "links must not be nested");
   }
   assert.equal(anchorDepth, 0);
+});
+
+test("public header and footer identify DoodleNote referrals to Onyx", () => {
+  for (const [Component, placement] of [[SiteHeader, "header"], [SiteFooter, "footer"]] as const) {
+    const html = renderToStaticMarkup(React.createElement(Component));
+    const matches = [...html.matchAll(/href="(https:\/\/onyxdev\.io[^"]*)"/g)];
+    assert.equal(matches.length, 1);
+    const url = new URL(matches[0][1].replaceAll("&amp;", "&"));
+    assert.equal(url.origin, "https://onyxdev.io");
+    assert.equal(url.pathname, "/");
+    assert.deepEqual(Object.fromEntries(url.searchParams), {
+      utm_source: "doodlenote",
+      utm_medium: "referral",
+      utm_campaign: "built_by_onyx",
+      utm_content: placement,
+    });
+  }
 });


### PR DESCRIPTION
The public header and footer’s “Built by Onyx Dev Labs” links currently send visitors to Onyx without explicit campaign attribution. Add `utm_source=doodlenote`, `utm_medium=referral`, and `utm_campaign=built_by_onyx`, with `utm_content=header` or `footer`, so Onyx can identify the referring app and link placement. Existing branding and link behavior are preserved.

Validation: All 5 brand attribution tests pass, including server rendering of SiteHeader and SiteFooter and validation of both UTM destinations.

Production deployment and GA event collection have not been verified.
