### PR TITLE
[ONY-279] Show remote MCP during active Cloud Sync trials

### DIFF
--- a/apps/web/app/api/sync/account/route.ts
+++ b/apps/web/app/api/sync/account/route.ts
@@ -1,6 +1,6 @@
 import { getDb } from "@repo/db";
 import { entitlementFor } from "@/lib/billing";
-import { hasActivePaidSubscription } from "@/lib/billing-state";
+import { isRemoteMcpEligible } from "@/lib/billing-state";
 import { syncAccountResponse } from "@/lib/sync-account";
 import { authenticateIdentityRequest } from "@/lib/sync-auth";
 import { syncV2Enabled } from "@/lib/sync-v2";
@@ -12,7 +12,7 @@ export async function GET(request: Request) {
       headers: { "Cache-Control": "private, no-store", Vary: "Authorization" } });
     const entitlement = await entitlementFor(device.userId);
     return await syncAccountResponse(getDb(), device, entitlement.entitled, syncV2Enabled(),
-      hasActivePaidSubscription(entitlement));
+      isRemoteMcpEligible(entitlement));
   } catch {
     return Response.json({ error: "account_unavailable" }, { status: 503,
       headers: { "Cache-Control": "private, no-store" } });

--- a/apps/web/lib/billing-state.ts
+++ b/apps/web/lib/billing-state.ts
@@ -30,11 +30,11 @@ export interface SubscriptionState {
   currentPeriodEnd: Date | null;
 }
 
-/** Setup visibility is narrower than Sync access (which includes trials/grace). */
-export function hasActivePaidSubscription(entitlement: Entitlement): boolean {
+/** Setup visibility permits paid subscriptions and active trials, but not grace access. */
+export function isRemoteMcpEligible(entitlement: Entitlement): boolean {
   return entitlement.entitled &&
-    entitlement.subscriptionStatus === "active" &&
-    (entitlement.reason === "active" || entitlement.reason === "grandfathered");
+    (entitlement.subscriptionStatus === "active" || entitlement.subscriptionStatus === "trialing") &&
+    (entitlement.reason === "active" || entitlement.reason === "trialing" || entitlement.reason === "grandfathered");
 }
 
 const SERVING_STATUSES = new Set(["trialing", "active", "past_due"]);

--- a/apps/web/tests/remote-mcp-account.test.ts
+++ b/apps/web/tests/remote-mcp-account.test.ts
@@ -6,7 +6,7 @@ import { createInMemoryDb } from "@repo/db/testing";
 import { hashToken, mintToken } from "../lib/sync-auth";
 import { GET } from "../app/api/sync/account/route";
 
-test("account endpoint exposes paid-only eligibility for the authenticated device without changing Sync access", async () => {
+test("account endpoint exposes paid and active-trial eligibility for the authenticated device without changing Sync access", async () => {
   const { db, close } = await createInMemoryDb({ throughMigration: 12 });
   const globalDb = globalThis as { __repoDbClient?: unknown };
   const previous = globalDb.__repoDbClient;
@@ -46,7 +46,7 @@ test("account endpoint exposes paid-only eligibility for the authenticated devic
         assert.deepEqual(await response.json(), {
           accountId: "paid-owner", workspaceId: "paid-work", workspaceName: "Paid workspace",
           entitled: grandfathered || ["active", "trialing", "past_due"].includes(status),
-          remoteMcpEligible: status === "active", syncAvailable: false, libraries: [],
+          remoteMcpEligible: status === "active" || status === "trialing", syncAvailable: false, libraries: [],
         });
       }
     }

--- a/apps/web/tests/remote-mcp-eligibility.test.ts
+++ b/apps/web/tests/remote-mcp-eligibility.test.ts
@@ -1,22 +1,29 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { entitlementFrom, hasActivePaidSubscription } from "../lib/billing-state";
+import { entitlementFrom, isRemoteMcpEligible } from "../lib/billing-state";
 
-test("remote setup requires active paid status, independently of broad Sync entitlement", () => {
+test("remote setup permits active paid and trialing subscriptions, independently of broad Sync entitlement", () => {
   for (const grandfathered of [false, true]) {
     for (const status of ["active", "trialing", "past_due", "canceled", "unpaid", "incomplete", "incomplete_expired", "paused", "none", "grandfathered", "invalid_price"]) {
       const entitlement = entitlementFrom("stripe", { status, grandfathered, currentPeriodEnd: new Date("2030-01-01") });
-      assert.equal(hasActivePaidSubscription(entitlement), status === "active", `${status}, grandfathered=${grandfathered}`);
+      assert.equal(isRemoteMcpEligible(entitlement), ["active", "trialing"].includes(status), `${status}, grandfathered=${grandfathered}`);
     }
   }
   for (const mode of ["stripe", "self-hosted", "development", "misconfigured"] as const) {
-    assert.equal(hasActivePaidSubscription(entitlementFrom(mode)), false, mode);
+    assert.equal(isRemoteMcpEligible(entitlementFrom(mode)), false, mode);
   }
 });
 
 test("scheduled cancellation retains eligibility only while the paid subscription is active", () => {
   // The existing webhook contract retains active until the paid period ends.
   const state = { status: "active", grandfathered: false, currentPeriodEnd: new Date("2030-01-01") };
-  assert.equal(hasActivePaidSubscription(entitlementFrom("stripe", state)), true);
-  assert.equal(hasActivePaidSubscription(entitlementFrom("stripe", { ...state, status: "canceled" })), false);
+  assert.equal(isRemoteMcpEligible(entitlementFrom("stripe", state)), true);
+  assert.equal(isRemoteMcpEligible(entitlementFrom("stripe", { ...state, status: "canceled" })), false);
+});
+
+test("trial activation, paid conversion and expiration refresh remote setup eligibility", () => {
+  for (const status of ["none", "trialing", "active", "canceled"]) {
+    const entitlement = entitlementFrom("stripe", { status, grandfathered: false, currentPeriodEnd: new Date("2030-01-01") });
+    assert.equal(isRemoteMcpEligible(entitlement), status === "trialing" || status === "active", status);
+  }
 });

--- a/docs/composio-mcp.md
+++ b/docs/composio-mcp.md
@@ -5,8 +5,8 @@ the server URL separately from the local MCP launch configuration. Web
 **Settings > AI agents** shows the same setup for that server.
 
 The desktop section appears only after the linked account is verified to have an
-active paid Cloud Sync subscription. Trials, grandfathered-only access and
-past-due subscriptions do not show it. Local MCP stays available without a paid
+active paid Cloud Sync subscription or an active Cloud Sync trial. Grandfathered-only
+access and past-due subscriptions do not show it. Local MCP stays available without a paid
 plan. Pausing uploads does not hide remote setup for an eligible subscriber.
 Opening Integrations, returning focus to the app, or reconnecting the network
 rechecks eligibility. While checking or when the service is unavailable, the

--- a/docs/qa/ony-279.md
+++ b/docs/qa/ony-279.md
@@ -1,4 +1,4 @@
-# ONY-279: paid-only remote MCP visibility
+# ONY-279: remote MCP visibility for paid subscriptions and active trials
 
 Base: main `1b22e72`. Scope: desktop setup visibility and an additive authenticated
 account field. General Sync entitlement and hosted MCP authorization are unchanged.
@@ -23,8 +23,8 @@ account field. General Sync entitlement and hosted MCP authorization are unchang
 
 | Contract criterion | Evidence |
 | --- | --- |
-| Active paid shows setup | Billing matrix, authenticated account endpoint tests, renderer harness |
-| Trial, grandfathered-only, past-due, canceled, unpaid, incomplete, missing or unlinked hides it | Server matrix and default-deny renderer; unlinked transition checked |
+| Active paid and trialing show setup | Billing matrix, authenticated account endpoint tests, renderer harness |
+| Grandfathered-only, past-due, canceled, unpaid, incomplete, missing or unlinked hides it | Server matrix and default-deny renderer; unlinked transition checked |
 | Broad entitlement, token and upload toggle are insufficient | Endpoint matrix keeps broad Sync states unchanged; desktop client demands explicit eligibility; renderer paid fixture has uploads paused |
 | Pending, malformed, error, unauthorized and missing-field replies hide it | Main client tests plus rendered pending/offline/failure and recovery |
 | Reopen/account/server changes, stale responses, paid-state revalidation | Renderer reopen/focus/online and account revision tests; client token/server/revision race tests |
@@ -57,9 +57,9 @@ Use Stripe test fixtures or existing approved accounts; no live charge is needed
 The normal zero-config/self-hosted server deliberately has no paid eligibility.
 
 Check this:
-1. Link an active paid test subscriber. Open Settings > Integrations; expect the
+1. Link an active paid or active-trial test subscriber. Open Settings > Integrations; expect the
    remote setup section. Pause uploads; reopen Integrations and expect it still.
-2. Use trial, grandfathered-only, past-due and expired/unlinked profiles; expect
+2. Use grandfathered-only, past-due and expired/unlinked profiles; expect
    only Local MCP. An active paid subscription scheduled for future cancellation
    should still show setup until billing changes out of active.
 3. Return from billing after changing the fixture state, disconnect/switch account,
@@ -96,3 +96,23 @@ passed; Local MCP 5 tests, notes engine 16 tests, database 30 tests and workspac
 lint passed. GitHub CI and code-owner approval must pass on the final commit before
 merge and Cloud deployment. The installed paid-account reveal must then be
 verified separately. No schema migration or billing-data edit is required.
+
+
+## Active Cloud Sync trial policy update (2026-09-09)
+
+The owner confirmed that active Cloud Sync trials should also see remote setup.
+The server predicate now permits persisted `active` and `trialing` states while
+continuing to reject missing, expired/canceled, past-due, unpaid, incomplete,
+grandfathered-only, and self-hosted/development-only access. General entitlement,
+token authorization, trial length and billing state are unchanged. The installed
+desktop already consumes the existing boolean, so no desktop update is needed.
+
+Before the predicate change, the updated status matrix, authenticated account
+route and trial lifecycle regression checks failed on `trialing`. Verify they pass
+after the change, deploy the compatible server, then reopen Integrations in the
+linked trial account and confirm the complete setup appears beside Local MCP.
+
+Follow-up local verification passed: frozen install, 128 web tests, web typecheck,
+lint, authentication smoke, production build, and production dependency audit
+(no known vulnerabilities). GitHub checks and live trial-account verification
+remain separate deployment gates.


### PR DESCRIPTION
Active Cloud Sync trials were hidden by the paid-only check introduced in #157. This follow-up implements the confirmed ONY-279 policy: linked `active` and `trialing` subscriptions receive `remoteMcpEligible: true`, so the existing desktop shows the full Composio / remote MCP setup after reopening Integrations.

Past-due, canceled/expired, unpaid, incomplete, missing, grandfathered-only and self-hosted/development-only access remain hidden. General Sync entitlement, billing state, trial duration and hosted token authorization are unchanged. No desktop rebuild or migration is needed.

## Verification

The trial status matrix, real authenticated account route and trial lifecycle regression failed on `trialing` before the predicate change and pass afterward. Local checks passed: frozen install; 128 web tests; web typecheck, lint, authentication smoke and production build; production dependency audit reports no known vulnerabilities. The required GitHub `checks` job, CodeQL and Vercel preview pass on `4cc7aa7`. [CI run](https://github.com/Onyx-Dev-Labs/doodle-note/actions/runs/34380521680).

Check this:
1. In the installed local app linked to an active Cloud Sync trial, reopen Settings > Integrations after Cloud deployment; expect Composio / remote MCP and the existing setup controls.
2. Paid active remains eligible; expired/canceled or past-due remains hidden.
3. Local MCP stays available independently of remote eligibility.

The user authorized this Cloud rollout and bypassing the pending review for this delivery. Required CI remains a gate. Public desktop release and updater publication are excluded.

Refs [ONY-279](https://linear.app/onyxdevlabs/issue/ONY-279/show-remote-mcp-for-active-paid-and-trial-cloud-sync-subscribers).
