### PR TITLE
[ONY-268] Resolve client_secret errors in desktop Google Calendar

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -2,6 +2,7 @@ name: Mac release
 
 # Builds, signs, notarizes, and publishes the Mac updater feed.
 # Required repo secrets:
+#   DOODLENOTE_GOOGLE_CLIENT_SECRET (Desktop client, not Web)
 #   BLOB_READ_WRITE_TOKEN
 #   MAC_CSC_LINK (base64 .p12) + MAC_CSC_KEY_PASSWORD
 #   APPLE_ID + APPLE_APP_SPECIFIC_PASSWORD + APPLE_TEAM_ID
@@ -38,10 +39,12 @@ jobs:
 
       - name: Package Mac app (signed + notarized)
         run: |
+          node apps/desktop/scripts/check-google-oauth.mjs
           pnpm --filter doodle-note-mcp build
           pnpm --filter desktop exec electron-vite build
           pnpm --filter desktop exec electron-builder --mac
         env:
+          DOODLENOTE_GOOGLE_CLIENT_SECRET: ${{ secrets.DOODLENOTE_GOOGLE_CLIENT_SECRET }}
           CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -89,3 +89,39 @@ Check permission denial/unavailable engine recovery, both menu-bar appearances,
 scaled/Retina displays, keyboard menu operation, calendar countdown coexistence,
 and quitting during capture. Packaging, release and installed-version evidence
 remain separate approval gates under `docs/RELEASING.md`.
+
+### Google Calendar in official desktop builds
+
+Downloaded official apps use DoodleNote's **Desktop** OAuth client. Users only
+select Connect Google and consent to read-only Calendar access; they do not need
+Node, a fork, Google Cloud setup, or a personal application secret.
+
+Maintainers supply `DOODLENOTE_GOOGLE_CLIENT_SECRET` in the build environment from
+secure credential storage. It must belong to the Desktop client declared in
+`src/shared/google-app.ts`, never the separate Web client. `electron-vite` embeds
+it only in the main-process bundle. Do not paste its value in source, `.env`
+examples, logs, issues, or chat. Build injection keeps the value out of Git, but
+**cannot make an installed-app credential confidential**: it is extractable from
+the distributed binary. PKCE, state, browser consent, loopback redirects, and
+OS-encrypted user refresh tokens remain necessary.
+
+The Mac release workflow reads the GitHub Actions repository secret named
+`DOODLENOTE_GOOGLE_CLIENT_SECRET`. Local Mac packaging and Windows publishing
+require the same environment variable. Generic development builds and unsigned
+Windows CI packages can build without it, but Google connection then gives a
+configuration error before opening a browser. They are not Google-enabled
+release artifacts. Changing the environment after building does not update an
+existing bundle: rebuild before packaging.
+
+Keep the client ID during secret rotation so existing refresh tokens remain
+associated with the same registration. Securely save a replacement, update the
+build input, build and test fresh connect plus expiry/restart refresh, and then
+release through the normal approved process. Do not disable the outgoing
+credential until dependent builds are retired. Users whose refresh tokens were
+revoked must reconnect Google; notes and calendar preferences must be preserved.
+
+Google Console must have Calendar API enabled, External production audience,
+verified branding/domain ownership, and verified declarations matching the
+actual `openid email https://www.googleapis.com/auth/calendar.readonly` request.
+OAuth verification requires a real working-flow demo; a successful unit test or
+branding check is not Google approval.

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -4,6 +4,11 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   main: {
+    define: {
+      __DOODLENOTE_GOOGLE_CLIENT_SECRET__: JSON.stringify(
+        process.env.DOODLENOTE_GOOGLE_CLIENT_SECRET?.trim() ?? ''
+      )
+    },
     // electron-vite externalizes every package.json dependency of the main
     // build by default. @repo/ai is unbuilt workspace TS source, so it must
     // be BUNDLED (excluded here); its native dep node-llama-cpp must stay

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,10 +15,10 @@
     "test": "tsx --test src/main/*.test.ts src/renderer/src/lib/*.test.ts",
     "lint": "eslint --cache .",
     "format": "prettier --write .",
-    "package": "pnpm --filter doodle-note-mcp build && electron-vite build && APPLE_KEYCHAIN_PROFILE=doodlenote-notary electron-builder --mac",
+    "package": "node scripts/check-google-oauth.mjs && pnpm --filter doodle-note-mcp build && electron-vite build && APPLE_KEYCHAIN_PROFILE=doodlenote-notary electron-builder --mac",
     "package:win": "pnpm --filter doodle-note-mcp build && electron-vite build && electron-builder --win --x64",
     "release": "pnpm package && node scripts/publish-release.mjs --mac",
-    "release:win": "pnpm package:win && powershell -NoProfile -ExecutionPolicy Bypass -File scripts/verify-windows-signature.ps1 && node scripts/publish-release.mjs --win",
+    "release:win": "node scripts/check-google-oauth.mjs && pnpm package:win && powershell -NoProfile -ExecutionPolicy Bypass -File scripts/verify-windows-signature.ps1 && node scripts/publish-release.mjs --win",
     "publish:win-beta": "node scripts/publish-windows-beta.mjs"
   },
   "dependencies": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "private": true,
   "description": "DoodleNote desktop app for privacy-first local capture, transcription, and AI meeting notes",
   "main": "./out/main/index.js",

--- a/apps/desktop/scripts/check-google-oauth.mjs
+++ b/apps/desktop/scripts/check-google-oauth.mjs
@@ -1,0 +1,7 @@
+// Public release guard. Never print the credential or read it from tracked files.
+if (!process.env.DOODLENOTE_GOOGLE_CLIENT_SECRET?.trim()) {
+  console.error(
+    'DOODLENOTE_GOOGLE_CLIENT_SECRET is required to package an official release with Google Calendar. Supply the Desktop client credential through secure build configuration.'
+  )
+  process.exit(1)
+}

