### PR TITLE
Release DoodleNote 0.4.24 with Composio setup

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "private": true,
   "description": "DoodleNote desktop app for privacy-first local capture, transcription, and AI meeting notes",
   "main": "./out/main/index.js",

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,15 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.24",
+    date: "September 8, 2026",
+    highlights: [
+      "Set up Composio and other remote MCP clients from Integrations with a separate server URL and authentication guide",
+      "Manage agent tokens within the selected cloud workspace",
+      "Keep local MCP client setup available alongside remote connections",
+    ],
+  },
+  {
     version: "0.4.23",
     date: "September 7, 2026",
     highlights: [


### PR DESCRIPTION
Prepare the authorized desktop release containing ONY-267. Bumps the desktop version to 0.4.24 and adds the matching website changelog. Shared release checks, local Mac signing/notarization, and updater artifact verification are in progress. The updater manifest will be staged after packaging. Sean approved release and updater publication; product QA follows publication.