### PR TITLE
Publish Mac 0.4.24 to Settings updater

### DIFF
--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,11 +1,11 @@
-version: 0.4.18
+version: 0.4.24
 files:
-  - url: DoodleNote-0.4.18-arm64-mac.zip
-    sha512: HkOWwPnejqNQgLhxe20QhiB39aY98B+ri3IEj+pEIoKiH+RNTYx2GVtjwGpX18FXbJFoSGrTcmubLm7xDk2tJA==
-    size: 185935094
-  - url: DoodleNote-0.4.18-arm64.dmg
-    sha512: lZWibWgGBeSgxq2uozNk2w0fwS8WqFRSPR+hFZ6OQEeiPcmJXN6nf8bfk1drxQ2YflU2fQVSbXMCAOdh+vDKJg==
-    size: 187883550
-path: DoodleNote-0.4.18-arm64-mac.zip
-sha512: HkOWwPnejqNQgLhxe20QhiB39aY98B+ri3IEj+pEIoKiH+RNTYx2GVtjwGpX18FXbJFoSGrTcmubLm7xDk2tJA==
-releaseDate: '2026-09-01T16:08:55.093Z'
+  - url: DoodleNote-0.4.24-arm64-mac.zip
+    sha512: WjSY24P+Mw4gHxG1SiIKyv7XK+YYZvddS+jhWPMX2IDoy2wvmimFnMBNF/zUtVptHmGwhf4d9fgxtw3gkVft0Q==
+    size: 185983132
+  - url: DoodleNote-0.4.24-arm64.dmg
+    sha512: hIr5Z1W4w6d82HP2HQ+LQ0lhdFk/ns+hssX6WZUbJlsyIaM7k9ICBhyOIsc+LmTqNh+OOV8qyIfI9XST3ts8iQ==
+    size: 187862249
+path: DoodleNote-0.4.24-arm64-mac.zip
+sha512: WjSY24P+Mw4gHxG1SiIKyv7XK+YYZvddS+jhWPMX2IDoy2wvmimFnMBNF/zUtVptHmGwhf4d9fgxtw3gkVft0Q==
+releaseDate: '2026-09-08T17:08:54.404Z'


### PR DESCRIPTION
Publish the authorized Mac 0.4.24 updater manifest. ZIP and DMG were built from the source tree merged in #150, uploaded to the existing release storage, and verified for version, SHA-512, Developer ID signature, Apple notarization, stapled tickets, and Gatekeeper acceptance. The ZIP contains the compiled Swift engine. Shared release checks and all #150 CI checks passed. Merge makes Settings discover 0.4.24; installed update and Sean product QA follow. Windows feeds remain unchanged.