### PR TITLE
Support complimentary setup access for legacy account IDs

### DIFF
--- a/apps/web/app/api/sync/account/route.ts
+++ b/apps/web/app/api/sync/account/route.ts
@@ -16,6 +16,11 @@ export async function GET(request: Request) {
     // Never substitute a paid Stripe status or broaden Cloud Sync entitlement.
     const complimentaryEmails = (process.env.DOODLENOTE_REMOTE_MCP_COMPLIMENTARY_EMAILS ?? "")
       .split(",").map((email) => email.trim().toLowerCase()).filter(Boolean);
+    const complimentaryAccountIds = (process.env.DOODLENOTE_REMOTE_MCP_COMPLIMENTARY_ACCOUNT_IDS ?? "")
+      .split(",").map((id) => id.trim()).filter(Boolean);
+    if (!remoteMcpEligible && entitlement.entitled && entitlement.reason === "grandfathered") {
+      remoteMcpEligible = complimentaryAccountIds.includes(device.userId);
+    }
     if (!remoteMcpEligible && entitlement.entitled && entitlement.reason === "grandfathered" && complimentaryEmails.length) {
       const [account] = await getDb().select({ email: user.email, verified: user.emailVerified })
         .from(user).where(eq(user.id, device.userId)).limit(1);

--- a/apps/web/tests/remote-mcp-account.test.ts
+++ b/apps/web/tests/remote-mcp-account.test.ts
@@ -69,6 +69,13 @@ test("account endpoint exposes paid and active-trial eligibility for the authent
     assert.equal((await (await GET(request(freeToken))).json()).remoteMcpEligible, false);
     await db.execute(sql`update "user" set email_verified=false where id='paid-owner'`);
     assert.equal((await (await GET(request(paidToken))).json()).remoteMcpEligible, false);
+    // An explicit immutable account ID also supports pre-verification legacy owners.
+    process.env.DOODLENOTE_REMOTE_MCP_COMPLIMENTARY_ACCOUNT_IDS = " paid-owner , free-owner ";
+    assert.equal((await (await GET(request(paidToken))).json()).remoteMcpEligible, true);
+    assert.equal((await (await GET(request(freeToken))).json()).remoteMcpEligible, false);
+    assert.deepEqual((await db.execute(sql`select * from subscriptions where user_id='paid-owner'`)).rows, legacyBefore.rows);
+    delete process.env.DOODLENOTE_REMOTE_MCP_COMPLIMENTARY_ACCOUNT_IDS;
+    assert.equal((await (await GET(request(paidToken))).json()).remoteMcpEligible, false);
     await db.execute(sql`update "user" set email_verified=true where id='paid-owner'`);
     delete process.env.DOODLENOTE_REMOTE_MCP_COMPLIMENTARY_EMAILS;
     assert.equal((await (await GET(request(paidToken))).json()).remoteMcpEligible, false);

--- a/docs/composio-mcp.md
+++ b/docs/composio-mcp.md
@@ -161,4 +161,10 @@ customer or subscription, change billing status, grant workspace membership,
 or modify notes, tokens, or device links. Remote MCP still requires its normal
 workspace-scoped token and server authorization. Remove an address to revoke
 this setup visibility exception; separately revoke any existing agent tokens
-if remote access must end. Keep actual account addresses out of Git.
+if remote access must end. For legacy owners whose email verification predates the current auth flow,
+maintainers may instead set `DOODLENOTE_REMOTE_MCP_COMPLIMENTARY_ACCOUNT_IDS`
+to a comma-separated list of immutable, independently confirmed existing user IDs.
+This applies the same grandfathered entitlement requirement and never changes
+email verification. The ID is taken from the authenticated device, not request
+parameters. Remove the ID to revoke this exception. Keep actual account
+addresses and IDs out of Git.


### PR DESCRIPTION
Legacy accounts can have Cloud Sync entitlement while their historical email-verification flag is false, so the verified-email complimentary grant still hides Composio setup. Add an optional server-side allowlist of independently confirmed immutable account IDs, matched only against authenticated device identity and only while grandfathered entitlement remains valid.

No billing status, email-verification flag, workspace membership, notes, or device credentials are changed. Removing the configured ID revokes the setup exception.

Validation: regression reproduced before the change and passes afterward, including revocation, non-entitled account denial, authenticated identity isolation, and unchanged subscription data. Web typecheck and targeted ESLint pass.
