### PR TITLE
Allow explicit complimentary Composio setup for legacy accounts

### DIFF
--- a/apps/web/app/api/sync/account/route.ts
+++ b/apps/web/app/api/sync/account/route.ts
@@ -1,4 +1,4 @@
-import { getDb } from "@repo/db";
+import { eq, getDb, user } from "@repo/db";
 import { entitlementFor } from "@/lib/billing";
 import { isRemoteMcpEligible } from "@/lib/billing-state";
 import { syncAccountResponse } from "@/lib/sync-account";
@@ -11,8 +11,18 @@ export async function GET(request: Request) {
     if (!device) return Response.json({ error: "invalid_account" }, { status: 401,
       headers: { "Cache-Control": "private, no-store", Vary: "Authorization" } });
     const entitlement = await entitlementFor(device.userId);
+    let remoteMcpEligible = isRemoteMcpEligible(entitlement);
+    // Explicit complimentary setup access preserves the existing legacy account.
+    // Never substitute a paid Stripe status or broaden Cloud Sync entitlement.
+    const complimentaryEmails = (process.env.DOODLENOTE_REMOTE_MCP_COMPLIMENTARY_EMAILS ?? "")
+      .split(",").map((email) => email.trim().toLowerCase()).filter(Boolean);
+    if (!remoteMcpEligible && entitlement.entitled && entitlement.reason === "grandfathered" && complimentaryEmails.length) {
+      const [account] = await getDb().select({ email: user.email, verified: user.emailVerified })
+        .from(user).where(eq(user.id, device.userId)).limit(1);
+      remoteMcpEligible = account?.verified === true && complimentaryEmails.includes(account.email.toLowerCase());
+    }
     return await syncAccountResponse(getDb(), device, entitlement.entitled, syncV2Enabled(),
-      isRemoteMcpEligible(entitlement));
+      remoteMcpEligible);
   } catch {
     return Response.json({ error: "account_unavailable" }, { status: 503,
       headers: { "Cache-Control": "private, no-store" } });

--- a/apps/web/tests/remote-mcp-account.test.ts
+++ b/apps/web/tests/remote-mcp-account.test.ts
@@ -56,6 +56,22 @@ test("account endpoint exposes paid and active-trial eligibility for the authent
     assert.equal(free.workspaceId, "free-work");
     assert.equal(free.remoteMcpEligible, false);
     assert.equal(free.entitled, false);
+    // Complimentary access only applies to the authenticated, verified legacy owner.
+    process.env.DOODLENOTE_REMOTE_MCP_COMPLIMENTARY_EMAILS = " PAID@example.test ";
+    await db.execute(sql`update subscriptions set status='grandfathered',grandfathered=true where user_id='paid-owner'`);
+    const legacyBefore = await db.execute(sql`select * from subscriptions where user_id='paid-owner'`);
+    const complimentary = await (await GET(request(paidToken))).json();
+    assert.equal(complimentary.remoteMcpEligible, true);
+    assert.equal(complimentary.accountId, "paid-owner");
+    assert.equal(complimentary.workspaceId, "paid-work");
+    assert.equal(complimentary.entitled, true);
+    assert.deepEqual((await db.execute(sql`select * from subscriptions where user_id='paid-owner'`)).rows, legacyBefore.rows);
+    assert.equal((await (await GET(request(freeToken))).json()).remoteMcpEligible, false);
+    await db.execute(sql`update "user" set email_verified=false where id='paid-owner'`);
+    assert.equal((await (await GET(request(paidToken))).json()).remoteMcpEligible, false);
+    await db.execute(sql`update "user" set email_verified=true where id='paid-owner'`);
+    delete process.env.DOODLENOTE_REMOTE_MCP_COMPLIMENTARY_EMAILS;
+    assert.equal((await (await GET(request(paidToken))).json()).remoteMcpEligible, false);
     process.env.DOODLENOTE_SELF_HOSTED = "true";
     const selfHosted = await (await GET(request(paidToken))).json();
     assert.equal(selfHosted.entitled, true);

--- a/docs/composio-mcp.md
+++ b/docs/composio-mcp.md
@@ -150,3 +150,15 @@ Vendor contract checked 2026-09-08 against the
 [official documentation source](https://github.com/ComposioHQ/composio/blob/next/docs/content/docs/extending-sessions/custom-mcp.mdx).
 Authenticated Composio interoperability remains a release QA gate until recorded
 against the intended test account; documentation alone does not establish it.
+
+## Complimentary setup access for an existing legacy account
+
+Maintainers can set `DOODLENOTE_REMOTE_MCP_COMPLIMENTARY_EMAILS` on the hosted
+server to a comma-separated list of verified account email addresses. This
+allows the desktop setup panel for those authenticated accounts only while they
+retain grandfathered Cloud Sync entitlement. It does not create a Stripe
+customer or subscription, change billing status, grant workspace membership,
+or modify notes, tokens, or device links. Remote MCP still requires its normal
+workspace-scoped token and server authorization. Remove an address to revoke
+this setup visibility exception; separately revoke any existing agent tokens
+if remote access must end. Keep actual account addresses out of Git.


### PR DESCRIPTION
Existing legacy Cloud Sync users can sync successfully while the desktop silently hides Composio setup because setup eligibility requires an active or trialing Stripe status.

Add an explicit deployment-configured email allowlist for verified, authenticated legacy accounts. This grants setup visibility without creating a subscription, changing stored billing state, or touching cloud notes, workspace membership, agent tokens, or device links. All existing remote MCP authentication and entitlement checks remain in place. The allowlist defaults to empty; removing an entry rolls back its exception. Account addresses are not committed.

Validation: reproduced the missing panel in 0.4.25; new account-route regression failed before the change and passes after it. Tests cover account/workspace identity preservation, unchanged subscription rows, other-account isolation, unverified email denial, and revocation. Existing paid/trial eligibility tests, web typecheck, targeted ESLint and diff checks pass.