--- a/apps/desktop/src/main/calendar-refresh.test.ts
+++ b/apps/desktop/src/main/calendar-refresh.test.ts
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { createRequire } from 'node:module'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  DEFAULT_CALENDAR_PREFS,
+  type CalendarEvent,
+  type CalendarInfo
+} from '../shared/calendar-api'
+const require = createRequire(import.meta.url)
+const loader = require('node:module') as { _load: (id: string, ...args: unknown[]) => unknown }
+const originalLoad = loader._load
+loader._load = (id, ...args) => (id === 'electron' ? {} : originalLoad(id, ...args))
+const { CalendarService } = require('./calendar-service') as typeof import('./calendar-service')
+loader._load = originalLoad
+const oldSync = '2026-01-01T00:00:00.000Z'
+const calendar = (id: string): CalendarInfo => ({
+  id,
+  name: 'Fixture',
+  colorHex: '#123456',
+  isDefault: true,
+  canEdit: false
+})
+const event = (id: string, calendarId: string): CalendarEvent => ({
+  id,
+  calendarId,
+  subject: 'Fixture',
+  startIso: '2099-01-01T00:00:00.000Z',
+  endIso: '2099-01-01T01:00:00.000Z',
+  isAllDay: false,
+  isOnlineMeeting: false,
+  hasParticipants: true
+})
+interface RefreshFixture {
+  prefs: { visibleCalendarIds: string[] | null }
+  account: unknown
+  rawEvents: CalendarEvent[]
+  calendars: CalendarInfo[]
+  googleCalendars: CalendarInfo[]
+  lastSyncIso: string
+  lastError?: string
+  eventCachePath: string
+  google: {
+    signedIn: boolean
+    fetchCalendars(): Promise<CalendarInfo[]>
+    fetchEvents(c: CalendarInfo): Promise<CalendarEvent[]>
+  }
+  fetchCalendars(): Promise<CalendarInfo[]>
+  fetchCalendarView(token: string, c: CalendarInfo): Promise<CalendarEvent[]>
+  refreshEvents(): Promise<void>
+  loadEventCache(): { googleCalendars?: CalendarInfo[] }
+}
+function fixture(microsoft = false): RefreshFixture {
+  return Object.assign(Object.create(CalendarService.prototype), {
+    refreshBusy: false,
+    account: microsoft ? {} : null,
+    rawEvents: [event('old-google', 'g:primary'), ...(microsoft ? [event('old-ms', 'ms')] : [])],
+    calendars: microsoft ? [calendar('ms')] : [],
+    googleCalendars: [calendar('g:primary')],
+    prefs: { ...DEFAULT_CALENDAR_PREFS },
+    lastSyncIso: oldSync,
+    google: {
+      signedIn: true,
+      fetchCalendars: async () => [calendar('g:primary')],
+      fetchEvents: async () => [event('new-google', 'g:primary')]
+    },
+    getAccessToken: async () => 'fixture-token',
+    fetchCalendars: async () => [calendar('ms')],
+    fetchCalendarView: async () => [event('new-ms', 'ms')],
+    saveEventCache: () => {},
+    checkMeetingStarts: () => {},
+    broadcastState: () => {}
+  }) as RefreshFixture
+}
+
+test('Google list failure keeps cached data and timestamp; healthy Microsoft still refreshes', async () => {
+  const s = fixture(true)
+  s.google.fetchCalendars = async () => {
+    throw new Error('Google Calendar is not configured correctly. Update DoodleNote.')
+  }
+  await s.refreshEvents()
+  assert.deepEqual(s.rawEvents.map((e) => e.id).sort(), ['new-ms', 'old-google'])
+  assert.equal(s.lastSyncIso, oldSync)
+  assert.match(s.lastError!, /^Google Calendar/)
+  s.google.fetchCalendars = async () => [calendar('g:primary')]
+  await s.refreshEvents()
+  assert.equal(s.lastError, undefined)
+  assert.notEqual(s.lastSyncIso, oldSync)
+  assert.deepEqual(s.rawEvents.map((e) => e.id).sort(), ['new-google', 'new-ms'])
+})
+
+test('Google-only event failure is not successful empty sync and cached calendars reload', async (t) => {
+  const s = fixture()
+  s.google.fetchEvents = async () => {
+    throw new Error('Google Calendar could not be reached. Check your connection and try again.')
+  }
+  await s.refreshEvents()
+  assert.equal(s.lastSyncIso, oldSync)
+  assert.equal(s.rawEvents[0]?.id, 'old-google')
+  assert.match(s.lastError!, /^Google Calendar/)
+  assert.doesNotMatch(s.lastError!, /Microsoft/)
+  const dir = mkdtempSync(join(tmpdir(), 'calendar-refresh-'))
+  t.after(() => rmSync(dir, { recursive: true, force: true }))
+  s.eventCachePath = join(dir, 'calendar-cache.json')
+  writeFileSync(
+    s.eventCachePath,
+    JSON.stringify({ events: s.rawEvents, googleCalendars: s.googleCalendars })
+  )
+  assert.deepEqual(s.loadEventCache().googleCalendars, s.googleCalendars)
+})
+
+test('Microsoft failure does not prevent Google refresh or erase Microsoft cache', async () => {
+  const s = fixture(true)
+  s.fetchCalendars = async () => {
+    throw new Error('Microsoft calendar unavailable')
+  }
+  await s.refreshEvents()
+  assert.deepEqual(s.rawEvents.map((e) => e.id).sort(), ['new-google', 'old-ms'])
+  assert.equal(s.lastSyncIso, oldSync)
+  assert.match(s.lastError!, /Microsoft/)
+})
+
+test('partial calendar failure preserves failed events while successful empty calendar clears old events', async () => {
+  const s = fixture()
+  s.rawEvents.push(event('old-other', 'g:other'))
+  s.google.fetchCalendars = async () => [calendar('g:primary'), calendar('g:other')]
+  s.google.fetchEvents = async (c) => {
+    if (c.id === 'g:primary') throw new Error('Google Calendar temporary failure')
+    return []
+  }
+  await s.refreshEvents()
+  assert.deepEqual(
+    s.rawEvents.map((e) => e.id),
+    ['old-google']
+  )
+  assert.equal(s.lastSyncIso, oldSync)
+})
+
+test('an explicitly selected Google calendar does not fetch hidden Microsoft events', async () => {
+  const s = fixture(true)
+  s.prefs.visibleCalendarIds = ['g:primary']
+  s.fetchCalendarView = async () => {
+    assert.fail('hidden Microsoft calendar must not be fetched')
+  }
+  await s.refreshEvents()
+  assert.equal(s.lastError, undefined)
+  assert.notEqual(s.lastSyncIso, oldSync)
+  assert.deepEqual(
+    s.rawEvents.map((e) => e.id),
+    ['new-google']
+  )
+})

