### PR TITLE
Release Mac 0.4.26 with Google Calendar approval notice

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "private": true,
   "description": "DoodleNote desktop app for privacy-first local capture, transcription, and AI meeting notes",
   "main": "./out/main/index.js",

--- a/apps/desktop/src/renderer/src/GoogleCalendarPending.tsx
+++ b/apps/desktop/src/renderer/src/GoogleCalendarPending.tsx
@@ -1,0 +1,22 @@
+import { useId, type ReactNode } from 'react'
+
+/** New connections stay unavailable until Google approves app verification. */
+export function GoogleCalendarPending({
+  buttonClassName,
+  children
+}: {
+  buttonClassName: string
+  children: ReactNode
+}): React.JSX.Element {
+  const descriptionId = useId()
+  return (
+    <div className="google-calendar-pending">
+      <button type="button" className={buttonClassName} disabled aria-describedby={descriptionId}>
+        {children}
+      </button>
+      <span id={descriptionId} className="google-calendar-pending-note">
+        Awaiting Google verification approval.
+      </span>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/ModelsView.tsx
+++ b/apps/desktop/src/renderer/src/ModelsView.tsx
@@ -1,3 +1,4 @@
+import { GoogleCalendarPending } from './GoogleCalendarPending'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   AUDIO_PERSIST_STORAGE_KEY,
@@ -421,18 +422,6 @@ export default function ModelsView({
     }
   }
 
-  const [googleConnecting, setGoogleConnecting] = useState(false)
-
-  const connectGoogle = async (): Promise<void> => {
-    if (googleConnecting) return
-    setGoogleConnecting(true)
-    try {
-      setCalState(await window.calendar.connectGoogle())
-    } finally {
-      setGoogleConnecting(false)
-    }
-  }
-
   const syncCalendar = async (): Promise<void> => {
     if (syncing) return
     setSyncing(true)
@@ -757,17 +746,10 @@ export default function ModelsView({
                       {connecting ? 'Waiting for your browser…' : 'Sign in with Microsoft'}
                     </span>
                   </button>
-                  <button
-                    type="button"
-                    className="ms-signin"
-                    disabled={googleConnecting}
-                    onClick={() => void connectGoogle()}
-                  >
+                  <GoogleCalendarPending buttonClassName="ms-signin">
                     <GoogleLogo />
-                    <span>
-                      {googleConnecting ? 'Waiting for your browser…' : 'Sign in with Google'}
-                    </span>
-                  </button>
+                    <span>Sign in with Google</span>
+                  </GoogleCalendarPending>
                   {!calState.builtIn && (
                     <button
                       type="button"
@@ -839,15 +821,10 @@ export default function ModelsView({
                       </button>
                     )}
                     {!calState.googleSignedIn && (
-                      <button
-                        type="button"
-                        className="provider-btn"
-                        disabled={googleConnecting}
-                        onClick={() => void connectGoogle()}
-                      >
+                      <GoogleCalendarPending buttonClassName="provider-btn">
                         <GoogleLogo />
-                        {googleConnecting ? 'Waiting for your browser…' : 'Connect Google'}
-                      </button>
+                        Connect Google
+                      </GoogleCalendarPending>
                     )}
                     {calState.googleSignedIn && (
                       <button

--- a/apps/desktop/src/renderer/src/OnboardingTour.tsx
+++ b/apps/desktop/src/renderer/src/OnboardingTour.tsx
@@ -1,3 +1,4 @@
+import { GoogleCalendarPending } from './GoogleCalendarPending'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { CalendarState } from '../../shared/calendar-api'
 import type { DetectState } from '../../shared/detect-api'
@@ -42,7 +43,7 @@ function OnboardingTour({
     cancel: cancelSync
   } = useSyncConnection()
   const [notes, setNotes] = useState<NotesSettingsView | null>(null)
-  const [busy, setBusy] = useState<'ms' | 'google' | null>(null)
+  const [busy, setBusy] = useState<'ms' | null>(null)
   const [stepIndex, setStepIndex] = useState(0)
 
   useEffect(() => {
@@ -91,15 +92,6 @@ function OnboardingTour({
     setBusy('ms')
     try {
       await window.calendar.connect()
-    } finally {
-      setBusy(null)
-    }
-  }, [])
-
-  const connectGoogle = useCallback(async () => {
-    setBusy('google')
-    try {
-      await window.calendar.connectGoogle()
     } finally {
       setBusy(null)
     }
@@ -211,14 +203,9 @@ function OnboardingTour({
                 >
                   {busy === 'ms' ? 'Waiting for browser…' : 'Connect Microsoft 365'}
                 </button>
-                <button
-                  type="button"
-                  className="tour-action"
-                  disabled={busy !== null}
-                  onClick={() => void connectGoogle()}
-                >
-                  {busy === 'google' ? 'Waiting for browser…' : 'Connect Google'}
-                </button>
+                <GoogleCalendarPending buttonClassName="tour-action">
+                  Connect Google
+                </GoogleCalendarPending>
               </div>
             )}
             <p className="tour-footnote">Optional — you can always start meetings by hand.</p>

--- a/apps/desktop/src/renderer/src/assets/main.css
+++ b/apps/desktop/src/renderer/src/assets/main.css
@@ -3502,10 +3502,25 @@ button.fp-row:hover {
   cursor: default;
 }
 
-/* Google sign-in placeholder */
-.ms-signin.google-soon {
+/* Explain why Google connection controls are temporarily unavailable. */
+.google-calendar-pending {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.google-calendar-pending > button:disabled {
   opacity: 0.55;
-  cursor: default;
+  filter: grayscale(1);
+  cursor: not-allowed;
+}
+
+.google-calendar-pending-note {
+  max-width: 230px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .soon-badge {

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,17 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
+    version: "0.4.25",
+    date: "September 11, 2026",
+    highlights: [
+      "Generate notes automatically after Stop, resume recordings, and regenerate notes from the latest transcript",
+      "Use one dog and calendar tray with Compact and Full Island views for today's meetings",
+      "Reuse installed local notes models and get clearer recording startup and setup feedback",
+      "Cancel and retry abandoned Cloud connections",
+      "Restore Google Calendar connection and refresh with clearer recovery messages and preserved cached meetings",
+    ],
+  },
+  {
     version: "0.4.24",
     date: "September 8, 2026",
     highlights: [

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,14 +9,14 @@ const RELEASES: Array<{
   highlights: string[];
 }> = [
   {
-    version: "0.4.25",
+    version: "0.4.26",
     date: "September 11, 2026",
     highlights: [
       "Generate notes automatically after Stop, resume recordings, and regenerate notes from the latest transcript",
       "Use one dog and calendar tray with Compact and Full Island views for today's meetings",
       "Reuse installed local notes models and get clearer recording startup and setup feedback",
       "Cancel and retry abandoned Cloud connections",
-      "Restore Google Calendar connection and refresh with clearer recovery messages and preserved cached meetings",
+      "Temporarily disable new Google Calendar connections while awaiting Google verification approval",
     ],
   },
   {

--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,11 +1,11 @@
-version: 0.4.25
+version: 0.4.24
 files:
-  - url: DoodleNote-0.4.25-arm64-mac.zip
-    sha512: xYhQrczu+nLlNugGVqfmaJTaL10nnz4jOIlPxIXqr8KaMCcfQgE2TscSJJpEuGQwUEfLXegUyT6Yh3uKCZ5qIg==
-    size: 186134650
-  - url: DoodleNote-0.4.25-arm64.dmg
-    sha512: VGnwzYjhWgPv5T5vcfYKgV51AjI8xY/pRTZL8hJ/mNd/3suCiXW6gq4gcUdOPN4cgBU/74di4Q5Eoe1E8Ya++A==
-    size: 188078006
-path: DoodleNote-0.4.25-arm64-mac.zip
-sha512: xYhQrczu+nLlNugGVqfmaJTaL10nnz4jOIlPxIXqr8KaMCcfQgE2TscSJJpEuGQwUEfLXegUyT6Yh3uKCZ5qIg==
-releaseDate: '2026-09-11T13:59:02.960Z'
+  - url: DoodleNote-0.4.24-arm64-mac.zip
+    sha512: WjSY24P+Mw4gHxG1SiIKyv7XK+YYZvddS+jhWPMX2IDoy2wvmimFnMBNF/zUtVptHmGwhf4d9fgxtw3gkVft0Q==
+    size: 185983132
+  - url: DoodleNote-0.4.24-arm64.dmg
+    sha512: hIr5Z1W4w6d82HP2HQ+LQ0lhdFk/ns+hssX6WZUbJlsyIaM7k9ICBhyOIsc+LmTqNh+OOV8qyIfI9XST3ts8iQ==
+    size: 187862249
+path: DoodleNote-0.4.24-arm64-mac.zip
+sha512: WjSY24P+Mw4gHxG1SiIKyv7XK+YYZvddS+jhWPMX2IDoy2wvmimFnMBNF/zUtVptHmGwhf4d9fgxtw3gkVft0Q==
+releaseDate: '2026-09-08T17:08:54.404Z'

--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,11 +1,11 @@
-version: 0.4.24
+version: 0.4.25
 files:
-  - url: DoodleNote-0.4.24-arm64-mac.zip
-    sha512: WjSY24P+Mw4gHxG1SiIKyv7XK+YYZvddS+jhWPMX2IDoy2wvmimFnMBNF/zUtVptHmGwhf4d9fgxtw3gkVft0Q==
-    size: 185983132
-  - url: DoodleNote-0.4.24-arm64.dmg
-    sha512: hIr5Z1W4w6d82HP2HQ+LQ0lhdFk/ns+hssX6WZUbJlsyIaM7k9ICBhyOIsc+LmTqNh+OOV8qyIfI9XST3ts8iQ==
-    size: 187862249
-path: DoodleNote-0.4.24-arm64-mac.zip
-sha512: WjSY24P+Mw4gHxG1SiIKyv7XK+YYZvddS+jhWPMX2IDoy2wvmimFnMBNF/zUtVptHmGwhf4d9fgxtw3gkVft0Q==
-releaseDate: '2026-09-08T17:08:54.404Z'
+  - url: DoodleNote-0.4.25-arm64-mac.zip
+    sha512: xYhQrczu+nLlNugGVqfmaJTaL10nnz4jOIlPxIXqr8KaMCcfQgE2TscSJJpEuGQwUEfLXegUyT6Yh3uKCZ5qIg==
+    size: 186134650
+  - url: DoodleNote-0.4.25-arm64.dmg
+    sha512: VGnwzYjhWgPv5T5vcfYKgV51AjI8xY/pRTZL8hJ/mNd/3suCiXW6gq4gcUdOPN4cgBU/74di4Q5Eoe1E8Ya++A==
+    size: 188078006
+path: DoodleNote-0.4.25-arm64-mac.zip
+sha512: xYhQrczu+nLlNugGVqfmaJTaL10nnz4jOIlPxIXqr8KaMCcfQgE2TscSJJpEuGQwUEfLXegUyT6Yh3uKCZ5qIg==
+releaseDate: '2026-09-11T13:59:02.960Z'

--- a/apps/web/public/updates/latest-mac.yml
+++ b/apps/web/public/updates/latest-mac.yml
@@ -1,11 +1,11 @@
-version: 0.4.24
+version: 0.4.26
 files:
-  - url: DoodleNote-0.4.24-arm64-mac.zip
-    sha512: WjSY24P+Mw4gHxG1SiIKyv7XK+YYZvddS+jhWPMX2IDoy2wvmimFnMBNF/zUtVptHmGwhf4d9fgxtw3gkVft0Q==
-    size: 185983132
-  - url: DoodleNote-0.4.24-arm64.dmg
-    sha512: hIr5Z1W4w6d82HP2HQ+LQ0lhdFk/ns+hssX6WZUbJlsyIaM7k9ICBhyOIsc+LmTqNh+OOV8qyIfI9XST3ts8iQ==
-    size: 187862249
-path: DoodleNote-0.4.24-arm64-mac.zip
-sha512: WjSY24P+Mw4gHxG1SiIKyv7XK+YYZvddS+jhWPMX2IDoy2wvmimFnMBNF/zUtVptHmGwhf4d9fgxtw3gkVft0Q==
-releaseDate: '2026-09-08T17:08:54.404Z'
+  - url: DoodleNote-0.4.26-arm64-mac.zip
+    sha512: FFg0RBinYCe/KsgWLO7HmHW8MCrQZC+MBOEERRjbUG8tx8KT4fEUCjKXAjn0vll1ZDTNpBS3W2pnP0O4UhpHyA==
+    size: 186145798
+  - url: DoodleNote-0.4.26-arm64.dmg
+    sha512: R7Sgwr2jWVrDPZjm4bjLL/rNrNlWCot8+i5RRyBDcYy74NFQ2h3Mh/Vp2CiP4sGqvkGDjKpl48No/8fUiOFfgA==
+    size: 188099122
+path: DoodleNote-0.4.26-arm64-mac.zip
+sha512: FFg0RBinYCe/KsgWLO7HmHW8MCrQZC+MBOEERRjbUG8tx8KT4fEUCjKXAjn0vll1ZDTNpBS3W2pnP0O4UhpHyA==
+releaseDate: '2026-09-11T21:32:24.054Z'

--- a/docs/qa/mac-release-0.4.26.md
+++ b/docs/qa/mac-release-0.4.26.md
@@ -1,0 +1,11 @@
+# Mac release 0.4.26
+
+Prepared for public release, superseding the unpublished 0.4.25 candidate.
+
+Includes the accepted desktop feature integration in PR #163, the Google token handling fix in PR #164, and disabled Google connection controls pending verification approval. The Settings signed-out view, additional-provider view, and welcome tour all show a disabled grey Google button with an accessible explanation. Existing connected-account sync and disconnect remain available. Re-enabling new connections requires a subsequent release after approval.
+
+Release highlights: automatic notes after Stop, Resume and regeneration, one dog/calendar tray with Compact and Full Island modes, local model reuse, clearer recording/setup feedback, and Cloud cancellation/retry. Google new connections are temporarily unavailable.
+
+Package Mac separately from publishing. Validate Developer ID signature, notarization/stapling, final ZIP/DMG hashes, website feed and download routing. Keep Windows production publication on hold for Azure signing approval.
+
+Native installed-app UI automation currently reports noWindowsAvailable; manual acceptance and actual updater relaunch remain separate from automated tests and artifact validation. Retain the prior Mac manifest and artifacts for rollback.


### PR DESCRIPTION
Google Calendar connections currently send users into an unapproved verification flow. Grey out new Google connection buttons in both Settings views and the welcome tour, with the visible, accessible note “Awaiting Google verification approval.” Existing connections retain sync and disconnect controls. Microsoft connections remain available.

Release the accepted desktop feature batch as Mac 0.4.26 so existing 0.4.25 testers can also upgrade. Add website release highlights. The Mac manifest matches the final signed, notarized, and stapled ZIP/DMG. Windows feeds and downloads are unchanged.

Validation: desktop typecheck and lint passed; 262 desktop tests passed with one environment skip; disabled markup and accessible description were verified using the actual rendered component, with a browser layout check. Production Electron and Swift engine builds passed. GitHub CI, CodeQL and Windows regression packaging passed for the source commit. App and DMG notarization accepted; stapled tickets, strict deep signature, Gatekeeper and extracted updater ZIP checks passed. Public ZIP/DMG downloaded back with matching hashes; public updater range requests pass. Final CI passed, production deployment succeeded, and all three supported Mac feed domains serve 0.4.26. Website download and changelog are verified; GitHub v0.4.26 is the latest public release.

Rollback: restore the previous Mac manifest and website deployment to stop new offers. This does not downgrade installations already completed. The owner requested public Mac release and then requested disabling Google connections before release. Prior feature acceptance by Alec is recorded in PR #163. Full recording and updater-relaunch smoke remains unverified because native installed-app automation reports noWindowsAvailable; publication does not claim that verification.
