### PR TITLE
[ONY-274] Keep My notes navigation stationary on hover

### DIFF
--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -3356,21 +3356,38 @@ button.fp-row:hover {
 }
 
 .folder-menu-btn {
-  display: none;
-  margin-left: 4px;
-  padding: 0 5px;
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 18px;
+  opacity: 0;
+  pointer-events: none;
   border-radius: 6px;
   color: var(--muted);
   font-size: 13px;
   line-height: 1.4;
 }
 
-.folder-row:hover .folder-menu-btn {
-  display: inline-flex;
+.folder-row .nav-count {
+  /* Share a stable slot with the overlaid options button. */
+  min-width: 22px;
+  text-align: right;
 }
 
-.folder-row:hover .nav-count {
-  display: none;
+.folder-row:hover .folder-menu-btn,
+.folder-row:focus-within .folder-menu-btn {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.folder-row:hover .nav-count,
+.folder-row:focus-within .nav-count {
+  visibility: hidden;
 }
 
 .folder-menu-btn:hover {

--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -362,7 +362,10 @@ a,
 
 .folder-add {
   flex-shrink: 0;
-  display: none;
+  /* Reserve the action's space so revealing it cannot resize the row. */
+  display: flex;
+  opacity: 0;
+  pointer-events: none;
   align-items: center;
   justify-content: center;
   width: 18px;
@@ -372,8 +375,10 @@ a,
   font-size: 11px;
 }
 
-.nav-item:hover .folder-add {
-  display: flex;
+.nav-item:hover .folder-add,
+.nav-item:focus-within .folder-add {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .folder-add:hover {


### PR DESCRIPTION
## Summary

[ONY-274](https://linear.app/onyxdevlabs/issue/ONY-274/keep-my-notes-navigation-stationary-on-hover): hovering My notes previously grew the row from 28px to 30px and moved Trash down 2px. Reserve the Create folder button's space so hover and keyboard focus reveal it without moving navigation.

Folder hover also replaces a count with a taller options button: the folder grew 28px → 30.1875px, shifted Trash by 2.1875px, and changed the label's width and vertical position. Overlay Folder options in the count's reserved slot, keeping both row and label geometry stable. Reveal options on pointer hover or keyboard focus.

## Affected surfaces

Desktop sidebar; one CSS selector group in `apps/desktop/src/renderer/src/assets/main.css`. Keep the action in layout with opacity, disable its pointer target while hidden, and reveal it on hover or focus within the row. Existing label, accessible name, event handlers, folder storage and filters are unchanged.

## Bug evidence / acceptance criteria

- [x] Measured the original 2px jump on the built renderer before editing.
- [x] After the fix, every sampled row/Trash x, y, width and height delta is **0px** across 16 cases: light/dark, empty/nonempty initial folders, device scale 1/2 and document zoom 100%/125%. Covered idle, hover, repeated pointer entry/exit, plus hover, focus and selected/unselected states.
- [x] Click, Enter and Space on Create folder each create exactly once without selecting My notes; Tab reaches the action. Screenshots show visible, unclipped focus in both themes.
- [x] Row click, Enter and Space still open all content; synthetic meeting and manual note remain visible. Existing Create folder accessible name and all storage/delete handlers are unchanged by source inspection.
- [ ] Human macOS workflow QA, native display scaling and post-release installed-client verification remain required; Windows native visual QA was not performed.

Browser checks used the actual production renderer with mocked desktop preload APIs and synthetic notes. This is renderer evidence, not installed-app proof. The repository has no existing sidebar layout suite; used an external Playwright harness and retained geometry/screenshots instead of adding a CSS-text assertion or new product dependency.

| Before hover | After with keyboard focus |
| --- | --- |
| ![Before](https://uploads.linear.app/01033051-dabd-43f8-8e09-13f7e0259146/7f49a0e4-530a-448b-895c-ef85e5e9dc05/21dfbd79-4795-4eed-a290-6816409f4a43) | ![After](https://uploads.linear.app/01033051-dabd-43f8-8e09-13f7e0259146/7b4cb253-9138-475a-8a06-55cc223a2fd8/43164ab0-1ef8-4734-8a26-bf7750f29bf5) |

## Verification

Rebased cleanly onto `main` at `5acc41b1ce93e120fe34f1220dc0a13bef03c490` after PR #148 landed; its remote-MCP CSS additions are separate from this selector.

- `pnpm install --frozen-lockfile` — pass.
- `pnpm --filter desktop test` — pass: 171 passed, 6 platform skips, 0 failed (177 total).
- `pnpm --filter desktop typecheck` — pass.
- `pnpm --filter desktop lint` — pass.
- `pnpm --filter desktop build` — pass.
- `git diff --check` — pass.
- `node /tmp/ony274-qa/check.cjs after` — pass, all 16 cases; no renderer page errors. Run against built renderer served with `python3 -m http.server 4274 --bind 127.0.0.1 --directory apps/desktop/out/renderer`.
- CI/CodeQL and human review requested through this PR; results remain authoritative in GitHub.

[Download renderer QA evidence and reproducible harness](https://uploads.linear.app/01033051-dabd-43f8-8e09-13f7e0259146/af62bd58-4e00-4070-9834-0275f9d6aa27/11a7ec8a-68ad-4ff8-83b1-0fff743aa6df).

[Expanded folder QA: harness, measurements and screenshots](https://uploads.linear.app/01033051-dabd-43f8-8e09-13f7e0259146/6a71bddd-99c7-45c2-b613-f0b6b26a63be/fdad0aec-39b9-4ab4-8d84-d7ecef144f09). At head `ca3ff5e`, all 16 cases pass including folder hover/options focus/menu activation and cancel rename. Desktop tests (171 pass, 6 skips), typecheck, lint and build pass. Human QA remains unresolved until the tested build is confirmed; the installed app observed locally is 0.4.18, and this PR is unmerged. CI reruns apply to the new head.

## Local QA

At this branch, run `pnpm install --frozen-lockfile`, then on macOS:
```sh
DOODLE_USER_DATA="$(mktemp -d /tmp/doodle-ony274-human.XXXXXX)" pnpm --filter desktop dev
```
Use the isolated test profile, complete setup, create a manual test note and folder, and use safe test meeting content if checking meeting filtering.

**Check this:**

1. In Spaces, move repeatedly between My notes, its plus, a test folder, its options button and empty sidebar space; rows and labels stay still. Repeat selected/unselected with no folders and with folders. Tab to Folder options, open it with Enter/Space, choose Rename and cancel; geometry and navigation stay stable.
2. Tab from My notes to Create folder; expect a visible focus outline and plus. Activate with Enter/Space and with the pointer; expect one folder input and no accidental row selection. Cancel an empty input and confirm normal navigation.
3. Click/Enter/Space on My notes; expect the existing all-content view. Check an existing folder's contents and ordinary test-note deletion still work.
4. Repeat in light/dark and macOS normal/scaled display settings; focus stays visible and targets do not shift.

## Privacy, compatibility, and release impact

No data flows, permissions, migrations, native code, packaging or version changes. No real meeting content or credentials included. Shared desktop CSS retains the existing Windows behavior while removing the layout shift. Rollback is a focused source revert through normal review/release.

## Follow-up

Sean Inman requested as the other configured CODEOWNER. Remaining gate: human QA/review, then separate merge/release approval. ONY-274 stays In Review until its later installed-and-verified boundary is met. Naming/navigation decisions belong to ONY-272.