--- a/apps/desktop/src/main/calendar-service.ts
+++ b/apps/desktop/src/main/calendar-service.ts
@@ -456,7 +456,7 @@ export class CalendarService {
     this.prefs = next
     this.saveSettings()
     this.broadcastState()
-    if (visibilityChanged && this.account) void this.refreshEvents()
+    if (visibilityChanged && (this.account || this.google.signedIn)) void this.refreshEvents()
     return this.state()
   }
 
@@ -550,6 +550,7 @@ export class CalendarService {
 
   private async disconnectGoogle(): Promise<CalendarState> {
     this.google.disconnect()
+    this.lastError = undefined
     this.googleCalendars = []
     this.rawEvents = this.rawEvents.filter((e) => !e.calendarId.startsWith('g:'))
     if (this.account === null) {
@@ -684,55 +685,56 @@ export class CalendarService {
     if (this.refreshBusy || (!this.account && !this.google.signedIn)) return
     this.refreshBusy = true
     try {
-      let token: string | null = null
-      if (this.account) {
-        token = await this.getAccessToken()
-        if (token !== null) {
-          this.calendars = await this.fetchCalendars(token)
-        } else if (!this.google.signedIn) {
-          return // lastError already explains
-        }
-      }
-      if (this.google.signedIn) {
-        try {
-          this.googleCalendars = await this.google.fetchCalendars()
-        } catch (err) {
-          // Google blip must not kill the Microsoft sync (and vice versa).
-          if (this.googleCalendars.length === 0) throw err
-          console.error('[calendar] google calendar list refresh failed:', err)
-        }
-      }
-      const visible = resolveVisibleCalendars(
-        this.allCalendars(),
-        this.prefs.visibleCalendarIds
-      ).filter((calendar) => (calendar.id.startsWith('g:') ? true : token !== null))
-      // Per-calendar fetches run in parallel; one failing shared calendar
-      // must not kill the sync, so failures are collected, not thrown.
-      const results = await Promise.allSettled(
-        visible.map((calendar) =>
-          calendar.id.startsWith('g:')
-            ? this.google.fetchEvents(calendar)
-            : this.fetchCalendarView(token as string, calendar)
-        )
+      // Providers refresh independently. Preserve the failed provider/calendar's
+      // cached meetings, and never advance the full-sync timestamp on partial failure.
+      const providers = [...(this.account ? [false] : []), ...(this.google.signedIn ? [true] : [])]
+      const loaded = await Promise.allSettled(
+        providers.map(async (google) => {
+          const token = google ? null : await this.getAccessToken()
+          if (!google && token === null) {
+            throw new Error(this.lastError ?? 'Microsoft calendar sign-in is required.')
+          }
+          const calendars = google
+            ? await this.google.fetchCalendars()
+            : await this.fetchCalendars(token as string)
+          if (google) this.googleCalendars = calendars
+          else this.calendars = calendars
+          return token
+        })
       )
-      const lists: CalendarEvent[][] = []
-      let firstFailure: unknown
-      results.forEach((result, i) => {
-        if (result.status === 'fulfilled') {
-          lists.push(result.value)
-        } else {
-          firstFailure ??= result.reason
-          console.error(`[calendar] sync failed for “${visible[i]?.name}”:`, result.reason)
-        }
-      })
-      // …but when every fetch failed there is nothing fresh at all — surface
-      // the first reason and keep the previous events.
-      if (lists.length === 0 && visible.length > 0) {
-        throw firstFailure instanceof Error ? firstFailure : new Error(String(firstFailure))
-      }
-      this.rawEvents = mergeCalendarEvents(lists)
-      this.lastSyncIso = new Date().toISOString()
-      this.lastError = undefined
+      // Resolve selection once across both providers, including cached calendars
+      // when a provider's list failed. A hidden provider must stay hidden.
+      const visible = resolveVisibleCalendars(this.allCalendars(), this.prefs.visibleCalendarIds)
+      const results = await Promise.all(
+        providers.map(async (google, providerIndex) => {
+          const cached = this.rawEvents.filter(
+            (event) => event.calendarId.startsWith('g:') === google
+          )
+          const loadedProvider = loaded[providerIndex]!
+          if (loadedProvider.status === 'rejected') {
+            return { events: cached, errors: [friendlyError(loadedProvider.reason)] }
+          }
+          const calendars = visible.filter((calendar) => calendar.id.startsWith('g:') === google)
+          const fetched = await Promise.allSettled(
+            calendars.map((calendar) =>
+              google
+                ? this.google.fetchEvents(calendar)
+                : this.fetchCalendarView(loadedProvider.value as string, calendar)
+            )
+          )
+          const errors: string[] = []
+          const lists = fetched.map((result, index) => {
+            if (result.status === 'fulfilled') return result.value
+            errors.push(friendlyError(result.reason))
+            return cached.filter((event) => event.calendarId === calendars[index]?.id)
+          })
+          return { events: mergeCalendarEvents(lists), errors }
+        })
+      )
+      this.rawEvents = mergeCalendarEvents(results.map((result) => result.events))
+      const errors = results.flatMap((result) => result.errors)
+      if (errors.length === 0) this.lastSyncIso = new Date().toISOString()
+      this.lastError = errors.length ? [...new Set(errors)].join(' ') : undefined
       this.saveEventCache()
       // Catch an already-imminent meeting without waiting for the next tick.
       this.checkMeetingStarts()
@@ -744,37 +746,28 @@ export class CalendarService {
     }
   }
 
-  /** GET /me/calendars — the account's calendar list. Falls back to the
-   *  cached list when Graph hiccups so a blip never blanks the sync. */
+  /** GET /me/calendars. The refresh coordinator preserves cached data on failure. */
   private async fetchCalendars(accessToken: string): Promise<CalendarInfo[]> {
     const params = new URLSearchParams({
       $select: 'id,name,color,hexColor,isDefaultCalendar,canEdit',
       $top: '50'
     })
-    try {
-      const res = await fetch(`https://graph.microsoft.com/v1.0/me/calendars?${params}`, {
-        headers: { Authorization: `Bearer ${accessToken}` }
-      })
-      if (!res.ok) {
-        throw new Error(await graphErrorMessage(res))
-      }
-      const body = (await res.json()) as { value?: unknown }
-      const items = Array.isArray(body.value) ? body.value : []
-      const calendars: CalendarInfo[] = []
-      for (const item of items) {
-        const calendar = normalizeGraphCalendar(item)
-        if (calendar) calendars.push(calendar)
-      }
-      // Every mailbox has a default calendar; an empty list is a Graph blip.
-      if (calendars.length === 0) throw new Error('Microsoft returned no calendars')
-      return calendars
-    } catch (err) {
-      if (this.calendars.length > 0) {
-        console.error('[calendar] calendar list refresh failed, using cached list:', err)
-        return this.calendars
-      }
-      throw err
+    const res = await fetch(`https://graph.microsoft.com/v1.0/me/calendars?${params}`, {
+      headers: { Authorization: `Bearer ${accessToken}` }
+    })
+    if (!res.ok) {
+      throw new Error(await graphErrorMessage(res))
     }
+    const body = (await res.json()) as { value?: unknown }
+    const items = Array.isArray(body.value) ? body.value : []
+    const calendars: CalendarInfo[] = []
+    for (const item of items) {
+      const calendar = normalizeGraphCalendar(item)
+      if (calendar) calendars.push(calendar)
+    }
+    // Every mailbox has a default calendar; an empty list is a Graph blip.
+    if (calendars.length === 0) throw new Error('Microsoft returned no calendars')
+    return calendars
   }
 
   /** GET /me/calendars/{id}/calendarView for the next LOOKAHEAD_DAYS. */
@@ -1057,6 +1050,9 @@ export class CalendarService {
       return {
         events,
         ...(calendars.length > 0 ? { calendars } : {}),
+        ...(Array.isArray(raw.googleCalendars)
+          ? { googleCalendars: raw.googleCalendars.filter(isStoredCalendarInfo) }
+          : {}),
         ...(typeof raw.lastSyncIso === 'string' ? { lastSyncIso: raw.lastSyncIso } : {}),
         ...(raw.account && typeof raw.account.email === 'string'
           ? {
@@ -1274,6 +1270,7 @@ async function graphErrorMessage(res: Response): Promise<string> {
 /** Turn auth/network failures into one calm sentence for the Settings card. */
 function friendlyError(err: unknown): string {
   const message = err instanceof Error ? err.message : String(err)
+  if (/^Google Calendar/i.test(message)) return clip(message)
   if (/AADSTS700016|unauthorized_client/i.test(message)) {
     return 'Microsoft didn’t recognize that Client ID — double-check the app registration.'
   }

--- a/apps/desktop/src/main/google-calendar.test.ts
+++ b/apps/desktop/src/main/google-calendar.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict'
+import { test, type TestContext } from 'node:test'
+import { createRequire } from 'node:module'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createHash } from 'node:crypto'
+
+const require = createRequire(import.meta.url)
+const loader = require('node:module') as { _load: (id: string, ...args: unknown[]) => unknown }
+const originalLoad = loader._load
+let browser: (url: string) => Promise<void> = async () => {}
+loader._load = (id, ...args) =>
+  id === 'electron'
+    ? {
+        shell: { openExternal: (url: string) => browser(url) },
+        safeStorage: {
+          encryptString: (value: string) => Buffer.from(`encrypted:${value}`),
+          decryptString: (value: Buffer) => value.toString().replace(/^encrypted:/, '')
+        }
+      }
+    : originalLoad(id, ...args)
+const { GoogleCalendarClient } = require('./google-calendar') as typeof import('./google-calendar')
+loader._load = originalLoad
+const secret = 'synthetic-desktop-credential'
+const calendar = {
+  id: 'g:primary',
+  name: 'Test calendar',
+  colorHex: '#123456',
+  isDefault: true,
+  canEdit: false
+}
+const response = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status })
+
+function setup(
+  t: TestContext,
+  persisted = false,
+  credential = secret
+): { client: InstanceType<typeof GoogleCalendarClient>; cache: string; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'google-calendar-test-'))
+  const cache = join(dir, 'google-token-cache')
+  if (persisted)
+    writeFileSync(
+      cache,
+      'encrypted:' + JSON.stringify({ refreshToken: 'fixture-refresh', email: 'qa@example.test' })
+    )
+  t.after(() => rmSync(dir, { recursive: true, force: true }))
+  return { client: new GoogleCalendarClient(dir, credential), cache, dir }
+}
+
+test('initial exchange includes desktop credential, PKCE and matching redirect; restart refresh uses same credential', async (t) => {
+  const { client, cache, dir } = setup(t)
+  const networkFetch = globalThis.fetch
+  const grants: string[] = []
+  let auth: URL
+  browser = async (url) => {
+    auth = new URL(url)
+    const callback = new URL(auth.searchParams.get('redirect_uri')!)
+    callback.searchParams.set('code', 'fixture-code')
+    callback.searchParams.set('state', auth.searchParams.get('state')!)
+    await networkFetch(callback)
+  }
+  t.mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input)
+    if (url === 'https://oauth2.googleapis.com/token') {
+      const params = new URLSearchParams(init?.body as URLSearchParams)
+      assert.equal(params.get('client_secret'), secret)
+      grants.push(params.get('grant_type')!)
+      if (params.get('grant_type') === 'authorization_code') {
+        assert.equal(params.get('redirect_uri'), auth.searchParams.get('redirect_uri'))
+        assert.equal(
+          createHash('sha256').update(params.get('code_verifier')!).digest('base64url'),
+          auth.searchParams.get('code_challenge')
+        )
+        assert.equal(
+          auth.searchParams.get('scope'),
+          'openid email https://www.googleapis.com/auth/calendar.readonly'
+        )
+      } else assert.equal(params.get('refresh_token'), 'fixture-refresh')
+      return response({
+        access_token: 'fixture-access',
+        expires_in: 3600,
+        refresh_token: 'fixture-refresh'
+      })
+    }
+    assert.match(url, /^https:\/\/www.googleapis.com\/calendar\/v3\//)
+    return response({ items: [{ id: 'primary', summary: 'Test calendar', primary: true }] })
+  })
+  await client.connect()
+  assert.match(readFileSync(cache, 'utf8'), /^encrypted:/)
+  await client.fetchCalendars()
+  await new GoogleCalendarClient(dir, secret).fetchCalendars()
+  assert.deepEqual(grants, ['authorization_code', 'refresh_token'])
+})
+
+test('missing credential fails before browser/network and preserves persisted credentials', async (t) => {
+  const { client, cache } = setup(t, true, '')
+  browser = async () => assert.fail('must not open browser with missing configuration')
+  t.mock.method(globalThis, 'fetch', async () => assert.fail('must not send unconfigured request'))
+  await assert.rejects(client.connect(), /Google Calendar.*configured.*Update DoodleNote/)
+  await assert.rejects(client.fetchCalendars(), /Google Calendar.*configured/)
+  assert.match(readFileSync(cache, 'utf8'), /fixture-refresh/)
+})
+
+test('Google missing-client-secret response gives application recovery without leaking provider payload; retry succeeds', async (t) => {
+  const { client, cache } = setup(t, true)
+  let failed = true
+  t.mock.method(globalThis, 'fetch', async (input: string | URL | Request) => {
+    if (String(input).includes('oauth2.googleapis.com')) {
+      if (failed)
+        return response(
+          {
+            error: 'invalid_request',
+            error_description: 'client_secret is missing. private-provider-detail'
+          },
+          400
+        )
+      return response({ access_token: 'fixture-access', expires_in: 3600 })
+    }
+    return response({ items: [{ id: 'primary' }] })
+  })
+  await assert.rejects(client.fetchCalendars(), (error) => {
+    assert.match(String(error), /Google Calendar.*Update DoodleNote/)
+    assert.doesNotMatch(String(error), /private-provider-detail|synthetic-desktop/)
+    return true
+  })
+  assert.match(readFileSync(cache, 'utf8'), /fixture-refresh/)
+  failed = false
+  assert.equal((await client.fetchCalendars()).length, 1)
+})
+
+test('expired access token refreshes, invalid grant requests reconnect, disconnect removes only Google tokens', async (t) => {
+  const { client, cache, dir } = setup(t, true)
+  writeFileSync(join(dir, 'notes-fixture'), 'preserve')
+  t.mock.timers.enable({ apis: ['Date'], now: 1_000_000 })
+  let refreshes = 0
+  let revoked = false
+  t.mock.method(globalThis, 'fetch', async (input: string | URL | Request) => {
+    if (String(input).includes('oauth2.googleapis.com')) {
+      refreshes++
+      return revoked
+        ? response({ error: 'invalid_grant' }, 400)
+        : response({ access_token: 'fixture-access', expires_in: 3600 })
+    }
+    return response({ items: [] })
+  })
+  await client.fetchEvents(calendar)
+  await client.fetchEvents(calendar)
+  assert.equal(refreshes, 1)
+  t.mock.timers.tick(3_600_000)
+  await client.fetchEvents(calendar)
+  assert.equal(refreshes, 2)
+  revoked = true
+  t.mock.timers.tick(3_600_000)
+  await assert.rejects(client.fetchEvents(calendar), /Google Calendar.*reconnect/i)
+  client.disconnect()
+  assert.equal(client.signedIn, false)
+  assert.throws(() => readFileSync(cache))
+  assert.equal(readFileSync(join(dir, 'notes-fixture'), 'utf8'), 'preserve')
+})

--- a/apps/desktop/src/main/google-calendar.test.ts
+++ b/apps/desktop/src/main/google-calendar.test.ts
@@ -84,7 +84,8 @@ test('initial exchange includes desktop credential, PKCE and matching redirect; 
         refresh_token: 'fixture-refresh'
       })
     }
-    assert.match(url, /^https:\/\/www.googleapis.com\/calendar\/v3\//)
+    assert.equal(new URL(url).origin, 'https://www.googleapis.com')
+    assert.ok(new URL(url).pathname.startsWith('/calendar/v3/'))
     return response({ items: [{ id: 'primary', summary: 'Test calendar', primary: true }] })
   })
   await client.connect()
@@ -107,7 +108,7 @@ test('Google missing-client-secret response gives application recovery without l
   const { client, cache } = setup(t, true)
   let failed = true
   t.mock.method(globalThis, 'fetch', async (input: string | URL | Request) => {
-    if (String(input).includes('oauth2.googleapis.com')) {
+    if (String(input) === 'https://oauth2.googleapis.com/token') {
       if (failed)
         return response(
           {
@@ -137,7 +138,7 @@ test('expired access token refreshes, invalid grant requests reconnect, disconne
   let refreshes = 0
   let revoked = false
   t.mock.method(globalThis, 'fetch', async (input: string | URL | Request) => {
-    if (String(input).includes('oauth2.googleapis.com')) {
+    if (String(input) === 'https://oauth2.googleapis.com/token') {
       refreshes++
       return revoked
         ? response({ error: 'invalid_grant' }, 400)

--- a/apps/desktop/src/main/google-calendar.ts
+++ b/apps/desktop/src/main/google-calendar.ts
@@ -4,6 +4,7 @@ import { createServer } from 'node:http'
 import { join } from 'node:path'
 import { safeStorage, shell } from 'electron'
 import { BUILT_IN_GOOGLE_CLIENT_ID } from '../shared/google-app'
+import { googleClientSecret, googleConfigurationError, googleTokenError } from './google-oauth'
 import type { CalendarAccount, CalendarEvent, CalendarInfo } from '../shared/calendar-api'
 
 const SCOPES = 'openid email https://www.googleapis.com/auth/calendar.readonly'
@@ -32,7 +33,10 @@ export class GoogleCalendarClient {
   private tokens: StoredTokens | null = null
   private access: AccessToken | null = null
 
-  constructor(userDataDir: string) {
+  constructor(
+    userDataDir: string,
+    private readonly clientSecret = googleClientSecret()
+  ) {
     this.cachePath = join(userDataDir, 'google-token-cache')
     this.tokens = this.readCache()
   }
@@ -47,6 +51,7 @@ export class GoogleCalendarClient {
 
   /** Browser OAuth: resolves once Google redirects back to the loopback. */
   async connect(): Promise<CalendarAccount> {
+    if (!this.clientSecret) throw googleConfigurationError()
     const verifier = randomBytes(32).toString('base64url')
     const challenge = createHash('sha256').update(verifier).digest('base64url')
     const state = randomBytes(16).toString('hex')
@@ -60,8 +65,9 @@ export class GoogleCalendarClient {
         }
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
         res.end(
-          '<html><body style="font-family:-apple-system,sans-serif;background:#f7f5ee;color:#26281f;display:flex;align-items:center;justify-content:center;height:100vh;margin:0"><div style="text-align:center"><h2>Google Calendar connected</h2><p>You can close this tab and return to DoodleNote.</p></div></body></html>'
+          '<html><body style="font-family:-apple-system,sans-serif;background:#f7f5ee;color:#26281f;display:flex;align-items:center;justify-content:center;height:100vh;margin:0"><div style="text-align:center"><h2>Return to DoodleNote</h2><p>You can close this tab and return to DoodleNote.</p></div></body></html>'
         )
+        clearTimeout(timeout)
         server.close()
         const returnedState = url.searchParams.get('state')
         const code = url.searchParams.get('code')
@@ -78,7 +84,10 @@ export class GoogleCalendarClient {
         reject(new Error('Google sign-in timed out — try again'))
       }, AUTH_TIMEOUT_MS)
       timeout.unref()
-      server.on('error', reject)
+      server.on('error', (error) => {
+        clearTimeout(timeout)
+        reject(error)
+      })
       server.listen(0, '127.0.0.1', () => {
         const address = server.address()
         const port = typeof address === 'object' && address ? address.port : 0
@@ -93,13 +102,19 @@ export class GoogleCalendarClient {
           code_challenge_method: 'S256',
           state
         })
-        void shell.openExternal(`https://accounts.google.com/o/oauth2/v2/auth?${params}`)
+        void shell
+          .openExternal(`https://accounts.google.com/o/oauth2/v2/auth?${params}`)
+          .catch(() => {
+            clearTimeout(timeout)
+            server.close()
+            reject(new Error('Google Calendar could not open your browser. Try connecting again.'))
+          })
         // Rebuild the redirect_uri for the token exchange below.
         this.pendingRedirect = `http://127.0.0.1:${port}/callback`
       })
     })
 
-    const body = await tokenRequest({
+    const body = await tokenRequest(this.clientSecret, {
       grant_type: 'authorization_code',
       code,
       code_verifier: verifier,
@@ -128,7 +143,7 @@ export class GoogleCalendarClient {
     if (this.access && Date.now() < this.access.expiresAtMs - 60_000) {
       return this.access.token
     }
-    const body = await tokenRequest({
+    const body = await tokenRequest(this.clientSecret, {
       grant_type: 'refresh_token',
       refresh_token: this.tokens.refreshToken
     })
@@ -142,7 +157,9 @@ export class GoogleCalendarClient {
     const res = await fetch(
       'https://www.googleapis.com/calendar/v3/users/me/calendarList?maxResults=50',
       { headers: { Authorization: `Bearer ${token}` } }
-    )
+    ).catch(() => {
+      throw new Error('Google Calendar could not be reached. Check your connection and try again.')
+    })
     if (!res.ok) throw new Error(await googleErrorMessage(res))
     const body = (await res.json()) as { items?: unknown[] }
     const calendars: CalendarInfo[] = []
@@ -180,7 +197,9 @@ export class GoogleCalendarClient {
     const res = await fetch(
       `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(rawId)}/events?${params}`,
       { headers: { Authorization: `Bearer ${token}` } }
-    )
+    ).catch(() => {
+      throw new Error('Google Calendar could not be reached. Check your connection and try again.')
+    })
     if (!res.ok) throw new Error(await googleErrorMessage(res))
     const body = (await res.json()) as { items?: unknown[] }
     const events: CalendarEvent[] = []
@@ -222,18 +241,35 @@ interface TokenResponse {
   id_token?: string
 }
 
-async function tokenRequest(params: Record<string, string>): Promise<TokenResponse> {
+async function tokenRequest(
+  clientSecret: string,
+  params: Record<string, string>
+): Promise<TokenResponse> {
+  if (!clientSecret) throw googleConfigurationError()
   const res = await fetch('https://oauth2.googleapis.com/token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
+      ...params,
       client_id: BUILT_IN_GOOGLE_CLIENT_ID,
-      ...params
+      client_secret: clientSecret
     })
+  }).catch(() => {
+    throw new Error('Google Calendar could not be reached. Check your connection and try again.')
   })
-  const body = (await res.json()) as TokenResponse & { error_description?: string; error?: string }
-  if (!res.ok || typeof body.access_token !== 'string') {
-    throw new Error(body.error_description ?? body.error ?? `Google token error ${res.status}`)
+  const body = (await res.json().catch(() => ({}))) as TokenResponse & {
+    error_description?: string
+    error?: string
+  }
+  if (
+    !res.ok ||
+    typeof body.access_token !== 'string' ||
+    !body.access_token ||
+    typeof body.expires_in !== 'number' ||
+    !Number.isFinite(body.expires_in) ||
+    body.expires_in <= 0
+  ) {
+    throw googleTokenError(body.error, body.error_description, res.status)
   }
   return body
 }
@@ -294,8 +330,13 @@ function normalizeGoogleEvent(raw: unknown, calendar: CalendarInfo): CalendarEve
 
 async function googleErrorMessage(res: Response): Promise<string> {
   try {
-    const body = (await res.json()) as { error?: { message?: string } }
-    return body.error?.message ?? `Google Calendar error ${res.status}`
+    await res.json()
+    if (res.status === 401)
+      return 'Google Calendar authorization expired. Open Settings > Calendar and reconnect Google.'
+    if (res.status === 403)
+      return 'Google Calendar access was denied. Check your Google account permissions and reconnect.'
+    if (res.status === 429) return 'Google Calendar is rate-limiting requests. Try again shortly.'
+    return `Google Calendar request failed (HTTP ${res.status}). Try again.`
   } catch {
     return `Google Calendar error ${res.status}`
   }

--- a/apps/desktop/src/main/google-oauth.ts
+++ b/apps/desktop/src/main/google-oauth.ts
@@ -1,0 +1,39 @@
+/** Injected only into the main-process bundle by electron-vite, never the renderer. */
+declare const __DOODLENOTE_GOOGLE_CLIENT_SECRET__: string
+
+export function googleClientSecret(): string {
+  return typeof __DOODLENOTE_GOOGLE_CLIENT_SECRET__ === 'string'
+    ? __DOODLENOTE_GOOGLE_CLIENT_SECRET__
+    : ''
+}
+
+export function googleConfigurationError(): Error {
+  return new Error(
+    'Google Calendar is not configured correctly in this build. Update DoodleNote or contact support.'
+  )
+}
+
+/** Never display/log raw token endpoint payloads, which may contain credentials. */
+export function googleTokenError(code: unknown, description: unknown, status: number): Error {
+  if (
+    code === 'invalid_client' ||
+    code === 'unauthorized_client' ||
+    code === 'deleted_client' ||
+    (typeof description === 'string' && /client_secret/i.test(description))
+  ) {
+    return googleConfigurationError()
+  }
+  if (code === 'invalid_grant') {
+    return new Error(
+      'Google Calendar authorization expired or was revoked. Open Settings > Calendar and reconnect Google.'
+    )
+  }
+  if (code === 'access_denied') {
+    return new Error(
+      'Google Calendar access was denied. Reconnect Google and allow read-only calendar access.'
+    )
+  }
+  return new Error(
+    `Google Calendar sign-in could not finish (HTTP ${status}). Try again or contact support.`
+  )
+}

--- a/apps/desktop/src/shared/google-app.ts
+++ b/apps/desktop/src/shared/google-app.ts
@@ -2,7 +2,8 @@
  * DoodleNote's Google OAuth client (Desktop-app type).
  *
  * The desktop OAuth flow is a public-client flow secured with PKCE and a
- * loopback redirect. Calendar access is read-only; no client secret is used.
+ * loopback redirect. Calendar access is read-only. The desktop credential is
+ * supplied separately to the main-process build; never put its value here.
  */
 export const BUILT_IN_GOOGLE_CLIENT_ID =
   '788495366298-3u0etj9tpm6jfrnlv8igcrm0t18mkrmr.apps.googleusercontent.com'

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -200,3 +200,23 @@ commands mutate production storage and require explicit authorization.
   separately.
 - [ ] Do not mark the release complete until publication, updater visibility,
   installation, and manual verification have each been observed.
+
+### Google Calendar credential gate
+
+Before an official desktop release, securely supply
+`DOODLENOTE_GOOGLE_CLIENT_SECRET` for DoodleNote's existing **Desktop** OAuth
+registration. The Mac workflow uses the identically named repository secret.
+Local `pnpm --filter desktop package` and `release:win` check for it before
+building. Generic `build` and CI `package:win` remain credential-free and do not
+qualify as Google-enabled production packages. Do not reuse a previously built
+bundle after changing the credential. Verify the packaged app's fresh Google
+connect, calendar list, selected events, expiry refresh and quit/relaunch before
+publication. Keep Microsoft connected for an isolation test: a Google failure
+must preserve Google cached events, allow Microsoft to refresh, display the
+Google error, and leave the last fully successful sync timestamp unchanged.
+
+Credential values are injected into the main process, never committed. Installed
+binaries can be inspected; this is not confidential-server secret storage.
+Rotation and public OAuth verification remain maintainer operations, not end-user
+setup. A source fix does not repair previously installed versions until a tested,
+approved update is distributed.

--- a/docs/qa/mac-release-0.4.25.md
+++ b/docs/qa/mac-release-0.4.25.md
@@ -1,0 +1,22 @@
+# Mac release candidate 0.4.25
+
+Status: Preparing, not published.
+
+Includes the accepted desktop integration from PR #163 (6b90f68) and Google Calendar fix PR #164. Do not merge the original feature PRs again.
+
+## Release notes
+
+- macOS: Restore Google Calendar connection and refresh after restarting DoodleNote, with clearer recovery messages and preserved cached meetings on sync failures.
+- Use one dog/calendar tray with Compact and Full Island modes and today-only upcoming meetings.
+- Generate notes after Stop, resume recordings, and regenerate notes with the latest transcript.
+- Reuse installed local notes models and improve recording startup and setup feedback.
+- Cancel and retry abandoned Cloud connections.
+
+## Release gates
+
+- Production identity: com.doodlenote.desktop; Developer ID Application: SEAN INMAN (VTZW6K32K4).
+- Package separately from publishing. Require accepted notarization, stapled tickets, Gatekeeper, and nested signature validation.
+- Verify upgrade preserves notes, settings, selected models, and stored credentials.
+- Smoke Record / Stop / Resume / regenerate, single tray with Compact / Full Island and today-only meetings, Cloud cancel / retry, and Google Calendar connect / refresh / restart.
+- Publish Mac artifacts and latest-mac.yml only. Preserve Windows artifacts, download and update feed.
+- Owner explicitly authorized review bypass, PR #164 merge, and necessary release merges after verification. Do not change repository protection rules.


### PR DESCRIPTION
## Summary

Desktop Google Calendar sends no client credential after the Aug 3 cleanup in PR #62. A synthetic refresh request against the existing Google Desktop OAuth client reproduces HTTP 400 `client_secret is missing.` The live registration is still a Desktop client with an enabled replacement credential, so changing client identity is unnecessary.

Restore the Desktop client credential on authorization-code exchange and refresh, supplied through secure build configuration. Keep the existing client ID, PKCE/state, loopback callback, read-only scopes, and encrypted refresh-token cache. Configuration failures now tell users to update/contact support; revoked consent directs them to reconnect. Failed reads retain cached meetings and the prior successful-sync timestamp while the other provider continues syncing.

## Affected surfaces

Electron desktop Google authorization, calendar synchronization/cache, and official Mac/Windows release configuration. No web or native mobile changes.

## Verification

- [x] Regression tests cover real loopback callback with mocked token endpoint, PKCE, code exchange, encrypted-cache reload, refresh expiry, missing credentials, safe errors, recovery, disconnect, partial calendar failures, provider isolation, and selected-calendar filtering.
- [x] `pnpm --filter desktop test`: 257 passed, 6 existing platform skips, 0 failed.
- [x] `pnpm --filter desktop typecheck` and `pnpm --filter desktop lint` passed.
- [x] `DOODLENOTE_GOOGLE_CLIENT_SECRET=synthetic-build-test-only pnpm --filter desktop build` passed. Synthetic value appears only in the main bundle, never preload/renderer.
- [x] Packaging guard rejects absent/blank credentials, accepts synthetic configured input, and never logs the value. `git diff --check` passed.
- [ ] Real-account sign-in/expiry/restart QA in a packaged Mac build and installed-release verification remain outstanding.

## Privacy, compatibility, and release impact

- [x] No real credentials, tokens, meeting content, or personal fixture data are included.
- [x] Maintainer/release documentation updated. Official Mac packaging and Windows release now require `DOODLENOTE_GOOGLE_CLIENT_SECRET`; Mac release workflow reads the corresponding repository secret. Generic development/build and unsigned Windows CI remain credential-free and show actionable Google configuration errors.
- [x] Missing credential blocks official packaging. A Desktop credential remains extractable from installed software, as expected for installed-app OAuth; this does not convert it into a confidential server credential. Never substitute the Web client's secret.

Keep the same Desktop client ID to preserve refresh-token compatibility. The owner generated the replacement Desktop credential on September 10; it is saved in the repository Actions secret and the Onyx Dev 1Password vault. The disabled July 7 secret was removed by the owner. Retain the enabled Aug 25 credential until the replacement build is verified. The Mac release version is now 0.4.25, with release notes and gates in docs/qa/mac-release-0.4.25.md. No artifact publication or installed-app repair is claimed here.

## Follow-up

Google branding and requested consent-scope declarations were corrected separately in the authorized console session. DNS domain ownership and Google's app verification remain pending; a truthful working-flow demo requires real account QA. These gates are distinct from this token-request fix.

[ONY-268](https://linear.app/onyxdevlabs/issue/ONY-268/resolve-client-secret-errors-in-desktop-google-calendar) stays open until an approved release is installed and verified. Maintainer review, required CI, replacement credential setup, and real-account QA are required before release.

The owner authorized merging this PR with a review bypass on September 11 and a Mac-only 0.4.25 release after signing, notarization, upgrade preservation, and smoke checks. PR #163 is already on main; its original feature PRs must not be merged again. No Windows artifact or updater publication is authorized.
