### PR TITLE
[ONY-267] Add Composio setup to MCP integrations

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -30,7 +30,8 @@
     "electron-updater": "^6.8.9",
     "node-llama-cpp": "^3.20.0",
     "sherpa-onnx-node": "^1.13.4",
-    "@repo/cloud-reader": "workspace:*"
+    "@repo/cloud-reader": "workspace:*",
+    "@repo/agent-contract": "workspace:*"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",

--- a/apps/desktop/src/main/remote-mcp-setup.test.ts
+++ b/apps/desktop/src/main/remote-mcp-setup.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { copyMcpServerUrl, remoteMcpSetup } from '@repo/agent-contract/setup'
+
+test('remote setup uses the configured HTTPS origin without leaking URL parameters', () => {
+  const setup = remoteMcpSetup('https://notes.example.test/settings?token=do-not-copy#secret')!
+  assert.equal(setup.serverUrl, 'https://notes.example.test/api/mcp')
+  assert.equal(setup.agentsUrl, 'https://notes.example.test/app/settings/agents')
+  const config = JSON.parse(setup.registrationJson)
+  assert.equal(config.toolkit_config.app_url, setup.serverUrl)
+  assert.deepEqual(config.toolkit_config.auth_schemes, [
+    {
+      mode: 'API_KEY',
+      headers: { Authorization: 'Bearer {{generic_api_key}}' }
+    }
+  ])
+  assert.equal(setup.registrationJson.includes('do-not-copy'), false)
+  assert.equal(setup.registrationJson.includes('mcpServers'), false)
+})
+
+test('remote setup does not fall back to the official server for invalid/self-hosted config', () => {
+  for (const baseUrl of [
+    undefined,
+    '',
+    'not a URL',
+    'http://localhost:4040',
+    'file:///tmp/server',
+    'https://user:secret@notes.example.test'
+  ]) {
+    assert.equal(remoteMcpSetup(baseUrl), null)
+  }
+})
+
+test('copy writes only the server URL and does not report success before the write completes', async () => {
+  let finish!: () => void
+  const pending = new Promise<void>((resolve) => {
+    finish = resolve
+  })
+  const writes: string[] = []
+  let settled = false
+  const url = remoteMcpSetup('https://www.doodlenote.ai')!.serverUrl
+  const result = copyMcpServerUrl(url, async (text) => {
+    writes.push(text)
+    await pending
+  })
+  void result.then(() => {
+    settled = true
+  })
+  await Promise.resolve()
+  assert.equal(settled, false)
+  assert.deepEqual(writes, ['https://www.doodlenote.ai/api/mcp'])
+  finish()
+  assert.deepEqual(await result, {
+    ok: true,
+    message: 'Server URL copied. Finish setup in Composio.'
+  })
+})
+
+test('clipboard rejection and missing API return a manual-copy fallback without error contents', async () => {
+  for (const write of [
+    () => {
+      throw new Error('private error details')
+    },
+    () => Promise.reject(new Error('private error details'))
+  ]) {
+    const result = await copyMcpServerUrl('https://www.doodlenote.ai/api/mcp', write)
+    assert.equal(result.ok, false)
+    assert.match(result.message, /Select and copy/)
+    assert.equal(result.message.includes('private'), false)
+  }
+})

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -19,6 +19,7 @@ import {
   type NotesModelsResponse,
   type NotesSettingsView
 } from '../../shared/notes-api'
+import { RemoteMcpSetup } from './RemoteMcpSetup'
 import mascotUrl from './assets/mascot-square.png'
 
 function lastSyncLabel(iso: string): string {
@@ -1303,12 +1304,13 @@ export default function ModelsView({
 
           {section === 'integrations' && (
             <>
+              <RemoteMcpSetup key={syncStatus?.baseUrl} baseUrl={syncStatus?.baseUrl} />
               <section className="keys-section calendar-section">
-                <h3>Agent access</h3>
+                <h3>Local MCP</h3>
                 <p className="models-sub">
                   Let AI tools on this computer (Claude, Codex, and other MCP clients) read your
                   meetings, notes, and transcripts. Read-only, off by default, and local — nothing
-                  is uploaded. Turning this off revokes access immediately.
+                  is uploaded. Turning this off revokes local access immediately.
                 </p>
                 {agentError && <div className="models-error">{agentError}</div>}
                 {agentAccess === null ? (
@@ -1377,7 +1379,7 @@ export default function ModelsView({
                       ))}
                       <div className="cal-row">
                         <span className="cal-row-main">
-                          <span className="cal-row-label">Other MCP clients</span>
+                          <span className="cal-row-label">Other local MCP clients</span>
                           <span className="cal-row-sub">
                             Copy a ready-made config snippet — no build steps, the server ships
                             inside DoodleNote

--- a/apps/desktop/src/renderer/src/RemoteMcpSetup.tsx
+++ b/apps/desktop/src/renderer/src/RemoteMcpSetup.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import {
+  COMPOSIO_AUTH_HEADER,
+  COMPOSIO_DOCS_URL,
+  copyMcpServerUrl,
+  remoteMcpSetup
+} from '@repo/agent-contract/setup'
+
+export function RemoteMcpSetup({ baseUrl }: { baseUrl: string | undefined }): React.JSX.Element {
+  const setup = remoteMcpSetup(baseUrl)
+  const [copying, setCopying] = useState(false)
+  const [feedback, setFeedback] = useState('')
+
+  async function copy(): Promise<void> {
+    if (!setup) return
+    setCopying(true)
+    setFeedback('')
+    const result = await copyMcpServerUrl(setup.serverUrl, (text) =>
+      navigator.clipboard.writeText(text)
+    )
+    setFeedback(result.message)
+    setCopying(false)
+  }
+
+  return (
+    <section
+      className="keys-section calendar-section remote-mcp"
+      aria-labelledby="remote-mcp-title"
+    >
+      <h3 id="remote-mcp-title">Composio / remote MCP</h3>
+      <p className="models-sub">
+        Let Composio read a cloud workspace’s synced notes and transcripts. Requires Cloud Sync
+        access. Unsynced local notes and recording audio are not available remotely.
+      </p>
+      {setup ? (
+        <>
+          <label className="cal-row-label" htmlFor="remote-mcp-url">
+            MCP server URL
+          </label>
+          <input id="remote-mcp-url" className="remote-mcp-url" readOnly value={setup.serverUrl} />
+          <div className="calendar-actions">
+            <button type="button" disabled={copying} onClick={() => void copy()}>
+              {copying ? 'Copying…' : 'Copy server URL'}
+            </button>
+            <button type="button" onClick={() => window.open(setup.agentsUrl)}>
+              Open token settings
+            </button>
+          </div>
+          <p className="calendar-note" role="status">
+            {feedback}
+          </p>
+          <ol className="remote-mcp-steps">
+            <li>
+              Open token settings, sign in, and select the workspace you want Composio to read.
+              Create a dedicated token named Composio and copy it once.
+            </li>
+            <li>
+              In Composio, use display name <strong>DoodleNote</strong> and the server URL above.
+              Choose API-key authentication, not OAuth or no authentication.
+            </li>
+            <li>
+              Store the DoodleNote token as the connected account’s API key. The server needs{' '}
+              <code>{COMPOSIO_AUTH_HEADER}</code>. Keep your Composio project key separate.
+            </li>
+            <li>
+              Sync the toolkit’s tools in Composio and test a read from the intended workspace.
+              Copying this URL does not connect an account.
+            </li>
+          </ol>
+          <details>
+            <summary>API setup and troubleshooting</summary>
+            <p className="models-sub">
+              If your Composio form only offers OAuth or cannot set the bearer header, use its
+              Custom MCP API setup. Register with this body, then create an API-key auth config and
+              connected account using the guide.
+            </p>
+            <pre>{setup.registrationJson}</pre>
+            <div className="calendar-actions">
+              <button type="button" onClick={() => window.open(COMPOSIO_DOCS_URL)}>
+                Open Composio setup guide
+              </button>
+            </div>
+            <p className="models-sub">
+              Subscription required? Check Cloud Sync access in web billing. No meetings returned?
+              Check the selected workspace and sync the notes you want to share. Invalid token?
+              Create a replacement in that workspace. Service unavailable? Retry later and check
+              DoodleNote’s web app before changing credentials.
+            </p>
+          </details>
+        </>
+      ) : (
+        <p className="models-sub" role="status">
+          Remote setup needs a public HTTPS DoodleNote server. If server settings have not loaded,
+          reopen Settings. For a local or self-hosted server, configure its public HTTPS address
+          first.
+        </p>
+      )}
+      <p className="calendar-note">
+        Local MCP can stay off. To stop remote access, revoke the dedicated token in web Settings
+        &gt; AI agents. Pausing local access or Sync does not revoke a remote token.
+      </p>
+    </section>
+  )
+}

--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -4037,3 +4037,49 @@ button.fp-row:hover {
 }
 
 .wizard-skip:hover { color: var(--ink); }
+
+/* Remote setup is independent of the local-agent opt-in. */
+.remote-mcp-url {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 8px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card);
+  color: var(--ink);
+  font-size: 12px;
+}
+
+.remote-mcp-steps {
+  padding-left: 22px;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.remote-mcp-steps li {
+  margin-bottom: 10px;
+}
+.remote-mcp code {
+  overflow-wrap: anywhere;
+}
+.remote-mcp summary {
+  cursor: pointer;
+  font-size: 12px;
+}
+.remote-mcp details p {
+  margin-top: 12px;
+}
+.remote-mcp pre {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: 11px;
+  padding: 12px;
+  border-radius: 8px;
+  background: var(--card);
+  border: 1px solid var(--border);
+}
+
+.remote-mcp .calendar-note { color: var(--ink); }
+.remote-mcp .calendar-actions { flex-wrap: wrap; }

--- a/apps/web/app/app/settings/agents/agents-panel.tsx
+++ b/apps/web/app/app/settings/agents/agents-panel.tsx
@@ -3,11 +3,12 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+import { RemoteMcpSetup } from "./remote-mcp-setup";
 import { buttonPrimary, inputClass } from "../../../ui";
 
 interface AgentToken { id: string; name: string; createdAt: string; lastUsedAt: string | null }
 
-export function AgentsPanel({ organizationId, tokens }: { organizationId: string; tokens: AgentToken[] }) {
+export function AgentsPanel({ organizationId, workspaceName, baseUrl, tokens }: { organizationId: string; workspaceName: string; baseUrl: string; tokens: AgentToken[] }) {
   const router = useRouter();
   const [name, setName] = useState("");
   const [pending, setPending] = useState(false);
@@ -17,17 +18,27 @@ export function AgentsPanel({ organizationId, tokens }: { organizationId: string
 
   async function create(event: React.FormEvent) {
     event.preventDefault(); setError(null); setMessage(null); setPending(true);
-    const response = await fetch("/api/agent-tokens", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ organizationId, name: name.trim() || "Agent" }) });
-    const body = (await response.json()) as { token?: string; error?: string };
-    setPending(false);
-    if (!response.ok || !body.token) { setError(body.error ?? "Could not create the token"); return; }
-    setMintedToken(body.token); setName(""); router.refresh();
+    try {
+      const response = await fetch("/api/agent-tokens", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ organizationId, name: name.trim() || "Agent" }) });
+      const body = (await response.json()) as { token?: string; error?: string };
+      if (!response.ok || !body.token) { setError(body.error ?? "Could not create the token"); return; }
+      setMintedToken(body.token); setName(""); router.refresh();
+    } catch {
+      setError("Could not reach the token service. Check your connection and reload the token list before trying again.");
+    } finally {
+      setPending(false);
+    }
   }
 
   async function revoke(id: string) {
-    setError(null); const response = await fetch(`/api/agent-tokens/${id}`, { method: "DELETE" });
-    if (!response.ok) { setError("Could not revoke the token"); return; }
-    router.refresh();
+    setError(null);
+    try {
+      const response = await fetch(`/api/agent-tokens/${id}`, { method: "DELETE" });
+      if (!response.ok) { setError("Could not revoke the token. Reload the list and try again."); return; }
+      router.refresh();
+    } catch {
+      setError("Could not reach the token service. Reload the list to check whether the token was revoked.");
+    }
   }
 
   async function copyToken() {
@@ -40,6 +51,8 @@ export function AgentsPanel({ organizationId, tokens }: { organizationId: string
     <section>
       <h2 className="font-display text-xl font-semibold text-ink">Agent access</h2>
       <p className="mt-1 text-sm leading-relaxed text-stone">Read-only tokens let approved AI tools access the active workspace’s synced meetings through DoodleNote’s hosted MCP server. Revoke them anytime.</p>
+      <p className="mt-2 text-sm font-medium text-ink">Workspace: {workspaceName}</p>
+      <RemoteMcpSetup baseUrl={baseUrl} />
       {(message || error) && <p aria-live="polite" className={`mt-4 text-sm ${error ? "text-red-700 dark:text-red-300" : "text-sage-deep"}`}>{error ?? message}</p>}
       {mintedToken && <div className="mt-5 rounded-xl border border-sand bg-sage-fill/50 p-4"><p className="text-sm font-medium text-ink">Copy this token now. It will not be shown again.</p><p className="mt-2 break-all font-mono text-xs text-ink">{mintedToken}</p><div className="mt-3 flex gap-2"><button type="button" onClick={() => void copyToken()} className="rounded-lg border border-sand bg-card px-3 py-2 text-sm font-medium text-ink hover:bg-sage-fill">Copy token</button><button type="button" onClick={() => setMintedToken(null)} className="px-3 py-2 text-sm text-stone hover:text-ink">Done</button></div></div>}
       {tokens.length > 0 && <ul className="mt-5 overflow-hidden rounded-xl border border-sand bg-card">{tokens.map((token) => <li key={token.id} className="flex items-center justify-between gap-3 border-b border-sand p-4 last:border-b-0"><div className="min-w-0"><p className="truncate text-sm font-medium text-ink">{token.name}</p><p className="mt-0.5 text-xs text-stone">Created {new Date(token.createdAt).toLocaleDateString()}{token.lastUsedAt ? ` · Last used ${new Date(token.lastUsedAt).toLocaleDateString()}` : " · Never used"}</p></div><button type="button" onClick={() => void revoke(token.id)} className="rounded-lg px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50 dark:text-red-300 dark:hover:bg-red-950">Revoke</button></li>)}</ul>}

--- a/apps/web/app/app/settings/agents/page.tsx
+++ b/apps/web/app/app/settings/agents/page.tsx
@@ -1,8 +1,9 @@
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { agentTokens, desc, eq, getDb } from "@repo/db";
+import { listWorkspaceAgentTokens } from "@/lib/agent-token-list";
 
 import { getAppWorkspace } from "@/lib/app-workspace";
+import { resolveAuthBaseUrl } from "@/lib/runtime-config";
 import { AgentsPanel } from "./agents-panel";
 
 export const metadata = { title: "Agent access — DoodleNote" };
@@ -10,6 +11,22 @@ export const metadata = { title: "Agent access — DoodleNote" };
 export default async function AgentSettingsPage() {
   const workspace = await getAppWorkspace(await headers());
   if (!workspace) redirect("/login");
-  const rows = await getDb().select({ id: agentTokens.id, name: agentTokens.name, createdAt: agentTokens.createdAt, lastUsedAt: agentTokens.lastUsedAt }).from(agentTokens).where(eq(agentTokens.userId, workspace.session.user.id)).orderBy(desc(agentTokens.createdAt));
-  return <AgentsPanel organizationId={workspace.activeOrganization.id} tokens={rows.map((token) => ({ id: token.id, name: token.name, createdAt: (token.createdAt ?? new Date()).toISOString(), lastUsedAt: token.lastUsedAt?.toISOString() ?? null }))} />;
+  const rows = await listWorkspaceAgentTokens(
+    workspace.session.user.id,
+    workspace.activeOrganization.id,
+  );
+  return (
+    <AgentsPanel
+      key={workspace.activeOrganization.id}
+      baseUrl={resolveAuthBaseUrl()}
+      workspaceName={workspace.activeOrganization.name}
+      organizationId={workspace.activeOrganization.id}
+      tokens={rows.map((token) => ({
+        id: token.id,
+        name: token.name,
+        createdAt: (token.createdAt ?? new Date()).toISOString(),
+        lastUsedAt: token.lastUsedAt?.toISOString() ?? null,
+      }))}
+    />
+  );
 }

--- a/apps/web/app/app/settings/agents/remote-mcp-setup.tsx
+++ b/apps/web/app/app/settings/agents/remote-mcp-setup.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import {
+  COMPOSIO_AUTH_HEADER,
+  COMPOSIO_DOCS_URL,
+  copyMcpServerUrl,
+  remoteMcpSetup,
+} from "@repo/agent-contract/setup";
+
+export function RemoteMcpSetup({ baseUrl }: { baseUrl: string }) {
+  const setup = remoteMcpSetup(baseUrl);
+  const [copying, setCopying] = useState(false);
+  const [feedback, setFeedback] = useState("");
+
+  async function copy() {
+    if (!setup) return;
+    setCopying(true);
+    setFeedback("");
+    const result = await copyMcpServerUrl(setup.serverUrl, (text) =>
+      navigator.clipboard.writeText(text),
+    );
+    setFeedback(result.message);
+    setCopying(false);
+  }
+
+  return (
+    <section
+      aria-labelledby="remote-mcp-heading"
+      className="mt-6 rounded-xl border border-sand bg-card p-4 text-sm leading-relaxed text-ink"
+    >
+      <h3 id="remote-mcp-heading" className="font-medium">
+        Composio / remote MCP
+      </h3>
+      <p className="mt-2 text-stone">
+        Remote agents read this workspace’s synced notes and transcripts. Cloud
+        Sync access is required on doodlenote.ai. Unsynced local notes and
+        recording audio stay on your device.
+      </p>
+      {setup ? (
+        <>
+          <label htmlFor="remote-mcp-url" className="mt-4 block font-medium">
+            MCP server URL
+          </label>
+          <input
+            id="remote-mcp-url"
+            value={setup.serverUrl}
+            readOnly
+            className="mt-1 w-full min-w-0 rounded-lg border border-sand bg-card p-2 font-mono text-xs text-ink"
+          />
+          <button
+            type="button"
+            onClick={() => void copy()}
+            disabled={copying}
+            className="mt-2 rounded-lg border border-sand px-3 py-2 hover:bg-sage-fill disabled:opacity-50"
+          >
+            {copying ? "Copying…" : "Copy server URL"}
+          </button>
+          <p role="status" className="mt-2 text-stone">
+            {feedback}
+          </p>
+          <ol className="mt-4 list-decimal space-y-2 pl-5">
+            <li>
+              Confirm the workspace above. Create a dedicated token named
+              Composio below and copy it once.
+            </li>
+            <li>
+              In Composio, use display name <strong>DoodleNote</strong> and this
+              URL. Choose API-key authentication, not OAuth or no
+              authentication.
+            </li>
+            <li>
+              Use the DoodleNote token as the connected account’s API key, with
+              header{" "}
+              <code className="break-all text-xs">{COMPOSIO_AUTH_HEADER}</code>.
+              Your Composio project key is a separate credential.
+            </li>
+            <li>
+              Sync the toolkit’s tools and test a read in Composio. Copying the
+              URL does not connect an account.
+            </li>
+          </ol>
+          <details className="mt-4">
+            <summary className="cursor-pointer font-medium">
+              API setup and troubleshooting
+            </summary>
+            <p className="mt-2">
+              If your dashboard only offers OAuth or cannot map the bearer
+              header, use Composio’s Custom MCP API. Register with this body,
+              then create an API-key auth config and connected account using the
+              guide.
+            </p>
+            <pre className="mt-2 whitespace-pre-wrap break-all rounded-lg bg-sage-fill/50 p-3 text-xs">
+              {setup.registrationJson}
+            </pre>
+            <a
+              href={COMPOSIO_DOCS_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="mt-3 inline-block underline"
+            >
+              Composio setup guide
+            </a>
+            <p className="mt-2 text-stone">
+              Subscription required? Check Cloud Sync access in billing. No
+              results? Check this workspace and sync the notes you want to
+              share. Invalid token? Create a replacement here. Service
+              unavailable? Retry later before changing credentials.
+            </p>
+          </details>
+        </>
+      ) : (
+        <p role="status" className="mt-3 text-stone">
+          Composio requires a public HTTPS server. This instance has no HTTPS
+          address configured. Configure its public server address before
+          connecting; localhost is not reachable by Composio.
+        </p>
+      )}
+      <p className="mt-4 text-stone">
+        Local MCP can stay off. Revoke the dedicated token here to stop remote
+        access. Pausing local access or Sync does not revoke a remote token.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/lib/agent-token-list.ts
+++ b/apps/web/lib/agent-token-list.ts
@@ -1,0 +1,23 @@
+import { agentTokens, and, desc, eq, getDb } from "@repo/db";
+
+/** Only return display metadata for the signed-in user's selected workspace. */
+export async function listWorkspaceAgentTokens(
+  userId: string,
+  organizationId: string,
+) {
+  return getDb()
+    .select({
+      id: agentTokens.id,
+      name: agentTokens.name,
+      createdAt: agentTokens.createdAt,
+      lastUsedAt: agentTokens.lastUsedAt,
+    })
+    .from(agentTokens)
+    .where(
+      and(
+        eq(agentTokens.userId, userId),
+        eq(agentTokens.organizationId, organizationId),
+      ),
+    )
+    .orderBy(desc(agentTokens.createdAt));
+}

--- a/apps/web/tests/agent-token-list.test.ts
+++ b/apps/web/tests/agent-token-list.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { organization, user } from "@repo/db/auth-schema";
+import { agentTokens } from "@repo/db/schema";
+import { createInMemoryDb } from "@repo/db/testing";
+import { listWorkspaceAgentTokens } from "../lib/agent-token-list";
+
+test("agent setup lists only the user's tokens in the selected workspace and no secrets", async () => {
+  const mem = await createInMemoryDb();
+  const singleton = globalThis as { __repoDbClient?: unknown };
+  const previous = singleton.__repoDbClient;
+  singleton.__repoDbClient = mem.db;
+  try {
+    await mem.db.insert(user).values([
+      { id: "u1", name: "Fixture One", email: "one@example.test" },
+      { id: "u2", name: "Fixture Two", email: "two@example.test" },
+    ]);
+    await mem.db.insert(organization).values([
+      { id: "w1", name: "Fixture A", slug: "fixture-a", createdAt: new Date() },
+      { id: "w2", name: "Fixture B", slug: "fixture-b", createdAt: new Date() },
+    ]);
+    await mem.db.insert(agentTokens).values([
+      {
+        id: "00000000-0000-4000-8000-000000000001",
+        userId: "u1",
+        organizationId: "w1",
+        name: "Composio A",
+        tokenHash: "fixture-hash-a",
+      },
+      {
+        id: "00000000-0000-4000-8000-000000000002",
+        userId: "u1",
+        organizationId: "w2",
+        name: "Composio B",
+        tokenHash: "fixture-hash-b",
+      },
+      {
+        id: "00000000-0000-4000-8000-000000000003",
+        userId: "u2",
+        organizationId: "w1",
+        name: "Someone else",
+        tokenHash: "fixture-hash-c",
+      },
+    ]);
+    const rows = await listWorkspaceAgentTokens("u1", "w1");
+    assert.deepEqual(
+      rows.map((row) => row.id),
+      ["00000000-0000-4000-8000-000000000001"],
+    );
+    assert.equal(JSON.stringify(rows).includes("tokenHash"), false);
+    assert.deepEqual(
+      (await listWorkspaceAgentTokens("u1", "w2")).map((row) => row.id),
+      ["00000000-0000-4000-8000-000000000002"],
+    );
+    assert.deepEqual(await listWorkspaceAgentTokens("u1", "unknown"), []);
+  } finally {
+    singleton.__repoDbClient = previous;
+    await mem.close();
+  }
+});

--- a/apps/web/tests/mcp-route.test.ts
+++ b/apps/web/tests/mcp-route.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import { after, before, test } from "node:test";
+import { createHash } from "node:crypto";
+import { eq } from "@repo/db";
 
 import { organization, user } from "@repo/db/auth-schema";
-import { agentTokens, meetings, notes } from "@repo/db/schema";
+import { agentTokens, meetings, notes, subscriptions } from "@repo/db/schema";
 import { createInMemoryDb, type InMemoryDb } from "@repo/db/testing";
 
 /**
@@ -32,7 +34,10 @@ function rpc(body: unknown, token = TOKEN): Request {
 
 async function call(method: string, params?: unknown, token = TOKEN) {
   const res = await post(rpc({ jsonrpc: "2.0", id: 1, method, params }, token));
-  return { status: res.status, body: res.status === 202 ? null : await res.json() };
+  return {
+    status: res.status,
+    body: res.status === 202 ? null : await res.json(),
+  };
 }
 
 before(async () => {
@@ -176,4 +181,55 @@ test("tool validation errors surface as isError content, not crashes", async () 
   });
   assert.equal(body.result.isError, true);
   assert.match(body.result.content[0].text, /query is required/);
+});
+
+test("revoking a dedicated remote token denies the next request", async () => {
+  const token = `dnag_${"ef".repeat(32)}`;
+  const tokenHash = createHash("sha256").update(token).digest("hex");
+  await mem.db
+    .insert(agentTokens)
+    .values({
+      tokenHash,
+      userId: "u1",
+      organizationId: "org-a",
+      name: "Revocation fixture",
+    });
+  assert.equal((await call("tools/list", undefined, token)).status, 200);
+  await mem.db.delete(agentTokens).where(eq(agentTokens.tokenHash, tokenHash));
+  assert.equal((await call("tools/list", undefined, token)).status, 401);
+});
+
+test("remote tools lose access when the token owner's entitlement lapses", async () => {
+  // Only entitlement reads run here; these fixtures never call Stripe.
+  const settings = {
+    DOODLENOTE_SELF_HOSTED: "false",
+    STRIPE_SECRET_KEY: "fixture-only",
+    STRIPE_ACCOUNT_ID: "acct_fixture",
+    STRIPE_PRICE_ID: "price_fixture",
+    STRIPE_WEBHOOK_SECRET: "fixture-only",
+    STRIPE_PORTAL_CONFIGURATION_ID: "bpc_fixture",
+  };
+  const previous = Object.fromEntries(
+    Object.keys(settings).map((key) => [key, process.env[key]]),
+  );
+  try {
+    Object.assign(process.env, settings);
+    await mem.db
+      .insert(subscriptions)
+      .values({ userId: "u1", status: "active" });
+    assert.equal((await call("tools/list")).status, 200);
+    await mem.db
+      .update(subscriptions)
+      .set({ status: "canceled" })
+      .where(eq(subscriptions.userId, "u1"));
+    const denied = await call("tools/list");
+    assert.equal(denied.status, 402);
+    assert.equal(denied.body.needsSubscription, true);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    await mem.db.delete(subscriptions).where(eq(subscriptions.userId, "u1"));
+  }
 });

--- a/docs/composio-mcp.md
+++ b/docs/composio-mcp.md
@@ -1,0 +1,139 @@
+# Connect DoodleNote to Composio
+
+DoodleNote's desktop **Settings > Integrations > Composio / remote MCP** provides
+the server URL separately from the local MCP launch configuration. Web
+**Settings > AI agents** shows the same setup for that server.
+
+## Before connecting
+
+- Sign in to the DoodleNote web app and select the workspace you intend to share.
+- Official hosted access requires Cloud Sync entitlement. Only synced notes and
+  transcripts are available. Unsynced local notes and recording audio are not.
+- Create a dedicated agent token named Composio in Settings > AI agents. The token
+  is displayed once. Give it only to the intended Composio connected account.
+- Keep DoodleNote's agent token separate from your Composio project API key.
+  DoodleNote does not collect or store the Composio project key.
+- Local MCP may remain disabled. To revoke remote access, revoke the agent token
+  in web settings. Pausing local MCP or cloud uploads does not revoke that token
+  or remove data already synced.
+
+## Dashboard setup, when available
+
+Use these values in Composio's Add Custom MCP form:
+
+| Field | Value |
+| --- | --- |
+| Display name | DoodleNote |
+| MCP server URL | `https://www.doodlenote.ai/api/mcp` for the official service |
+| Authentication | API key, sent as an Authorization bearer header |
+| Header mapping | `Authorization: Bearer {{generic_api_key}}` |
+| Connected-account API key | Your DoodleNote agent token, without adding a second `Bearer ` prefix |
+
+For self-hosting, use the public HTTPS URL shown by your instance, not the official
+service. Configure `BETTER_AUTH_URL` on the web server and `DOODLE_SYNC_URL` for
+the desktop instance consistently. Do not expose a local stdio process or put
+credentials in a URL. Localhost cannot be reached by Composio.
+
+Composio's Custom MCP feature is experimental. Its documentation currently
+describes API registration; some accounts expose a dashboard form. If the form
+only offers OAuth or cannot configure the bearer header, use the API flow below.
+DoodleNote's hosted MCP does not provide OAuth Dynamic Client Registration.
+Do not choose OAuth or disable authentication to make discovery pass.
+
+## API setup alternative
+
+The following are request templates, not automatically executed by DoodleNote.
+Use a trusted API client with secure credential storage. Do not paste credentials
+into shell history, shared screenshots, documentation, or source files.
+
+1. Register the toolkit with `POST https://backend.composio.dev/api/v3.1/custom/toolkits/upsert`.
+   Authenticate to Composio with its project key in the `x-api-key` header and
+   send this JSON body. The in-app API section generates the same body using
+   your configured server's origin.
+
+   ```json
+   {
+     "slug": "DOODLENOTE",
+     "toolkit_config": {
+       "name": "DoodleNote",
+       "app_url": "https://www.doodlenote.ai/api/mcp",
+       "auth_schemes": [
+         {
+           "mode": "API_KEY",
+           "headers": {
+             "Authorization": "Bearer {{generic_api_key}}"
+           }
+         }
+       ]
+     }
+   }
+   ```
+
+2. Use the returned toolkit slug (normally `CUSTOM_DOODLENOTE`) to create an
+   auth config with `POST https://backend.composio.dev/api/v3.1/auth_configs`:
+
+   ```json
+   {
+     "toolkit": { "slug": "CUSTOM_DOODLENOTE" },
+     "auth_config": {
+       "type": "use_custom_auth",
+       "authScheme": "API_KEY",
+       "credentials": {},
+       "is_enabled_for_tool_router": true
+     }
+   }
+   ```
+
+3. Complete Composio's connected-account flow for that auth config and the
+   intended Composio user. Supply the DoodleNote token as `generic_api_key`.
+   Follow the current [Custom MCP guide](https://docs.composio.dev/docs/extending-sessions/custom-mcp)
+   and [connected-account reference](https://docs.composio.dev/reference/api-reference/connected-accounts).
+   An auth config alone is not an authenticated connection.
+
+4. Once the account is active, verify tool sync. If the initial sync fails, use
+   `POST https://backend.composio.dev/api/v3.1/custom/toolkits/sync` with the
+   returned IDs:
+
+   ```json
+   {
+     "slug": "CUSTOM_DOODLENOTE",
+     "connected_account_id": "YOUR_CONNECTED_ACCOUNT_ID"
+   }
+   ```
+
+5. Include the toolkit in your Composio session. Confirm the intended connected
+   account is selected. Without automatic account matching, select it explicitly
+   in the session's `connected_accounts` configuration as shown in the guide.
+
+Review an existing toolkit before reusing its slug. Composio makes its server URL
+and auth schemes immutable after registration. If they conflict, choose a new
+slug or explicitly plan a replacement; deleting a toolkit also revokes its
+connections. DoodleNote does not replace or delete toolkits for you.
+
+## Verify and troubleshoot
+
+Use a test workspace containing synthetic notes before granting access to real
+meeting content. Confirm discovery of `list_recent_meetings`, `search_meetings`,
+`get_meeting`, `get_meeting_notes`, and `get_meeting_transcript`. Run a read and
+compare it to the expected fixture. An accepted URL or copied snippet is not
+proof of a working connection.
+
+| Symptom | Next check |
+| --- | --- |
+| Invalid token / 401 | Check the connected account's DoodleNote token and bearer header. A revoked token needs replacement. |
+| Subscription required / 402 | Check the token owner's Cloud Sync entitlement in DoodleNote billing. |
+| Empty meeting results | Confirm the workspace and that the intended notes have synced. |
+| Service unavailable / 503 | Retry later; check the DoodleNote web service before rotating credentials. |
+| No active connection | Check the Composio user, auth config and connected-account selection. |
+| Toolkit has no tools | Check sync status and the selected toolkit version in Composio. |
+| GET returns 405 | This stateless endpoint accepts MCP JSON-RPC POST requests, not a browser GET or persistent SSE stream. |
+
+Verify a second workspace's note cannot be read and that revoking the dedicated
+token prevents subsequent requests. Store only redacted results in QA evidence.
+No new server, migration, additional tool permissions, or production configuration
+change is needed for this setup UI.
+
+Vendor contract checked 2026-09-08 against the
+[official documentation source](https://github.com/ComposioHQ/composio/blob/next/docs/content/docs/extending-sessions/custom-mcp.mdx).
+Authenticated Composio interoperability remains a release QA gate until recorded
+against the intended test account; documentation alone does not establish it.

--- a/packages/agent-contract/package.json
+++ b/packages/agent-contract/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./setup": "./src/setup.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/agent-contract/src/setup.ts
+++ b/packages/agent-contract/src/setup.ts
@@ -1,0 +1,57 @@
+/** Browser-safe setup information. Never accepts or stores credentials. */
+export const COMPOSIO_DOCS_URL =
+  "https://docs.composio.dev/docs/extending-sessions/custom-mcp";
+export const COMPOSIO_AUTH_HEADER = "Authorization: Bearer {{generic_api_key}}";
+
+export function remoteMcpSetup(baseUrl: string | undefined) {
+  if (!baseUrl) return null;
+  let origin: URL;
+  try {
+    origin = new URL(baseUrl);
+  } catch {
+    return null;
+  }
+  if (origin.protocol !== "https:" || origin.username || origin.password)
+    return null;
+  const serverUrl = new URL("/api/mcp", origin.origin).href;
+  return {
+    serverUrl,
+    agentsUrl: new URL("/app/settings/agents", origin.origin).href,
+    registrationJson: JSON.stringify(
+      {
+        slug: "DOODLENOTE",
+        toolkit_config: {
+          name: "DoodleNote",
+          app_url: serverUrl,
+          auth_schemes: [
+            {
+              mode: "API_KEY",
+              headers: { Authorization: "Bearer {{generic_api_key}}" },
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    ),
+  };
+}
+
+/** Use a callback so unavailable clipboard APIs also fail inside the guard. */
+export async function copyMcpServerUrl(
+  serverUrl: string,
+  writeText: (text: string) => Promise<void>,
+): Promise<{ ok: boolean; message: string }> {
+  try {
+    await writeText(serverUrl);
+    return {
+      ok: true,
+      message: "Server URL copied. Finish setup in Composio.",
+    };
+  } catch {
+    return {
+      ok: false,
+      message: "Could not copy. Select and copy the server URL above.",
+    };
+  }
+}

--- a/packages/doodle-note-mcp/README.md
+++ b/packages/doodle-note-mcp/README.md
@@ -75,7 +75,7 @@ as the command. Once published to npm, `npx doodle-note-mcp` works too.
 The same five tools are served remotely at `https://www.doodlenote.ai/api/mcp`,
 backed by your cloud-synced meetings instead of the local store — for Claude
 web/mobile, cloud Codex, and agents that don't run on your machine. Mint a
-read-only agent token in the web app (**Workspaces → AI agents**), then:
+read-only agent token in the web app (**Settings → AI agents**), then:
 
 ```bash
 claude mcp add --transport http doodle-note https://www.doodlenote.ai/api/mcp \
@@ -84,6 +84,14 @@ claude mcp add --transport http doodle-note https://www.doodlenote.ai/api/mcp \
 
 Tokens are workspace-scoped and revocable from the same panel. Remote access
 requires cloud sync (it reads the synced copy of your meetings).
+
+### Composio
+
+In desktop **Settings → Integrations → Composio / remote MCP**, copy the server URL
+and open token settings. Composio needs the hosted HTTPS endpoint and API-key
+authentication mapped to an Authorization bearer header; the local launch JSON
+cannot be used as a server URL. See the [Composio setup guide](../../docs/composio-mcp.md)
+for dashboard and API steps, workspace scope, verification, and revocation.
 
 ## Development
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@44.0.0)
+      '@repo/agent-contract':
+        specifier: workspace:*
+        version: link:../../packages/agent-contract
       '@repo/ai':
         specifier: workspace:*
         version: link:../../packages/ai


### PR DESCRIPTION
## Linear Issue
[ONY-267](https://linear.app/onyxdevlabs/issue/ONY-267/add-composio-setup-to-mcp-integrations)

## Outcome
Desktop Integrations now offers Composio / remote MCP with a URL-only copy action, workspace token setup, and API-key bearer instructions. The existing local MCP configuration remains available under Local MCP.

## What Changed
- Added desktop and web setup cards with an API registration body, vendor guide, Cloud Sync/data-scope explanation, and revocation/troubleshooting guidance.
- Reuse the configured server origin via a browser-safe shared setup module. No credentials in URLs or reusable examples, no automatic Composio registration, no OAuth claim or new backend.
- Scope the web token list to the signed-in user's active workspace and remount the token panel on workspace changes. Network failures now release the Create token spinner and explain how to recover.
- Added URL/copy, workspace-token isolation, revocation and entitlement regression coverage, plus a setup guide.

## Evidence
The previous copy action emitted local process-launch JSON. Composio expects a remote HTTPS URL. Existing hosted MCP already accepts workspace-scoped bearer tokens; its authentication and five read-only tools are unchanged.

## Acceptance Criteria Evidence
- [x] Remote setup is outside local-agent opt-in; local connect/disconnect and JSON remain unchanged. Existing local-config tests pass.
- [x] URL-only copy, rejected clipboard, API-key header mapping and no-HTTPS configuration: automated tests and browser fixtures.
- [x] Scope/entitlement/sync, sign-in, empty-result and unavailable-service guidance present; no fabricated connected state.
- [x] Workspace token metadata filtering is verified with a real in-memory database. No hash or secret is returned. Existing one-time creation and revocation permissions are retained.
- [x] Hosted route tests verify five tools, fixture reads, other-workspace denial, token revocation and entitlement lapse.
- [x] Browser fixture smoke: desktop and web cards at normal and 390px widths; copy success/failure, Enter activation, expanded API instructions, no-HTTPS guidance, and token-service network/402 failures. Clipboard and token responses were synthetic; no external account was contacted.
- [ ] Human QA: installed desktop local-client regression, workspace switching and token workflow in the actual app.
- [ ] External QA: approved Composio account and synthetic DoodleNote workspace must discover all five tools and read the intended fixture. No live Composio authorization or production data access was performed.

## Verification
All listed commands passed:
- `pnpm install --frozen-lockfile` (and repeated after the workspace-only dependency addition).
- `pnpm --filter desktop test`: 171 pass, 6 existing skips.
- `pnpm --filter web test`: 124 pass.
- `pnpm --filter doodle-note-mcp test`: 5 pass.
- `pnpm --filter @repo/agent-contract test`: 5 pass.
- `pnpm --filter desktop typecheck`, `pnpm --filter web typecheck`, `pnpm --filter doodle-note-mcp typecheck`, `pnpm --filter @repo/agent-contract typecheck`.
- `pnpm --filter desktop lint`, `pnpm --filter web lint`.
- `pnpm --filter desktop build`, `pnpm --filter web build`.
- `git diff --check`.
- `pnpm audit --prod --audit-level=low`: no known vulnerabilities.

## Preview and review gates
The automatic [Vercel preview](https://doodle-note-git-codex-ony-267-composio-mcp-setup-ony-dev-labs.vercel.app/app/settings/agents) builds, but agent settings returns HTTP 500. Targeted runtime logs confirm `DATABASE_URL is required in production`. The preview needs an explicitly approved isolated database/auth configuration before authenticated QA; no environment settings were changed and the fail-closed database guard was preserved. Use local fixture QA in the meantime.

Alec Tribble is requested as the configured human reviewer. GitHub CI checks, Windows packaging and CodeQL all passed on `60a100df3a229942c3fad3b5ea5ababb316854d6`. Human review is still required.

## Local QA
Use a clean checkout of `codex/ONY-267-composio-mcp-setup`, Node 22+, and `pnpm install --frozen-lockfile`.

Check this:
1. Run `pnpm --filter desktop dev` (the Swift engine is needed only for capture). In Settings > Integrations with local MCP disabled, copy the remote URL. Expect only the configured HTTPS `/api/mcp` URL, visible feedback, and an enabled Open token settings action. Do not enable real integrations merely to inspect the UI.
2. Use Tab/Enter and a narrow settings window. Expect reachable controls, readable feedback, and wrapping API instructions. Reopen Integrations; expect no persisted connection claim.
3. Run `pnpm --filter web dev`; open `/app/settings/agents` using an isolated test account. Local HTTP development correctly shows the public-HTTPS prerequisite. For end-to-end remote QA use a separately approved HTTPS test instance, never a localhost tunnel to real notes.
4. In an authorized test workspace, create a dedicated token. Switch workspaces; expect the matching token list and no retained plaintext from the prior workspace. Simulate offline/token-service failure; expect an actionable error and an enabled Create token button afterward.
5. With explicit test-account access approval, follow `docs/composio-mcp.md` in Composio. Expect five tools and the intended fixture read; another workspace's fixture is denied. Revoke the token and confirm subsequent requests fail.
6. Re-check existing Claude/Codex local connection and Copy snippet on a test profile; expect the original local configuration behavior.

## Risks and Release Notes
No migration, new server, OAuth flow, token transport, or tool-permission expansion. Composio's Custom MCP surface is experimental; the user's dashboard authentication options still require live validation. API setup is documented when the UI cannot map the bearer header.

PRs #117/#145 also touch ModelsView for transcription controls; this diff changes only its integration entry point and labels. There is no shared-contract dependency; recheck merge conflicts at the merge gate.

Stop at reviewed PR. Merge, production deployment, signing/publication, and installed-release verification are separate gates. Rollback is a source/UI revert and the prior approved desktop release. Dedicated QA credentials/toolkits require explicit cleanup authorization.

## Follow-ups
No additional issues created. Live Composio interoperability and installed release evidence remain required before ONY-267 is Done.
